### PR TITLE
Pretty: handle tilde in paths

### DIFF
--- a/src/Nix/Pretty.hs
+++ b/src/Nix/Pretty.hs
@@ -183,6 +183,7 @@ prettyNix = withoutParens . cata phi where
     "../" -> "../."
     ".." -> "../."
     txt | "/" `isPrefixOf` txt -> txt
+        | "~/" `isPrefixOf` txt -> txt
         | "./" `isPrefixOf` txt -> txt
         | "../" `isPrefixOf` txt -> txt
         | otherwise -> "./" ++ txt

--- a/tests/PrettyTests.hs
+++ b/tests/PrettyTests.hs
@@ -24,6 +24,12 @@ case_function_params :: Assertion
 case_function_params =
     assertPretty (mkFunction (mkParamset [] True) (mkInt 3)) "{ ... }:\n  3"
 
+case_paths :: Assertion
+case_paths = do
+    assertPretty (mkPath False "~/test.nix") "~/test.nix"
+    assertPretty (mkPath False "/test.nix") "/test.nix"
+    assertPretty (mkPath False "./test.nix") "./test.nix"
+
 tests :: TestTree
 tests = $testGroupGenerator
 


### PR DESCRIPTION
@jwiegley I was thinking to rewrite pretty tests into property testing of `parse . pretty ~~ id` as per #158, without autogenerating expressions.

That way they'd check the whole pipeline, but they have to be golden tests written in pretty output style. Another benefit would be that adding tests is really simple, a literal nix string.