### PR TITLE
Needs GHC >= 7.6 due to MultiWayIf, LambdaCase, DataKinds

### DIFF
--- a/hnix.cabal
+++ b/hnix.cabal
@@ -42,7 +42,7 @@ Library
     RankNTypes
     TupleSections
   Build-depends:
-      base                     >= 4.3          && < 5
+      base                     >= 4.6          && < 5
     , ansi-wl-pprint
     , containers
     , text


### PR DESCRIPTION
I revised the current version (http://hackage.haskell.org/package/hnix-0.2.0/revisions/) so a new release is only necessary if you want to add backwards compatibility.
