### PR TITLE
Represent builtins with 2 arguments with currying

### DIFF
--- a/Nix/Builtins.hs
+++ b/Nix/Builtins.hs
@@ -65,18 +65,18 @@ evalPred pred = error $ "Trying to call a " ++ show pred
 -- Primops
 
 prim_toString :: MonadFix m => Functor m => NValue m
-prim_toString = Fix $ NVBuiltin1 "toString" $ toString
+prim_toString = builtin "toString" $ toString
 toString :: MonadFix m => NValue m -> m (NValue m)
 toString s = return $ Fix $ uncurry NVStr $ valueText s
 
 prim_hasAttr :: MonadFix m => NValue m
-prim_hasAttr = Fix $ NVBuiltin2 "hasAttr" [] hasAttr
+prim_hasAttr = builtin2 "hasAttr" hasAttr
 hasAttr :: MonadFix m => NValue m -> NValue m -> m (NValue m)
 hasAttr (Fix (NVStr key _)) (Fix (NVSet aset)) = return $ Fix $ NVConstant $ NBool $ Map.member key aset
 hasAttr key aset = error $ "Invalid types for builtin.hasAttr: " ++ show (key, aset)
 
 prim_getAttr :: MonadFix m => NValue m
-prim_getAttr = Fix $ NVBuiltin2 "getAttr" [] getAttr
+prim_getAttr = builtin2 "getAttr" getAttr
 getAttr :: MonadFix m => NValue m -> NValue m -> m (NValue m)
 getAttr (Fix (NVStr key _)) (Fix (NVSet aset)) = return $ Map.findWithDefault _err key aset
   where _err = error ("Field does not exist " ++ Text.unpack key)
@@ -84,13 +84,13 @@ getAttr key aset = error $ "Invalid types for builtin.getAttr: " ++ show (key, a
 
 
 prim_any :: MonadFix m => NValue m
-prim_any = Fix $ NVBuiltin2 "any" [] _any
+prim_any = builtin2 "any" _any
 _any :: MonadFix m => NValue m -> NValue m -> m (NValue m)
 _any pred (Fix (NVList l)) = mkBool . any extractBool <$> mapM (evalPred pred) l
 _any _ list = error $ "builtins.any takes a list as second argument, not a " ++ show list
 
 prim_all :: MonadFix m => NValue m
-prim_all = Fix $ NVBuiltin2 "all" [] _all
+prim_all = builtin2 "all" _all
 _all :: MonadFix m => NValue m -> NValue m -> m (NValue m)
 _all pred (Fix (NVList l)) = mkBool . all extractBool <$> mapM (evalPred pred) l
 _all _ list = error $ "builtins.all takes a list as second argument, not a " ++ show list

--- a/Nix/Pretty.hs
+++ b/Nix/Pretty.hs
@@ -187,8 +187,7 @@ prettyNixValue = prettyNix . valueToExpr
         go (NVFunction p _) = NSym . pack $ ("<function with " ++ show (() <$ p)  ++ ">")
         go (NVLiteralPath fp) = NLiteralPath fp
         go (NVEnvPath p) = NEnvPath p
-        go (NVBuiltin1 name _) = NSym $ Text.pack $ "builtins." ++ name
-        go (NVBuiltin2 name _ _) = NSym $ Text.pack $ "builtins." ++ name
+        go (NVBuiltin name _) = NSym $ Text.pack $ "builtins." ++ name
 
 
 printNix :: Functor m => NValue m -> String
@@ -201,5 +200,4 @@ printNix = cata phi
         phi (NVFunction _ _) = "<<lambda>>"
         phi (NVLiteralPath fp) = fp
         phi (NVEnvPath p) = p
-        phi (NVBuiltin1 name _) = "<<builtin " ++ name ++ ">>"
-        phi (NVBuiltin2 name _ _) = "<<builtin " ++ name ++ ">>"
+        phi (NVBuiltin name _) = "<<builtin " ++ name ++ ">>"


### PR DESCRIPTION
As a result, `NVBuiltin2` is not needed anymore, and `NVBuiltin1` gets renamed
to `NVBuiltin`

@layus This is what we were talking about in #82, if you're interested.