### PR TITLE
implement inherit in name bindings

### DIFF
--- a/Nix/Eval.hs
+++ b/Nix/Eval.hs
@@ -4,6 +4,7 @@ import           Control.Applicative
 import           Control.Arrow
 import           Control.Monad hiding (mapM)
 import qualified Data.Map as Map
+import           Data.Text (Text)
 import           Data.Traversable as T
 import           Nix.Types
 import           Prelude hiding (mapM)
@@ -43,20 +44,15 @@ evalExpr = cata phi
     phi (NArgSet s) = \env -> Fix . NVArgSet <$> mapM (T.sequence . fmap ($ env)) s
 
     -- TODO: recursive sets
-    phi (NSet _b xs)   = \env ->
-        Fix . NVSet . Map.fromList
-            <$> mapM (fmap (first valueText) . go env) xs
-      where
-        go env (x, y) = liftM2 (,) (x env) (y env)
+    phi (NSet _b binds)   = \env ->
+        Fix . NVSet <$> evalBinds env binds
 
     -- TODO: recursive binding
     phi (NLet binds e) = \env -> case env of
       (Fix (NVSet env')) -> do
-        letenv <- Map.fromList <$> mapM (fmap (first valueText) . go) binds
+        letenv <- evalBinds env binds
         let newenv = Map.union letenv env'
         e . Fix . NVSet $ newenv
-        where
-          go (x, y) = liftM2 (,) (x env) (y env)
       _ -> error "invalid evaluation environment"
 
     phi (NIf cond t f)  = \env -> do
@@ -98,3 +94,12 @@ evalExpr = cata phi
         -- set
         args <- a env
         return $ Fix $ NVFunction args b
+
+evalBinds :: NValue -> [Binding (NValue -> IO NValue)] ->
+  IO (Map.Map Text NValue)
+evalBinds env xs =
+  Map.fromList <$> mapM (fmap (first valueText)) (concatMap go xs) where
+    go :: Binding (NValue -> IO NValue) -> [IO (NValue, NValue)]
+    go (NamedVar x y) = [liftM2 (,) (x env) (y env)]
+    go (Inherit ys) = map (\y -> (,) <$> y env <*> y env) ys
+    go (ScopedInherit x ys) = map (\y -> (,) <$> x env <*> y env) ys

--- a/Nix/Pretty.hs
+++ b/Nix/Pretty.hs
@@ -5,8 +5,10 @@ import Data.Text (Text, unpack)
 import Nix.Types
 import Text.PrettyPrint.ANSI.Leijen
 
-prettyBind :: (NExpr, NExpr) -> Doc
-prettyBind (n, v) = prettyNix n <+> equals <+> prettyNix v <> semi
+prettyBind :: Binding NExpr -> Doc
+prettyBind (NamedVar n v) = prettyNix n <+> equals <+> prettyNix v <> semi
+prettyBind (Inherit ns) = text "inherit" <+> fillSep (map prettyNix ns)
+prettyBind (ScopedInherit s ns) = text "inherit" <+> parens (prettyNix s) <+> fillSep (map prettyNix ns)
 
 prettySetArg :: (Text, Maybe NExpr) -> Doc
 prettySetArg (n, Nothing) = text (unpack n)
@@ -62,7 +64,6 @@ prettyNix (Fix expr) = go expr where
 
   go (NWith scope body) = text "with" <+> prettyNix scope <> semi <+> prettyNix body
   go (NAssert cond body) = text "assert" <+> prettyNix cond <> semi <+> prettyNix body
-  go (NInherit _attrs) = text "inherit"
 
   go (NVar e) = prettyNix e
   go (NApp fun arg) = prettyNix fun <+> parens (prettyNix arg)


### PR DESCRIPTION
Two points which are not clear from the manual, where this patch follows
the grammar.y bison implementation:
- The presence of parens in the first argument distinguishes the scoped
  inherit
- inherit has the same syntax in sets as in let
