### PR TITLE
default.nix: fix evaluation on nixos-unstable

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,9 +1,10 @@
 { nixpkgs ? import <nixpkgs> {}, compiler ? null }:
 let
-  haskellPackages = if compiler == null
-                    # use the current default version
-                    then nixpkgs.pkgs.haskellPackages
-                    else nixpkgs.pkgs.haskell.packages.${compiler};
+  haskellPackages =
+    if compiler == null || !(nixpkgs.lib.hasAttr compiler nixpkgs.pkgs.haskell.packages)
+      # use the current default version
+      then nixpkgs.pkgs.haskellPackages
+      else nixpkgs.lib.attrByPath [compiler] {} nixpkgs.pkgs.haskell.packages;
 in
 
 haskellPackages.callPackage ./project.nix {


### PR DESCRIPTION
`pkgs.haskell.packages.ghc801` doesn't exist in recent `nixos-unstable`, and
accessing a missing attribute throws an error:

```
❯ nix-shell
error: attribute ‘ghc801’ missing, at /Users/rkm/sync/git/personal/hnix/default.nix:6:26
(use ‘--show-trace’ to show detailed location information)
```

Proposed solution: use `lib.hasAttr` and `lib.attrByPath` to get it instead.