### PR TITLE
Make thunks monadic values

### DIFF
--- a/Nix.hs
+++ b/Nix.hs
@@ -31,7 +31,6 @@ import           Nix.Scope
 import           Nix.Stack
 import           Nix.Thunk
 import           Nix.Utils
-import           System.IO.Unsafe
 
 -- | Evaluate a nix expression in the default context
 evalTopLevelExpr :: MonadBuiltins e m
@@ -93,7 +92,7 @@ instance MonadIO m => MonadFile (Lint m) where
 
 instance MonadInterleave (Lint IO) where
     unsafeInterleave (Lint (ReaderT f)) = Lint $ ReaderT $ \e ->
-        liftIO $ unsafeInterleaveIO (f e)
+        liftIO $ liftIO <$> unsafeInterleave (f e)
 
 instance MonadIO m =>
       Eval.MonadExpr (SThunk (Lint m))

--- a/Nix/Lint.hs
+++ b/Nix/Lint.hs
@@ -81,8 +81,9 @@ sthunk = fmap SThunk . buildThunk
 sforce :: Applicative m => SThunk m -> m (Symbolic m)
 sforce = forceThunk . getSThunk
 
+-- TODO: Remove pure
 svalueThunk :: Applicative m => Symbolic m -> m (SThunk m)
-svalueThunk = fmap SThunk . valueRef
+svalueThunk = pure . SThunk . valueRef
 
 class Monad m => MonadVar m where
     type Var m :: * -> *

--- a/Nix/Monad.hs
+++ b/Nix/Monad.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 
 module Nix.Monad where
@@ -29,8 +30,9 @@ thunk = fmap coerce . buildThunk
 force :: Applicative m => NThunk m -> m (NValue m)
 force = forceThunk . coerce
 
-valueThunk :: Applicative m => NValue m -> m (NThunk m)
-valueThunk = fmap coerce . valueRef
+-- TODO: Remove pure
+valueThunk :: forall m. Applicative m => NValue m -> m (NThunk m)
+valueThunk = pure . coerce . valueRef @m
 
 -- | An 'NValue' is the most reduced form of an 'NExpr' after evaluation
 -- is completed.

--- a/Nix/Monad/Instance.hs
+++ b/Nix/Monad/Instance.hs
@@ -40,7 +40,6 @@ import           System.Directory
 import           System.Environment
 import           System.Exit (ExitCode (ExitSuccess))
 import           System.FilePath
-import           System.IO.Unsafe
 import           System.Posix.Files
 import           System.Process (readProcessWithExitCode)
 
@@ -90,7 +89,7 @@ instance (MonadFix m, MonadNix (Lazy m), MonadIO m,
 
 instance MonadInterleave (Lazy IO) where
     unsafeInterleave (Lazy (ReaderT f)) = Lazy $ ReaderT $ \e ->
-        liftIO $ unsafeInterleaveIO (f e)
+        liftIO $ liftIO <$> unsafeInterleave (f e)
 
 instance MonadIO m => MonadFile (Lazy m) where
     readFile = liftIO . BS.readFile


### PR DESCRIPTION
Before, we just enforced that with the `pure $!` during elimination. Now
we store them as a monadic value with `pure $!` or similar effectively
done already. Effectively, instead of encapsulation on the construction
and elimination side, we only have encapsulation on the construction
side.

In both the old and the new cases, the invariant is that forcing a thunk
must be done in the Monad needed to run the thunk lest it not be cached.

This shouldn't change the correctness of the existing code, at least as
measured by the test suite. But hopefully it makes writing code going
forward easier.