### PR TITLE
Fix eval-okay-xml

### DIFF
--- a/Nix/Eval.hs
+++ b/Nix/Eval.hs
@@ -29,6 +29,7 @@ import           Data.Fix
 import           Data.Functor.Compose
 import           Data.HashMap.Lazy (HashMap)
 import qualified Data.HashMap.Lazy as M
+import           Data.HashMap.Strict.InsOrd (toHashMap)
 import           Data.List (intercalate)
 import           Data.Maybe (fromMaybe, catMaybes)
 import           Data.Text (Text)
@@ -402,7 +403,7 @@ buildArgument params arg = case params of
                 let inject = case m of
                         Nothing -> id
                         Just n -> M.insert n $ const $ pure arg
-                loebM (inject $ alignWithKey (assemble isVariadic) args s)
+                loebM (inject $ alignWithKey (assemble isVariadic) args (toHashMap s))
 
             x -> throwError $ "Expected set in function call, received: "
                     ++ show (void x)

--- a/Nix/Expr/Shorthands.hs
+++ b/Nix/Expr/Shorthands.hs
@@ -8,7 +8,7 @@
 module Nix.Expr.Shorthands where
 
 import           Data.Fix
-import qualified Data.HashMap.Lazy as M
+import qualified Data.HashMap.Strict.InsOrd as M
 import           Data.Monoid
 import           Data.Text (Text)
 import           Nix.Atoms

--- a/Nix/Expr/Types.hs
+++ b/Nix/Expr/Types.hs
@@ -14,7 +14,7 @@ import Data.Data
 import Data.Eq.Deriving
 import Data.Fix
 import Data.Functor.Classes
-import Data.HashMap.Lazy (HashMap)
+import Data.HashMap.Strict.InsOrd (InsOrdHashMap)
 import Data.Text (Text, pack)
 import Data.Traversable
 import GHC.Exts
@@ -104,7 +104,13 @@ data Params r
   deriving (Ord, Eq, Generic, Typeable, Data, Functor, Show,
             Foldable, Traversable)
 
-type ParamSet r = HashMap VarName (Maybe r)
+--instance Show1 Params where
+--  liftShowsPrec sp sl p = undefined
+--  liftShowsPrec sp sl p = \case
+--    Param n -> show n
+--    ParamSet s b mn  -> showsUnaryWith showsPrec "StaticKey" p t
+
+type ParamSet r = InsOrdHashMap VarName (Maybe r)
 
 instance IsString (Params r) where
   fromString = Param . fromString
@@ -159,17 +165,17 @@ data NKeyName r
 instance IsString (NKeyName r) where
   fromString = StaticKey . fromString
 
-instance Eq1 NKeyName where
-  liftEq eq (DynamicKey a) (DynamicKey b) = liftEq2 (liftEq eq) eq a b
-  liftEq _ (StaticKey a) (StaticKey b) = a == b
-  liftEq _ _ _ = False
-
--- Deriving this instance automatically is not possible because @r@
--- occurs not only as last argument in @Antiquoted (NString r) r@
-instance Show1 NKeyName where
-  liftShowsPrec sp sl p = \case
-    DynamicKey a -> showsUnaryWith (liftShowsPrec2 (liftShowsPrec sp sl) (liftShowList sp sl) sp sl) "DynamicKey" p a
-    StaticKey t  -> showsUnaryWith showsPrec "StaticKey" p t
+-- instance Eq1 NKeyName where
+--   liftEq eq (DynamicKey a) (DynamicKey b) = liftEq2 (liftEq eq) eq a b
+--   liftEq _ (StaticKey a) (StaticKey b) = a == b
+--   liftEq _ _ _ = False
+-- 
+-- -- Deriving this instance automatically is not possible because @r@
+-- -- occurs not only as last argument in @Antiquoted (NString r) r@
+-- instance Show1 NKeyName where
+--   liftShowsPrec sp sl p = \case
+--     DynamicKey a -> showsUnaryWith (liftShowsPrec2 (liftShowsPrec sp sl) (liftShowList sp sl) sp sl) "DynamicKey" p a
+--     StaticKey t  -> showsUnaryWith showsPrec "StaticKey" p t
 
 -- Deriving this instance automatically is not possible because @r@
 -- occurs not only as last argument in @Antiquoted (NString r) r@
