### PR TITLE
added a bunch of wrapper functions, simpler representation of empties

### DIFF
--- a/Nix/Pretty.hs
+++ b/Nix/Pretty.hs
@@ -119,16 +119,14 @@ prettyNix = withoutParens . cata phi where
   phi :: NExprF NixDoc -> NixDoc
   phi (NConstant atom) = prettyAtom atom
   phi (NStr str) = simpleExpr $ prettyString str
+  phi (NList []) = simpleExpr $ lbracket <> rbracket
   phi (NList xs) = simpleExpr $ group $
     nest 2 (vsep $ lbracket : map (wrapParens appOpNonAssoc) xs) <$> rbracket
+  phi (NSet rec []) = simpleExpr $ recPrefix rec <> lbrace <> rbrace
   phi (NSet rec xs) = simpleExpr $ group $
-    nest 2 (vsep $ prefix rec <> lbrace : map prettyBind xs) <$> rbrace
-   where
-    prefix Rec = text "rec" <> space
-    prefix NonRec = empty
+    nest 2 (vsep $ recPrefix rec <> lbrace : map prettyBind xs) <$> rbrace
   phi (NAbs args body) = leastPrecedence $
     (prettyFormals args <> colon) </> withoutParens body
-
   phi (NOper oper) = prettyOper oper
   phi (NSelect r attr o) = (if isJust o then leastPrecedence else flip NixDoc selectOp) $
      wrapParens selectOp r <> dot <> prettySelector attr <> ordoc
@@ -150,3 +148,6 @@ prettyNix = withoutParens . cata phi where
     text "with"  <+> withoutParens scope <> semi <+> withoutParens body
   phi (NAssert cond body) = leastPrecedence $
     text "assert" <+> withoutParens cond <> semi <+> withoutParens body
+
+  recPrefix Rec = text "rec" <> space
+  recPrefix NonRec = empty


### PR DESCRIPTION
@jwiegley I extended the current crop of wrapper functions to make `NExpr`s. Also added some functions for manipulating `NExpr`s: specifically, adding additional bindings to `NLet`s and `NSet`s, and applying a function to the body of an `NAbs`. Conceivably, there could be a whole library of these kinds of transformations to facilitate programmatic manipulation of nix expressions. It's probably a bit better to do that stuff through lenses, but as I don't know much about lens, I just left them as straightforward partial functions.
