### PR TITLE
Bump to 0.3.4

### DIFF
--- a/hnix.cabal
+++ b/hnix.cabal
@@ -1,5 +1,5 @@
 Name:                hnix
-Version:             0.3.3
+Version:             0.3.4
 Synopsis:            Haskell implementation of the Nix language
 Description:
   Haskell implementation of the Nix language.

--- a/project.nix
+++ b/project.nix
@@ -10,7 +10,7 @@ in
 
 mkDerivation {
   pname = "hnix";
-  version = "0.3.3";
+  version = "0.3.4";
   src = let
     notNamed = list: name: !(elem (baseNameOf name) list);
   in filterSource (n: _: notNamed [".git" "dist" "benchmarks"] n) ./.;


### PR DESCRIPTION
It would be nice with a version bump (and Hackage upload) since nixpkgs Hydra is currently failing the `hnix` build due to the issue that was fixed in 3a23917d5990d4d172a8d83720158536da10c4d9: https://hydra.nixos.org/build/41795938
