### PR TITLE
Replace pcre-light with regex-tdfa

### DIFF
--- a/Nix/Builtins.hs
+++ b/Nix/Builtins.hs
@@ -14,7 +14,7 @@
 {-# OPTIONS_GHC -Wno-missing-signatures #-}
 {-# OPTIONS_GHC -fno-warn-name-shadowing #-}
 
-module Nix.Builtins where --(MonadBuiltins, baseEnv) where
+module Nix.Builtins (MonadBuiltins, baseEnv) where
 
 import           Control.Monad
 import           Control.Monad.Fix

--- a/Nix/Expr/Types.hs
+++ b/Nix/Expr/Types.hs
@@ -123,8 +123,8 @@ data Antiquoted v r = Plain !v | Antiquoted !r
 -- the final string is constructed by concating all the parts.
 data NString r
   = DoubleQuoted ![Antiquoted Text r]
-  -- ^ Strings wrapped with double-quotes (") are not allowed to contain
-  -- literal newline characters.
+  -- ^ Strings wrapped with double-quotes (") can contain literal newline
+  -- characters, but the newlines are preserved and no indentation is stripped.
   | Indented ![Antiquoted Text r]
   -- ^ Strings wrapped with two single quotes ('') can contain newlines,
   -- and their indentation will be stripped.

--- a/hnix.cabal
+++ b/hnix.cabal
@@ -49,6 +49,7 @@ Library
       base                     >= 4.9          && < 5
     , aeson
     , ansi-wl-pprint
+    , array >= 0.4 && < 0.6
     , base16-bytestring
     , containers
     , cryptohash
@@ -79,7 +80,6 @@ Library
     , syb
     , vector
     , xml
-    , pcre-light
   if flag(parsec)
     Cpp-options: -DUSE_PARSEC
     Build-depends: parsec


### PR DESCRIPTION
The regex-tdfa package implements POSIX extended regular expressions, which are what Nix uses.