### PR TITLE
Dollar quoting

### DIFF
--- a/Nix/Pretty.hs
+++ b/Nix/Pretty.hs
@@ -70,7 +70,7 @@ prettyString (Indented parts)
     f ([Plain t] : xs) | Text.null (strip t) = xs
     f xs = xs
   prettyLine = hcat . map prettyPart
-  prettyPart (Plain t) = text . unpack . replace "$" "''$" . replace "''" "'''" $ t
+  prettyPart (Plain t) = text . unpack . replace "${" "''${" . replace "''" "'''" $ t
   prettyPart (Antiquoted r) = text "$" <> braces (withoutParens r)
 
 prettyParams :: Params NixDoc -> Doc

--- a/hnix.cabal
+++ b/hnix.cabal
@@ -107,6 +107,7 @@ Test-suite hnix-tests
   Other-modules:
     ParserTests
     EvalTests
+    ShorthandTests
   Build-depends:
       base >= 4.3 && < 5
     , containers

--- a/hnix.cabal
+++ b/hnix.cabal
@@ -108,6 +108,7 @@ Test-suite hnix-tests
     ParserTests
     EvalTests
     ShorthandTests
+    PrettyTests
   Build-depends:
       base >= 4.3 && < 5
     , containers

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -5,6 +5,7 @@ import Test.Tasty
 import qualified ParserTests
 import qualified EvalTests
 import qualified ShorthandTests
+import qualified PrettyTests
 
 import Prelude (IO, ($))
 
@@ -13,4 +14,5 @@ main = defaultMain $ testGroup "hnix"
   [ ParserTests.tests
   , EvalTests.tests
   , ShorthandTests.tests
+  , PrettyTests.tests
   ]

--- a/tests/PrettyTests.hs
+++ b/tests/PrettyTests.hs
@@ -1,0 +1,28 @@
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE OverloadedStrings #-}
+module PrettyTests (tests) where
+
+import Test.Tasty
+import Test.Tasty.HUnit
+import Test.Tasty.TH
+
+import Nix.Expr
+import Nix.Pretty
+
+case_indented_antiquotation :: Assertion
+case_indented_antiquotation = do
+    assertPretty (mkIndentedStr "echo $foo") "''echo $foo''"
+    assertPretty (mkIndentedStr "echo ${foo}") "''echo ''${foo}''"
+
+case_string_antiquotation :: Assertion
+case_string_antiquotation = do
+    -- TODO: plain $ doesn't need to be escaped here either
+    assertPretty (mkStr "echo $foo") "\"echo \\$foo\""
+    assertPretty (mkStr "echo ${foo}") "\"echo \\${foo}\""
+
+tests :: TestTree
+tests = $testGroupGenerator
+
+--------------------------------------------------------------------------------
+assertPretty :: NExpr -> String -> Assertion
+assertPretty e s = assertEqual ("When pretty-printing " ++ show e) s . show $ prettyNix e


### PR DESCRIPTION
The Nix manual [states]:

> Since ${ and '' have special meaning in indented strings, you need a way to quote them. ${ can be escaped by prefixing it with '' (that is, two single quotes), i.e., ''${.

but says nothing about needing to escape `$` followed by any other character. hnix currently escapes `$` unconditionally when pretty-printing, which is also accepted by the Nix tooling:

```
λ> show . prettyNix $ Fix (NStr (Indented [Plain "$foo"]))
"''''$foo''"
```
```
nix-shell> ''''$foo''
"$foo"
```

I can't find any documentation about this behaviour by the Nix tools.

None of this is really a _bug_, but it does make the common case of including shell variables in Nix strings a bit unintuitive; at first glance I thought this string ended too early:

```
preConfigure = ''
  export PATH="''$PWD/dist/build/intero:''$PATH"
'';
```

So this PR modifies the pretty-printer to only escape `${` in indented strings. I would've changed the printing of non-indented strings as well, but I can't find where that escaping is done.

Somewhat related to #58.

[states]: https://nixos.org/nix/manual/#idm140737318139904