### PR TITLE
shell.nix: pin nixpkgs revision to HEAD of nixos-17.09

### DIFF
--- a/nixpkgs.nix
+++ b/nixpkgs.nix
@@ -1,0 +1,26 @@
+{ stdenv, fetchFromGitHub }:
+
+stdenv.mkDerivation rec {
+  name = "nixos-17.09-${version}";
+  version = "2017-01-19";
+
+  # To update the pinned nixpkgs revision:
+  #
+  # $ nix-prefetch-git git@github.com:NixOS/nixpkgs-channels.git \
+  #     --rev refs/heads/nixos-17.09
+  #
+  # Update the "rev" and "sha256" lines.
+  src = fetchFromGitHub {
+    owner = "NixOS";
+    repo = "nixpkgs-channels";
+    rev = "d9a2891c32ee452a2cd701310040b660da0cc853";
+    sha256 = "14m6krpv7iga96bjpb4xmdq1fpysryyfvkghn68k6g8gr9y61fqs";
+  };
+
+  dontBuild = true;
+  preferLocalBuild = true;
+
+  installPhase = ''
+    cp -a . $out
+  '';
+}

--- a/shell.nix
+++ b/shell.nix
@@ -1,2 +1,12 @@
-{ nixpkgs ? import <nixpkgs> {}, compiler ? "ghc801" }:
-(import ./default.nix { inherit nixpkgs compiler; }).env
+{ nixpkgs ? <nixpkgs>
+, system ? builtins.currentSystem
+, compiler ? "ghc801"
+}:
+
+let
+  nixpkgsLocal = import nixpkgs { inherit system; };
+
+  nixpkgsStable = import (nixpkgsLocal.callPackage ./nixpkgs.nix {}) {
+    inherit system;
+  };
+in (import ./default.nix { nixpkgs = nixpkgsStable; inherit compiler; }).env


### PR DESCRIPTION
This is just for the sake of people not on the stable channel who want to use
the same version of GHC specified here.