### PR TITLE
Add a pretty-printer for NValue

### DIFF
--- a/Nix/Eval.hs
+++ b/Nix/Eval.hs
@@ -15,7 +15,6 @@ import qualified Data.Text as Text
 import           Data.Traversable as T
 import           Data.Typeable (Typeable)
 import           GHC.Generics
-import           Nix.Pretty (atomText)
 import           Nix.StringOperations (runAntiquoted)
 import           Nix.Atoms
 import           Nix.Expr
@@ -57,6 +56,13 @@ valueText = cata phi where
     phi (NVFunction _ _)  = error "Cannot coerce a function to a string"
     phi (NVLiteralPath p) = Text.pack p
     phi (NVEnvPath p)     = Text.pack p
+
+-- | Translate an atom into its nix representation.
+atomText :: NAtom -> Text
+atomText (NInt i)   = Text.pack (show i)
+atomText (NBool b)  = if b then "true" else "false"
+atomText NNull      = "null"
+atomText (NUri uri) = uri
 
 buildArgument :: Params (NValue m) -> NValue m -> NValue m
 buildArgument paramSpec arg = either error (Fix . NVSet) $ case paramSpec of


### PR DESCRIPTION
Here is a little thing I wrote writing a small repl with hnix. As explained in the commit message, I used a trick for the implementation, so feel free to reject this PR if you don't like the way this is implemented.

-----

The implementation is a bit hacky: we convert the NValue to a NExpr, which
let us reuse the ast pretty-printing logic.

This commit also moves `atomText` from `Nix.Pretty` to `Nix.Eval` to avoid a
circular dependency. I don't have a strong argument for that, except that the
pretty-printer depending from the evaluator makes a bit more sense than other
way around.