@@ -221,16 +227,16 @@ paramName :: Params r -> Maybe VarName
 paramName (Param n) = Just n
 paramName (ParamSet _ _ n) = n
 
-$(deriveEq1 ''NExprF)
-$(deriveEq1 ''NString)
-$(deriveEq1 ''Binding)
-$(deriveEq1 ''Params)
-$(deriveEq1 ''Antiquoted)
-$(deriveEq2 ''Antiquoted)
-
-$(deriveShow1 ''NExprF)
-$(deriveShow1 ''NString)
-$(deriveShow1 ''Params)
-$(deriveShow1 ''Binding)
-$(deriveShow1 ''Antiquoted)
-$(deriveShow2 ''Antiquoted)
+-- $(deriveEq1 ''NExprF)
+-- $(deriveEq1 ''NString)
+-- $(deriveEq1 ''Binding)
+-- $(deriveEq1 ''Params)
+-- $(deriveEq1 ''Antiquoted)
+-- $(deriveEq2 ''Antiquoted)
+-- 
+-- $(deriveShow1 ''NExprF)
+-- $(deriveShow1 ''NString)
+-- $(deriveShow1 ''Params)
+-- $(deriveShow1 ''Binding)
+-- $(deriveShow1 ''Antiquoted)
+-- $(deriveShow2 ''Antiquoted)

--- a/Nix/Expr/Types.hs
+++ b/Nix/Expr/Types.hs
@@ -104,12 +104,8 @@ data Params r
   deriving (Ord, Eq, Generic, Typeable, Data, Functor, Show,
             Foldable, Traversable)
 
---instance Show1 Params where
---  liftShowsPrec sp sl p = undefined
---  liftShowsPrec sp sl p = \case
---    Param n -> show n
---    ParamSet s b mn  -> showsUnaryWith showsPrec "StaticKey" p t
-
+-- This uses InsOrdHashMap because nix XML serialization preserves the order of
+-- the param set.
 type ParamSet r = InsOrdHashMap VarName (Maybe r)
 
 instance IsString (Params r) where
@@ -165,17 +161,17 @@ data NKeyName r
 instance IsString (NKeyName r) where
   fromString = StaticKey . fromString
 
--- instance Eq1 NKeyName where
---   liftEq eq (DynamicKey a) (DynamicKey b) = liftEq2 (liftEq eq) eq a b
---   liftEq _ (StaticKey a) (StaticKey b) = a == b
---   liftEq _ _ _ = False
--- 
--- -- Deriving this instance automatically is not possible because @r@
--- -- occurs not only as last argument in @Antiquoted (NString r) r@
--- instance Show1 NKeyName where
---   liftShowsPrec sp sl p = \case
---     DynamicKey a -> showsUnaryWith (liftShowsPrec2 (liftShowsPrec sp sl) (liftShowList sp sl) sp sl) "DynamicKey" p a
---     StaticKey t  -> showsUnaryWith showsPrec "StaticKey" p t
+instance Eq1 NKeyName where
+  liftEq eq (DynamicKey a) (DynamicKey b) = liftEq2 (liftEq eq) eq a b
+  liftEq _ (StaticKey a) (StaticKey b) = a == b
+  liftEq _ _ _ = False
+
+-- Deriving this instance automatically is not possible because @r@
+-- occurs not only as last argument in @Antiquoted (NString r) r@
+instance Show1 NKeyName where
+  liftShowsPrec sp sl p = \case
+    DynamicKey a -> showsUnaryWith (liftShowsPrec2 (liftShowsPrec sp sl) (liftShowList sp sl) sp sl) "DynamicKey" p a
+    StaticKey t  -> showsUnaryWith showsPrec "StaticKey" p t
 
 -- Deriving this instance automatically is not possible because @r@
 -- occurs not only as last argument in @Antiquoted (NString r) r@
@@ -227,16 +223,16 @@ paramName :: Params r -> Maybe VarName
 paramName (Param n) = Just n
 paramName (ParamSet _ _ n) = n
 
