### PR TITLE
Fix errors while running benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,19 @@ $ runhaskell Setup.hs build
 $ runhaskell Setup.hs test
 # To run all of the tests, which takes up to a minute:
 $ LANGUAGE_TESTS=yes NIXPKGS_TESTS=yes runhaskell Setup.hs test
-$ runhaskell Setup.hs bench
 $ ./dist/build/hnix/hnix --help
 ```
+## Building with benchmarks enabled
+
+To build `hnix` with benchmarks enabled:
+
+```
+$ nix-shell --arg doBenchmarks true
+$ runhaskell Setup.hs configure --enable-tests --enable-benchmarks
+$ runhaskell Setup.hs build
+$ runhaskell Setup.hs bench
+```
+
 
 ## Building with profiling enabled
 

--- a/default.nix
+++ b/default.nix
@@ -37,7 +37,7 @@ let
     modifier = drv: pkgs.haskell.lib.overrideCabal drv (attrs: {
       testHaskellDepends = attrs.testHaskellDepends ++
         [ pkgs.nix haskellPackages.hpack ];
-      doBenchmark = doBenchmark;
+      inherit doBenchmark;
     });
   };
 

--- a/default.nix
+++ b/default.nix
@@ -37,11 +37,9 @@ let
     modifier = drv: pkgs.haskell.lib.overrideCabal drv (attrs: {
       testHaskellDepends = attrs.testHaskellDepends ++
         [ pkgs.nix haskellPackages.hpack ];
+      doBenchmark = doBenchmark;
     });
   };
 
-  variant = if doBenchmark
-            then pkgs.haskell.lib.doBenchmark
-            else pkgs.lib.id;
 
-in variant pkg
+in pkg


### PR DESCRIPTION
Errors while trying to run benchmarks by following the README,

```bash
   $ nix-shell
   [nix-shell]$ runhaskell Setup.hs configure --enable-tests
   
   [nix-shell]$ runhaskell Setup.hs bench
   Setup.hs: No benchmarks enabled. Did you remember to configure with
   '--enable-benchmarks'?
   
   [nix-shell]$ runhaskell Setup.hs configure --enable-tests --enable-benchmarks
   Configuring hnix-0.5.0...
   Setup.hs: Encountered missing dependencies:
   criterion -any
```

```bash
   $ nix-shell --arg doBenchmark true
   error: attribute 'override' missing, at /nix/store/s0j05civayrjpc2zvhlwmpm7hrgnm8d3-source/pkgs/development/haskell-modules/lib.nix:37:28
```
---
After the fix (which I followed from the PR https://github.com/NixOS/nixpkgs/pull/34405)

```bash
  $ nix-shell --arg doBenchmark true
  [nix-shell]$ runhaskell Setup.hs configure --enable-tests --enable-benchmarks
  [nix-shell]$ runhaskell Setup.hs build
  [nix-shell]$ runhaskell Setup.hs bench
  Running 1 benchmarks...
  Benchmark hnix-benchmarks: RUNNING...
  benchmarking Parser/nixpkgs-all-packages.nix
  time                 309.9 ms   (270.6 ms .. 377.6 ms)
                       0.986 R²   (0.930 R² .. 1.000 R²)
  mean                 302.4 ms   (289.8 ms .. 321.8 ms)
  std dev              18.61 ms   (2.879 ms .. 24.59 ms)
  variance introduced by outliers: 17% (moderately inflated)

  benchmarking Parser/nixpkgs-all-packages-pretty.nix
  time                 3.813 ms   (3.747 ms .. 3.871 ms)
                       0.997 R²   (0.995 R² .. 0.999 R²)
  mean                 3.817 ms   (3.775 ms .. 3.890 ms)
  std dev              175.7 μs   (129.4 μs .. 247.9 μs)
  variance introduced by outliers: 27% (moderately inflated)

  benchmarking Parser/let-comments.nix
  time                 223.4 μs   (220.4 μs .. 227.2 μs)
                       0.997 R²   (0.996 R² .. 0.998 R²)
  mean                 226.1 μs   (222.7 μs .. 230.6 μs)
  std dev              13.21 μs   (10.37 μs .. 19.06 μs)
  variance introduced by outliers: 56% (severely inflated)

  benchmarking Parser/let-comments-multiline.nix
  time                 245.4 μs   (239.8 μs .. 250.4 μs)
                       0.996 R²   (0.995 R² .. 0.998 R²)
  mean                 249.5 μs   (244.5 μs .. 256.4 μs)
  std dev              20.03 μs   (14.75 μs .. 28.66 μs)
  variance introduced by outliers: 70% (severely inflated)

  benchmarking Parser/let.nix
  time                 218.4 μs   (213.6 μs .. 223.5 μs)
                       0.996 R²   (0.995 R² .. 0.998 R²)
  mean                 218.6 μs   (214.7 μs .. 223.5 μs)
  std dev              14.47 μs   (10.95 μs .. 20.83 μs)
  variance introduced by outliers: 62% (severely inflated)

  benchmarking Parser/simple.nix
  time                 839.7 μs   (825.4 μs .. 854.7 μs)
                       0.997 R²   (0.996 R² .. 0.998 R²)
  mean                 833.6 μs   (821.7 μs .. 843.1 μs)
  std dev              35.91 μs   (30.90 μs .. 41.35 μs)
  variance introduced by outliers: 34% (moderately inflated)

  benchmarking Parser/simple-pretty.nix
  time                 846.8 μs   (824.4 μs .. 866.2 μs)
                       0.996 R²   (0.995 R² .. 0.998 R²)
  mean                 839.1 μs   (827.3 μs .. 851.9 μs)
  std dev              43.28 μs   (37.11 μs .. 51.72 μs)
  variance introduced by outliers: 42% (moderately inflated)

  Benchmark hnix-benchmarks: FINISH 
```
