### PR TITLE
Prettyprinter fixes

### DIFF
--- a/Nix/Pretty.hs
+++ b/Nix/Pretty.hs
@@ -170,8 +170,8 @@ prettyNix = withoutParens . cata phi where
      <$> align (text "else" <+> withoutParens falseBody)
       )
   phi (NWith scope body) = leastPrecedence $
-    text "with"  <+> withoutParens scope <> semi <+> withoutParens body
+   text "with"  <+> withoutParens scope <> semi <$> align (withoutParens body)
   phi (NAssert cond body) = leastPrecedence $
-    text "assert" <+> withoutParens cond <> semi <+> withoutParens body
+   text "assert" <+> withoutParens cond <> semi <$> align (withoutParens body)
 
   recPrefix = text "rec" <> space

--- a/Nix/Pretty.hs
+++ b/Nix/Pretty.hs
@@ -131,7 +131,7 @@ prettyNix = withoutParens . cata phi where
   phi (NRecSet xs) = simpleExpr $ group $
     nest 2 (vsep $ recPrefix <> lbrace : map prettyBind xs) <$> rbrace
   phi (NAbs args body) = leastPrecedence $
-    (prettyParams args <> colon) </> (nest 2 $ withoutParens body)
+   (prettyParams args <> colon) </> (indent 2 (withoutParens body))
   phi (NBinary op r1 r2) = flip NixDoc opInfo $ hsep
     [ wrapParens (f NAssocLeft) r1
     , text $ operatorName opInfo

--- a/Nix/Pretty.hs
+++ b/Nix/Pretty.hs
@@ -80,16 +80,16 @@ prettyParams (ParamSet s mname) = prettyParamSet s <> case mname of
   Just name -> text "@" <> text (unpack name)
 
 prettyParamSet :: ParamSet NixDoc -> Doc
-prettyParamSet params = lbrace <+> middle <+> rbrace
+prettyParamSet params = encloseSep (lbrace <> space) (align rbrace) sep prettyArgs
   where
+    prettySetArg (n, maybeDef) = case maybeDef of
+      Nothing -> text (unpack n)
+      Just v -> text (unpack n) <+> text "?" <+> withoutParens v
     prettyArgs = case params of
       FixedParamSet args -> map prettySetArg (toList args)
 
       VariadicParamSet args -> map prettySetArg (toList args) ++ [text "..."]
-    middle = hcat $ punctuate (comma <> space) prettyArgs
-    prettySetArg (n, maybeDef) = case maybeDef of
-      Nothing -> text (unpack n)
-      Just v -> text (unpack n) <+> text "?" <+> withoutParens v
+    sep = align (comma <> space)
 
 prettyBind :: Binding NixDoc -> Doc
 prettyBind (NamedVar n v) = prettySelector n <+> equals <+> withoutParens v <> semi

--- a/Nix/Pretty.hs
+++ b/Nix/Pretty.hs
@@ -162,8 +162,8 @@ prettyNix = withoutParens . cata phi where
         | "../" `isPrefixOf` txt -> txt
         | otherwise -> "./" ++ txt
   phi (NSym name) = simpleExpr $ text (unpack name)
-  phi (NLet binds body) = leastPrecedence $ group $ nest 2 $
-        vsep (text "let" : map prettyBind binds) <$> text "in" <+> withoutParens body
+  phi (NLet binds body) = leastPrecedence $ group $ text "let" <$> indent 2 (
+        vsep (map prettyBind binds)) <$> text "in" <+> withoutParens body
   phi (NIf cond trueBody falseBody) = leastPrecedence $
     group $ nest 2 $ (text "if" <+> withoutParens cond) <$>
       (  align (text "then" <+> withoutParens trueBody)


### PR DESCRIPTION
Before:

```
let
  localLib = import ./lib.nix;
  in { compiler ? pkgs.haskell.packages.ghc802, config ? {}, enableDebugging ? false, enableProfiling ? false, pkgs ? import localLib.fetchNixPkgs {
    inherit system config;
  }, system ? builtins.currentSystem }:
  with pkgs.lib; with pkgs.haskell.lib; let
      nixops = let
        nixopsUnstable = pkgs.fetchFromGitHub {
          owner = "NixOS";
          repo = "nixops";
          rev = "92034401b5291070a93ede030e718bb82b5e6da4";
          sha256 = "139mmf8ag392w5mn419k7ajp3pgcz6q349n7vm7gsp3g4sck2jjn";
        };
        in (import "${nixopsUnstable}/release.nix" {
          nixpkgs = localLib.fetchNixPkgs;
        }).build.system;
      iohk-ops-extra-runtime-deps = [
        pkgs.gitFull
        pkgs.nix-prefetch-scripts
        compiler.yaml
        pkgs.wget
        pkgs.file
        cardano-sl-pkgs.cardano-sl-auxx
        cardano-sl-pkgs.cardano-sl-tools
        nixops
        pkgs.terraform_0_11
      ];
      cardano-sl-src = builtins.fromJSON (builtins.readFile ./cardano-sl-src.json);
      cardano-sl-pkgs = import (pkgs.fetchgit cardano-sl-src) {
        gitrev = cardano-sl-src.rev;
        inherit enableDebugging
        enableProfiling;
      };
      in {
        inherit nixops;
        iohk-ops = pkgs.haskell.lib.overrideCabal (compiler.callPackage ./iohk/default.nix {}) (drv:
        {
            executableToolDepends = [
              pkgs.makeWrapper
            ];
            libraryHaskellDepends = iohk-ops-extra-runtime-deps;
            postInstall = ''
              wrapProgram ''$out/bin/iohk-ops \
              --prefix PATH : "${pkgs.lib.makeBinPath iohk-ops-extra-runtime-deps}"
            '';
          });
      } // cardano-sl-pkgs

```

after:

```
let
  localLib = import ./lib.nix;
in { compiler ? pkgs.haskell.packages.ghc802
   , config ? {}
   , enableDebugging ? false
   , enableProfiling ? false
   , pkgs ? import localLib.fetchNixPkgs {
     inherit system config;
   }
   , system ? builtins.currentSystem}:
  with pkgs.lib;
  with pkgs.haskell.lib;
  let
    nixops = let
      nixopsUnstable = pkgs.fetchFromGitHub {
        owner = "NixOS";
        repo = "nixops";
        rev = "92034401b5291070a93ede030e718bb82b5e6da4";
        sha256 = "139mmf8ag392w5mn419k7ajp3pgcz6q349n7vm7gsp3g4sck2jjn";
      };
    in (import "${nixopsUnstable}/release.nix" {
      nixpkgs = localLib.fetchNixPkgs;
    }).build.system;
    iohk-ops-extra-runtime-deps = [
      pkgs.gitFull
      pkgs.nix-prefetch-scripts
      compiler.yaml
      pkgs.wget
      pkgs.file
      cardano-sl-pkgs.cardano-sl-auxx
      cardano-sl-pkgs.cardano-sl-tools
      nixops
      pkgs.terraform_0_11
    ];
    cardano-sl-src = builtins.fromJSON (builtins.readFile ./cardano-sl-src.json);
    cardano-sl-pkgs = import (pkgs.fetchgit cardano-sl-src) {
      gitrev = cardano-sl-src.rev;
      inherit enableDebugging
      enableProfiling;
    };
  in {
    inherit nixops;
    iohk-ops = pkgs.haskell.lib.overrideCabal (compiler.callPackage ./iohk/default.nix {}) (drv:
      {
        executableToolDepends = [
          pkgs.makeWrapper
        ];
        libraryHaskellDepends = iohk-ops-extra-runtime-deps;
        postInstall = ''
          wrapProgram $out/bin/iohk-ops \
          --prefix PATH : "${pkgs.lib.makeBinPath iohk-ops-extra-runtime-deps}"
        '';
      });
  } // cardano-sl-pkgs
```

@jwiegley 