### PR TITLE
Add context to strings

### DIFF
--- a/Nix/Builtins.hs
+++ b/Nix/Builtins.hs
@@ -67,18 +67,18 @@ evalPred pred = error $ "Trying to call a " ++ show pred
 prim_toString :: MonadFix m => Functor m => NValue m
 prim_toString = Fix $ NVBuiltin1 "toString" $ toString
 toString :: MonadFix m => NValue m -> m (NValue m)
-toString s = return $ Fix $ NVStr $ valueText s
+toString s = return $ Fix $ uncurry NVStr $ valueText s
 
 prim_hasAttr :: MonadFix m => NValue m
 prim_hasAttr = Fix $ NVBuiltin2 "hasAttr" [] hasAttr
 hasAttr :: MonadFix m => NValue m -> NValue m -> m (NValue m)
-hasAttr (Fix (NVStr key)) (Fix (NVSet aset)) = return $ Fix $ NVConstant $ NBool $ Map.member key aset
+hasAttr (Fix (NVStr key _)) (Fix (NVSet aset)) = return $ Fix $ NVConstant $ NBool $ Map.member key aset
 hasAttr key aset = error $ "Invalid types for builtin.hasAttr: " ++ show (key, aset)
 
 prim_getAttr :: MonadFix m => NValue m
 prim_getAttr = Fix $ NVBuiltin2 "getAttr" [] getAttr
 getAttr :: MonadFix m => NValue m -> NValue m -> m (NValue m)
-getAttr (Fix (NVStr key)) (Fix (NVSet aset)) = return $ Map.findWithDefault _err key aset
+getAttr (Fix (NVStr key _)) (Fix (NVSet aset)) = return $ Map.findWithDefault _err key aset
   where _err = error ("Field does not exist " ++ Text.unpack key)
 getAttr key aset = error $ "Invalid types for builtin.getAttr: " ++ show (key, aset)
 

--- a/Nix/Pretty.hs
+++ b/Nix/Pretty.hs
@@ -179,7 +179,7 @@ prettyNixValue = prettyNix . valueToExpr
         hmap :: (Functor f, Functor g) => (forall a. f a -> g a) -> Fix f -> Fix g
         hmap eps = ana (eps . unFix)
         go (NVConstant a) = NConstant a
-        go (NVStr t) = NStr (DoubleQuoted [Plain t])
+        go (NVStr t _) = NStr (DoubleQuoted [Plain t])
         go (NVList l) = NList l
         go (NVSet s) = NSet [NamedVar [StaticKey k] v | (k, v) <- toList s]
         go (NVFunction p _) = NSym . pack $ ("<function with " ++ show (() <$ p)  ++ ">")
@@ -193,7 +193,7 @@ printNix :: Functor m => NValue m -> String
 printNix = cata phi
   where phi :: NValueF m String -> String
         phi (NVConstant a) = unpack $ atomText a
-        phi (NVStr t) = unpack t
+        phi (NVStr t _) = unpack t
         phi (NVList l) = "[ " ++ (intercalate " " l) ++ " ]"
         phi (NVSet s) = intercalate ", " $ [ unpack k ++ ":" ++ v | (k, v) <- toList s]
         phi (NVFunction p _) = error "Cannot print a thunk"


### PR DESCRIPTION
This commit adds a `DList Text` to the NVStr constructor. This allows haskell
code that generates string to give them a context, which will be tracked when
the string in used.

This allows, for example, to determine the dependencies of a derivation.

-------

I used a DList, because I want O(1) concatenation, and I don't expect to read it except one when I consume it to find out the dependencies of a computation.

## Alternative

Instead of hardcoding for `DList Text`, we could make it work with any monoid. That would adding one more type parameter to all types (`NValueF c m r`, `NValue c m` and `ValueSet c m`)