### PR TITLE
Use ghc7103 by default

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,2 +1,2 @@
-{ nixpkgs ? import <nixpkgs> {}, compiler ? "ghc7102" }:
+{ nixpkgs ? import <nixpkgs> {}, compiler ? "ghc7103" }:
 (import ./default.nix { inherit nixpkgs compiler; }).env


### PR DESCRIPTION
No problems compiling or testing. This has the advantage of binary packages being available on Hydra.
