### PR TITLE
Change the nixpkgs pin

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -2,9 +2,9 @@ let
   hostPkgs = import <nixpkgs> {};
   pinnedPkgs = hostPkgs.fetchFromGitHub {
     owner = "NixOS";
-    repo = "nixpkgs-channels";
-    rev = "ee28e35ba37ab285fc29e4a09f26235ffe4123e2";
-    sha256 = "0a6xrqjj2ihkz1bizhy5r843n38xgimzw5s2mfc42kk2rgc95gw5";
+    repo = "nixpkgs";
+    rev = "b0482248fefbf3b6cdd9c92053cfb49778a3a3a8";
+    sha256 = "0qdgzdxkdl77381ifmzpikxr2gi5jcmflg9syvbi1h2pjfsi2424";
   };
 
 in { nixpkgs ? import pinnedPkgs {}


### PR DESCRIPTION
The existing commit fails to build on my machine with the error:

```
api.c:22:10: fatal error: 'endian.h' file not found
#include <endian.h>
         ^~~~~~~~~~
1 error generated.
make[3]: *** [Makefile:693: libseccomp_la-api.lo] Error 1
make[2]: *** [Makefile:918: all-recursive] Error 1
make[1]: *** [Makefile:498: all-recursive] Error 1
make: *** [Makefile:407: all] Error 2
builder for '/nix/store/y77qz7z2s4skis94n82ji10lfiqcn0mv-libseccomp-2.3.3.drv' failed with exit code 2
```

This PR fixes the problem.