--- $(deriveEq1 ''NExprF)
--- $(deriveEq1 ''NString)
--- $(deriveEq1 ''Binding)
--- $(deriveEq1 ''Params)
--- $(deriveEq1 ''Antiquoted)
--- $(deriveEq2 ''Antiquoted)
--- 
--- $(deriveShow1 ''NExprF)
--- $(deriveShow1 ''NString)
--- $(deriveShow1 ''Params)
--- $(deriveShow1 ''Binding)
--- $(deriveShow1 ''Antiquoted)
--- $(deriveShow2 ''Antiquoted)
+$(deriveEq1 ''NExprF)
+$(deriveEq1 ''NString)
+$(deriveEq1 ''Binding)
+$(deriveEq1 ''Params)
+$(deriveEq1 ''Antiquoted)
+$(deriveEq2 ''Antiquoted)
+
+$(deriveShow1 ''NExprF)
+$(deriveShow1 ''NString)
+$(deriveShow1 ''Params)
+$(deriveShow1 ''Binding)
+$(deriveShow1 ''Antiquoted)
+$(deriveShow2 ''Antiquoted)

--- a/Nix/Lint.hs
+++ b/Nix/Lint.hs
@@ -18,6 +18,7 @@ import           Data.Coerce
 import           Data.Fix
 import           Data.HashMap.Lazy (HashMap)
 import qualified Data.HashMap.Lazy as M
+import qualified Data.HashMap.Strict.InsOrd as OM
 import           Data.List
 import           Data.Maybe
 import           Data.Text (Text)
@@ -372,7 +373,7 @@ lintApp context fun arg = fun >>= unpackSymbolic >>= \case
                            M.singleton name <$> everyPossible
                        ParamSet _s _ (Just _) -> error "NYI"
                        ParamSet s _ Nothing ->
-                           traverse (const everyPossible) s
+                           traverse (const everyPossible) (OM.toHashMap s)
                     pset' <- traverse (sthunk . pure) pset
                     arg'  <- sthunk $ mkSymbolic [TSet (Just pset')]
                     args  <- buildArgument params arg'

--- a/Nix/Parser.hs
+++ b/Nix/Parser.hs
@@ -16,7 +16,7 @@ import           Control.Monad
 import           Control.Monad.IO.Class
 import           Data.Foldable hiding (concat)
 import           Data.Functor
-import qualified Data.HashMap.Lazy as M
+import qualified Data.HashMap.Strict.InsOrd as M
 import           Data.Text hiding (map, foldl', concat)
 import           Nix.Expr hiding (($>))
 import           Nix.Parser.Library

--- a/Nix/Pretty.hs
+++ b/Nix/Pretty.hs
@@ -5,6 +5,7 @@ module Nix.Pretty where
 
 import           Data.Fix
 import           Data.HashMap.Lazy (toList)
+import qualified Data.HashMap.Strict.InsOrd as OM
 import qualified Data.HashSet as HashSet
 import           Data.List (isPrefixOf, sort)
 import           Data.Maybe (isJust)
@@ -90,8 +91,8 @@ prettyParamSet args var =
       Nothing -> text (unpack n)
       Just v -> text (unpack n) <+> text "?" <+> withoutParens v
     prettyArgs
-        | var = map prettySetArg (toList args)
-        | otherwise = map prettySetArg (toList args) ++ [text "..."]
+        | var = map prettySetArg (OM.toList args)
+        | otherwise = map prettySetArg (OM.toList args) ++ [text "..."]
     sep = align (comma <> space)
 
 prettyBind :: Binding NixDoc -> Doc

--- a/Nix/XML.hs
+++ b/Nix/XML.hs
@@ -4,6 +4,9 @@ module Nix.XML where
 
 import           Data.Fix
 import qualified Data.HashMap.Lazy as M
+import qualified Data.HashMap.Strict.InsOrd as OM
+import           Data.List
+import           Data.Ord
 import qualified Data.Text as Text
 import           Nix.Atoms
 import           Nix.Expr.Types
@@ -31,7 +34,7 @@ toXML = (.) ((++ "\n") .
         (map (\(k, v) -> Elem (Element (unqual "attr")
                                       [Attr (unqual "name") (Text.unpack k)]
                                       [Elem v] Nothing))
-             (M.toList s)) Nothing
+             (sortBy (comparing fst) $ M.toList s)) Nothing
 
     NVClosure _ p _  ->
         Element (unqual "function") [] (paramsXML p) Nothing
@@ -52,4 +55,4 @@ paramsXML (ParamSet s b mname) =
     nattr = maybe [] ((:[]) . Attr (unqual "name") . Text.unpack) (mname)
 
 paramSetXML :: ParamSet r -> [Content]
-paramSetXML m = map (\(k,_) -> Elem $ mkElem "attr" "name" (Text.unpack k)) $ M.toList m
+paramSetXML m = map (\(k,_) -> Elem $ mkElem "attr" "name" (Text.unpack k)) $ OM.toList m

--- a/Nix/XML.hs
+++ b/Nix/XML.hs
@@ -6,6 +6,7 @@ import           Data.Fix
 import qualified Data.HashMap.Lazy as M
 import qualified Data.Text as Text
 import           Nix.Atoms
+import           Nix.Expr.Types
 import           Nix.Monad
 import           Text.XML.Light
 
@@ -17,13 +18,13 @@ toXML = (.) ((++ "\n") .
         $ cata
         $ \case
     NVConstant a -> case a of
-        NInt n   -> elem "int" "value" (show n)
-        NFloat f -> elem "float" "value" (show f)
-        NBool b  -> elem "bool" "value" (if b then "true" else "false")
+        NInt n   -> mkElem "int" "value" (show n)
+        NFloat f -> mkElem "float" "value" (show f)
+        NBool b  -> mkElem "bool" "value" (if b then "true" else "false")
         NNull    -> Element (unqual "null") [] [] Nothing
-        NUri u   -> elem "uri" "value" (Text.unpack u)
+        NUri u   -> mkElem "uri" "value" (Text.unpack u)
 
-    NVStr t _ -> elem "string" "value" (Text.unpack t)
+    NVStr t _ -> mkElem "string" "value" (Text.unpack t)
     NVList l  -> Element (unqual "list") [] (Elem <$> l) Nothing
 
     NVSet s   -> Element (unqual "attrs") []
@@ -32,11 +33,23 @@ toXML = (.) ((++ "\n") .
                                       [Elem v] Nothing))
              (M.toList s)) Nothing
 
