### PR TITLE
Minor fixes in pretty printing.

### DIFF
--- a/Nix/Parser/Library.hs
+++ b/Nix/Parser/Library.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 module Nix.Parser.Library ( module Nix.Parser.Library, module X) where
 
+import Prelude
 import Control.Applicative
 import Control.Monad
 import Control.Monad.IO.Class

--- a/Nix/Types.hs
+++ b/Nix/Types.hs
@@ -130,6 +130,7 @@ escapeCodes =
   , ('\t', 't' )
   , ('\\', '\\')
   , ('$' , '$' )
+  , ('"', '"')
   ]
 
 fromEscapeCode :: Char -> Maybe Char

--- a/default.nix
+++ b/default.nix
@@ -1,21 +1,6 @@
-{ mkDerivation, ansi-wl-pprint, base, containers, data-fix, parsers
-, stdenv, tasty, tasty-hunit, tasty-th, text, transformers
-, trifecta, unordered-containers
-}:
-mkDerivation {
-  pname = "hnix";
-  version = "0.2.1";
-  src = ./.;
-  isLibrary = true;
-  isExecutable = true;
-  buildDepends = [
-    ansi-wl-pprint base containers data-fix parsers text transformers
-    trifecta unordered-containers
-  ];
-  testDepends = [
-    base containers data-fix tasty tasty-hunit tasty-th text
-  ];
-  homepage = "http://github.com/jwiegley/hnix";
-  description = "Haskell implementation of the Nix language";
-  license = stdenv.lib.licenses.bsd3;
-}
+{ nixpkgs ? import <nixpkgs> {}, compiler ? "ghc7102" }:
+let
+  haskellPackages = nixpkgs.pkgs.haskell.packages.${compiler};
+in
+
+haskellPackages.callPackage ./project.nix {}

--- a/hnix.cabal
+++ b/hnix.cabal
@@ -1,5 +1,5 @@
 Name:                hnix
-Version:             0.2.1
+Version:             0.2.2
 Synopsis:            Haskell implementation of the Nix language
 Description:
   Haskell implementation of the Nix language.

--- a/project.nix
+++ b/project.nix
@@ -1,0 +1,21 @@
+{ mkDerivation, ansi-wl-pprint, base, containers, data-fix, parsers
+, stdenv, tasty, tasty-hunit, tasty-th, text, transformers
+, trifecta, unordered-containers, cabal-install
+}:
+mkDerivation {
+  pname = "hnix";
+  version = "0.2.2";
+  src = ./.;
+  isLibrary = true;
+  isExecutable = true;
+  buildDepends = [
+    ansi-wl-pprint base containers data-fix parsers text transformers
+    trifecta unordered-containers cabal-install
+  ];
+  testDepends = [
+    base containers data-fix tasty tasty-hunit tasty-th text
+  ];
+  homepage = "http://github.com/jwiegley/hnix";
+  description = "Haskell implementation of the Nix language";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/shell.nix
+++ b/shell.nix
@@ -1,1 +1,2 @@
-{ pkgs ? import <nixpkgs> {} }: pkgs.haskellPackages.callPackage ./default.nix {}
+{ nixpkgs ? import <nixpkgs> {}, compiler ? "ghc7102" }:
+(import ./default.nix { inherit nixpkgs compiler; }).env


### PR DESCRIPTION
- Correctly escape double quotes. 
- Use quotes when bindings are reserved words.
