### PR TITLE
Eval: coerce a set to a string if there is a __asString attribute

### DIFF
--- a/Nix/Eval.hs
+++ b/Nix/Eval.hs
@@ -67,7 +67,9 @@ valueText = cata phi where
     phi (NVConstant a)    = (atomText a, mempty)
     phi (NVStr t c)       = (t, c)
     phi (NVList _)        = error "Cannot coerce a list to a string"
-    phi (NVSet _)         = error "Cannot coerce a set to a string"
+    phi (NVSet set)
+      | Just asString <- Map.lookup "__asString" set = asString
+      | otherwise = error "Cannot coerce a set to a string"
     phi (NVFunction _ _)  = error "Cannot coerce a function to a string"
     phi (NVLiteralPath p) = (Text.pack p, mempty)
     phi (NVEnvPath p)     = (Text.pack p, mempty)


### PR DESCRIPTION
This is the last missing piece for my "nix for data jobs" prototype. It allows a set to be coerced to a string if it has a `__asString` attribute.

For reference, in the C++ nix, this can happen in two ways:
- If the set has an `outPath` attribute (in which case it is used);
- If the set has a `__toString` attribute, which is a function (in which case it is called with the set as argument).

I went for `__asString`, as it makes sense outside of the specific context of implementing derivations in nix.