-    NVClosure _ _p _  ->
-        Element (unqual "function") []
-                (error "NYI: XML function param attrset") Nothing
-    NVLiteralPath fp -> elem "path" "value" fp
-    NVEnvPath p      -> elem "path" "value" p
-    NVBuiltin name _ -> elem "function" "name" name
+    NVClosure _ p _  ->
+        Element (unqual "function") [] (paramsXML p) Nothing
+    NVLiteralPath fp -> mkElem "path" "value" fp
+    NVEnvPath p      -> mkElem "path" "value" p
+    NVBuiltin name _ -> mkElem "function" "name" name
+
+mkElem :: String -> String -> String -> Element
+mkElem n a v = Element (unqual n) [Attr (unqual a) v] [] Nothing
+
+paramsXML :: Params r -> [Content]
+paramsXML (Param name) =
+    [Elem $ mkElem "varpat" "name" (Text.unpack name)]
+paramsXML (ParamSet s b mname) =
+    [Elem $ Element (unqual "attrspat") (battr ++ nattr) (paramSetXML s) Nothing]
   where
-    elem n a v = Element (unqual n) [Attr (unqual a) v] [] Nothing
+    battr = if b then [Attr (unqual "ellipsis") "1"] else []
+    nattr = maybe [] ((:[]) . Attr (unqual "name") . Text.unpack) (mname)
+
+paramSetXML :: ParamSet r -> [Content]
+paramSetXML m = map (\(k,_) -> Elem $ mkElem "attr" "name" (Text.unpack k)) $ M.toList m

--- a/default.nix
+++ b/default.nix
@@ -31,8 +31,8 @@ let
       insert-ordered-containers = pkgs.fetchFromGitHub {
         owner = "mightybyte";
         repo = "insert-ordered-containers";
-        rev = "2a15aea6a9733259ee494eb379dd4df206d215c5";
-        sha256 = "1pjg9lwahm767mf88r6cb0dcaga84l8p08zd7mxjz322ll07q1ja";
+        rev = "87054c519b969b62131bcf7a183470d422cbb535";
+        sha256 = "0l0g6ns5bcrcaij0wbdgc04qyl9h0vk1kx9lkzdkwj9v51l26azm";
       };
     };
   };

--- a/default.nix
+++ b/default.nix
@@ -31,8 +31,8 @@ let
       insert-ordered-containers = pkgs.fetchFromGitHub {
         owner = "mightybyte";
         repo = "insert-ordered-containers";
-        rev = "87054c519b969b62131bcf7a183470d422cbb535";
-        sha256 = "0l0g6ns5bcrcaij0wbdgc04qyl9h0vk1kx9lkzdkwj9v51l26azm";
+        rev = "2a15aea6a9733259ee494eb379dd4df206d215c5";
+        sha256 = "1pjg9lwahm767mf88r6cb0dcaga84l8p08zd7mxjz322ll07q1ja";
       };
     };
   };

