### PR TITLE
Change the environment in evaluation to be a `Map Text (NValue m)`

### DIFF
--- a/tests/EvalTests.hs
+++ b/tests/EvalTests.hs
@@ -40,8 +40,8 @@ tests = $testGroupGenerator
 
 constantEqual :: NExpr -> NExpr -> Assertion
 constantEqual a b = do
-    Fix (NVConstant a') <- evalExpr a (Fix (NVSet mempty))
-    Fix (NVConstant b') <- evalExpr b (Fix (NVSet mempty))
+    Fix (NVConstant a') <- evalExpr a mempty
+    Fix (NVConstant b') <- evalExpr b mempty
     assertEqual "" a' b'
 
 constantEqualStr :: String -> String -> Assertion


### PR DESCRIPTION
Currently, the environment is passed as a `NValue m`, but is assumed to be
a set every single time it is used. This commit changes it `Map Text (NValue
m)`. Since this is used a lot, it defines a new type alias:

```
type Set m = Map.Map Text (NValue m)
```

This has multiples benefits:
- Simplify some code by removing all the checks that the env is indeed a set
- Simplify the usage of the module by making clear that we need a set as the
  environment. (I especially like this, since it took me a while to figure out
  what that argument was supposed to be the first time).
- Make it simple to inject functions in the environment (for example to have
  builtins) since now the function definition doesn't need to unwrap the set.