### PR TITLE
null is a constant added to the base environment, not a reserved word

### DIFF
--- a/Nix/Parser/Library.hs
+++ b/Nix/Parser/Library.hs
@@ -82,7 +82,6 @@ reservedNames :: HashSet.HashSet String
 reservedNames = HashSet.fromList
     [ "let", "in"
     , "if", "then", "else"
-    , "null"
     , "assert"
     , "with"
     , "rec"


### PR DESCRIPTION
Opening as a PR to get @jwiegley's opinion.