--- a/hnix.cabal
+++ b/hnix.cabal
@@ -64,6 +64,7 @@ Library
     , data-fix
     , deepseq
     , exceptions
+    , insert-ordered-containers >= 0.2.2 && < 0.3
     , process
     , directory
     , filepath
@@ -143,6 +144,7 @@ Test-suite hnix-tests
     , split
     , transformers
     , interpolate
+    , insert-ordered-containers
     , unordered-containers
 
 Benchmark hnix-benchmarks

--- a/tests/NixLanguageTests.hs
+++ b/tests/NixLanguageTests.hs
@@ -95,7 +95,7 @@ assertLangOk file = do
   assertEqual "" expected $ Text.pack (actual ++ "\n")
 
 assertLangOkXml :: FilePath -> Assertion
-assertLangOkXml file = do --assertFailure $ "Not implemented: " ++ file
+assertLangOkXml file = do
   actual <- toXML <$> nixEvalFile (file ++ ".nix")
   expected <- Text.readFile $ file ++ ".exp.xml"
   assertEqual "" expected $ Text.pack actual

--- a/tests/NixLanguageTests.hs
+++ b/tests/NixLanguageTests.hs
@@ -98,7 +98,7 @@ assertLangOkXml :: FilePath -> Assertion
 assertLangOkXml file = do --assertFailure $ "Not implemented: " ++ file
   actual <- toXML <$> nixEvalFile (file ++ ".nix")
   expected <- Text.readFile $ file ++ ".exp.xml"
-  assertEqual "" expected $ Text.pack (actual ++ "\n")
+  assertEqual "" expected $ Text.pack actual
 
 assertEval :: [FilePath] -> Assertion
 assertEval files =

--- a/tests/NixLanguageTests.hs
+++ b/tests/NixLanguageTests.hs
@@ -20,6 +20,7 @@ import           Nix.Monad
 import           Nix.Monad.Instance
 import           Nix.Parser
 import           Nix.Pretty
+import           Nix.XML
 import           System.Environment
 import           System.FilePath
 import           System.FilePath.Glob (compile, globDir1)
@@ -94,7 +95,10 @@ assertLangOk file = do
   assertEqual "" expected $ Text.pack (actual ++ "\n")
 
 assertLangOkXml :: FilePath -> Assertion
-assertLangOkXml name = assertFailure $ "Not implemented: " ++ name
+assertLangOkXml file = do --assertFailure $ "Not implemented: " ++ file
+  actual <- toXML <$> nixEvalFile (file ++ ".nix")
+  expected <- Text.readFile $ file ++ ".exp.xml"
+  assertEqual "" expected $ Text.pack (actual ++ "\n")
 
 assertEval :: [FilePath] -> Assertion
 assertEval files =

--- a/tests/ParserTests.hs
+++ b/tests/ParserTests.hs
@@ -4,6 +4,7 @@ module ParserTests (tests) where
 
 import           Data.Fix
 import qualified Data.HashMap.Lazy as M
+import qualified Data.HashMap.Strict.InsOrd as OM
 import           Data.Text (pack)
 import           Nix.Atoms
 import           Nix.Expr
@@ -168,9 +169,9 @@ case_lambda_pattern = do
  where
   fixed args = ParamSet args False
   variadic args = ParamSet args True
-  args = M.fromList [("b", Nothing), ("c", Just $ mkInt 1)]
-  vargs = M.fromList [("b", Nothing), ("c", Just $ mkInt 1)]
-  args2 = M.fromList [("b", Just lam)]
+  args = OM.fromList [("b", Nothing), ("c", Just $ mkInt 1)]
+  vargs = OM.fromList [("b", Nothing), ("c", Just $ mkInt 1)]
+  args2 = OM.fromList [("b", Just lam)]
   lam = Fix $ NAbs (Param "x") (mkSym "x")
 
 case_lambda_app_int :: Assertion


### PR DESCRIPTION
This fixes the eval-okay-xml test case.  It adds a dependency on a custom version of insert-ordered-containers because the upstream library didn't have all the needed instances.  Even with that, I still ended up commenting out a bunch of instances that were causing issues.  Should I implement those instances or can we get rid of them?