### PR TITLE
Fix recset evaluation logic

### DIFF
--- a/Nix/Eval.hs
+++ b/Nix/Eval.hs
@@ -148,7 +148,7 @@ evalExpr = cata phi
         rec
           mergedEnv <- pure $ Fix $ NVSet $ evaledBinds `Map.union` env'
           evaledBinds <- evalBinds True mergedEnv binds
-        pure mergedEnv
+        pure . Fix . NVSet $ evaledBinds
       _ -> error "invalid evaluation environment"
 
     phi (NLet binds e) = \env -> case env of


### PR DESCRIPTION
Before, an evaluation of a recset would contain all the environment. Eg:
```
>>> let a = 4; in rec {x = 2;}
{x = 2; a = 4;}
```

This commit changes it to only contain the values actually bound in the set:
```
>>> let a = 4; in rec {x = 2;}
{x = 2;}
```