### PR TITLE
Correctly parse identifiers with reserved word prefixes

### DIFF
--- a/Nix/Parser.hs
+++ b/Nix/Parser.hs
@@ -105,11 +105,11 @@ nixInt = annotateLocation1 $ mkIntF <$> token decimal <?> "integer"
 
 nixBool :: Parser NExprLoc
 nixBool = annotateLocation1 $ try (true <|> false) <?> "bool" where
-  true = mkBoolF True <$ symbol "true"
-  false = mkBoolF False <$ symbol "false"
+  true = mkBoolF True <$ reserved "true"
+  false = mkBoolF False <$ reserved "false"
 
 nixNull :: Parser NExprLoc
-nixNull = annotateLocation1 $ mkNullF <$ try (symbol "null") <?> "null"
+nixNull = annotateLocation1 $ mkNullF <$ try (reserved "null") <?> "null"
 
 nixParens :: Parser NExprLoc
 nixParens = parens nixExprLoc <?> "parens"

--- a/tests/ParserTests.hs
+++ b/tests/ParserTests.hs
@@ -220,6 +220,14 @@ case_identifier_special_chars = do
   assertParseFail ".a"
   assertParseFail "'a"
 
+case_identifier_keyword_prefix :: Assertion
+case_identifier_keyword_prefix = do
+  assertParseString "true-name" $ mkSym "true-name"
+  assertParseString "trueName" $ mkSym "trueName"
+  assertParseString "null-name" $ mkSym "null-name"
+  assertParseString "nullName" $ mkSym "nullName"
+  assertParseString "[ null-name ]" $ mkList [ mkSym "null-name" ]
+
 makeStringParseTest :: String -> Assertion
 makeStringParseTest str = assertParseString ("\"" ++ str ++ "\"") $ mkStr $ pack str
 


### PR DESCRIPTION
The expression `[ true-name ]` didn't parse with hnix, but did with nix-repl. I believe this corrects the issue.