### PR TITLE
Simplify mkDots, handle some edge cases

### DIFF
--- a/Nix/Expr/Shorthands.hs
+++ b/Nix/Expr/Shorthands.hs
@@ -6,10 +6,11 @@ module Nix.Expr.Shorthands where
 
 import Prelude
 import Data.Monoid
-import Data.Text (Text)
+import Data.Text (Text, unpack)
 import Data.Fix
 import qualified Data.Map as Map
 import Nix.Atoms
+import Nix.Parser.Library (reservedNames)
 import Nix.Expr.Types
 import Text.Regex.TDFA.Text ()
 import Text.Regex.TDFA ((=~))
@@ -130,19 +131,14 @@ mkFunction params = Fix . NAbs params
 mkDot :: NExpr -> Text -> NExpr
 mkDot e key = mkDots e [key]
 
+-- | Create a dotted expression using only text.
 mkDots :: NExpr -> [Text] -> NExpr
-mkDots e keys = Fix $ NSelect e (toKey <$> keys) Nothing
-  where
-    toKey :: Text -> NKeyName NExpr
-    toKey k = (if isPlainSymbol k then StaticKey else dynamicKey) k
-    -- | Make a dynamic key name that is only enclosed in double quotes
-    -- (no antiquotes).
-    dynamicKey :: Text -> NKeyName NExpr
-    dynamicKey k = DynamicKey $ Plain $ DoubleQuoted [Plain k]
-    -- | Check if it’s a valid nix symbol
-    -- the nix lexer regex for IDs (symbols) is [a-zA-Z\_][a-zA-Z0-9\_\'\-]*
-    isPlainSymbol :: Text -> Bool
-    isPlainSymbol s = s =~ ("^[a-zA-Z_][a-zA-Z0-9_'-]*$" :: Text)
+mkDots e [] = e
+mkDots (Fix (NSelect e keys' x)) keys =
+  -- Special case: if the expression in the first argument is already
+  -- a dotted expression, just extend it.
+  Fix (NSelect e (keys' <> map StaticKey keys) x)
+mkDots e keys = Fix $ NSelect e (map StaticKey keys) Nothing
 
 -- | An `inherit` clause without an expression to pull from.
 inherit :: [NKeyName e] -> Binding e


### PR DESCRIPTION
* Remove unnecessary partiality in `printNix` function
* Remove some unused imports
* For the `mkDots` helper function, a few tweaks:
  * Don't apply an empty list of attributes
  * If the expression being dotted is itself an `NSelect`, just extend the list of selectors
  * There doesn't seem to be any need to switch between static and dynamic keys based on the contents of the key, since the pretty-printer will apply quotes if necessary
* Pretty-printer should treat an `NSelect` which has no attributes as being the same as the internal expression
* Handle an edge case of an empty-string selector in an `NSelect`