### PR TITLE
getURL is introduced and implemented via http-client

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -36,8 +36,6 @@ in haskellPackages.developPackage {
       [
         pkgs.nix
         haskellPackages.hpack
-        haskellPackages.http-client
-        haskellPackages.http-client-tls
         # haskellPackages.cabal-install
       ];
 

--- a/default.nix
+++ b/default.nix
@@ -36,6 +36,7 @@ in haskellPackages.developPackage {
       [
         pkgs.nix
         haskellPackages.hpack
+        haskellPackages.HTTP
         # haskellPackages.cabal-install
       ];
 

--- a/default.nix
+++ b/default.nix
@@ -36,7 +36,8 @@ in haskellPackages.developPackage {
       [
         pkgs.nix
         haskellPackages.hpack
-        haskellPackages.HTTP
+        haskellPackages.http-client
+        haskellPackages.http-client-tls
         # haskellPackages.cabal-install
       ];
 

--- a/hnix.cabal
+++ b/hnix.cabal
@@ -95,6 +95,7 @@ library
     , exceptions
     , filepath
     , hashable
+    , HTTP
     , megaparsec
     , monadlist
     , mtl

--- a/hnix.cabal
+++ b/hnix.cabal
@@ -95,7 +95,9 @@ library
     , exceptions
     , filepath
     , hashable
-    , HTTP
+    , http-types
+    , http-client
+    , http-client-tls
     , megaparsec
     , monadlist
     , mtl

--- a/hnix.cabal
+++ b/hnix.cabal
@@ -2,7 +2,7 @@
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: f2849e05edde8ddd3f02ee010be0fa0e7ee673392948670ced6209113f5b5e7f
+-- hash: 3928a85f453159f5a9ef8d10caa3a7df439c403f9f5abb658b1d1dc06b92fc25
 
 name:           hnix
 version:        0.5.0
@@ -95,6 +95,9 @@ library
     , exceptions
     , filepath
     , hashable
+    , http-client
+    , http-client-tls
+    , http-types
     , megaparsec
     , monadlist
     , mtl

--- a/hnix.cabal
+++ b/hnix.cabal
@@ -95,9 +95,6 @@ library
     , exceptions
     , filepath
     , hashable
-    , http-types
-    , http-client
-    , http-client-tls
     , megaparsec
     , monadlist
     , mtl

--- a/package.yaml
+++ b/package.yaml
@@ -68,6 +68,9 @@ library:
     - deriving-compat           >= 0.3 && < 0.5
     - directory
     - hashable
+    - http-types
+    - http-client
+    - http-client-tls
     - megaparsec
     - monadlist
     - pretty-show

--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -135,6 +135,7 @@ builtinsList = sequence [
     , add2 Normal   "elem"                       elem_
     , add2 Normal   "elemAt"                     elemAt_
     , add  Normal   "fetchTarball"               fetchTarball
+    , add  Normal   "fetchurl"                   fetchurl
     , add2 Normal   "filter"                     filter_
     , add3 Normal   "foldl'"                     foldl'_
     , add  Normal   "fromJSON"                   fromJSON
@@ -801,6 +802,33 @@ fetchTarball v = v >>= \case
         nixInstantiateExpr $ "builtins.fetchTarball { "
           ++ "url    = \"" ++ Text.unpack url ++ "\"; "
           ++ "sha256 = \"" ++ Text.unpack sha ++ "\"; }"
+
+fetchurl :: forall e m. MonadNix e m => m (NValue m) -> m (NValue m)
+fetchurl v = v >>= \case
+    NVSet s _ -> case M.lookup "url" s of
+        Nothing -> throwError @String "builtins.fetchurl: Missing url attribute"
+        Just url -> force url $ go (M.lookup "sha256" s)
+    v@NVStr {} -> go Nothing v
+    v@(NVConstant (NUri _)) -> go Nothing v
+    v -> throwError @String $ "builtins.fetchurl: Expected URI or set, got "
+            ++ show v
+ where
+    go :: Maybe (NThunk m) -> NValue m -> m (NValue m)
+    go msha = \case
+        NVStr uri _ -> fetch uri msha
+        NVConstant (NUri uri) -> fetch uri msha
+        v -> throwError @String $ "builtins.fetchurl: Expected URI or string, got "
+                ++ show v
+
+    fetch :: Text -> Maybe (NThunk m) -> m (NValue m)
+    fetch uri Nothing =
+        nixInstantiateExpr $ "builtins.fetchurl \"" ++
+            Text.unpack uri ++ "\""
+    fetch url (Just m) = fromValue m >>= \sha ->
+        nixInstantiateExpr $ "builtins.fetchurl { "
+          ++ "url    = \"" ++ Text.unpack url ++ "\"; "
+          ++ "sha256 = \"" ++ Text.unpack sha ++ "\"; }"
+
 
 partition_ :: forall e m. MonadNix e m
            => m (NValue m) -> m (NValue m) -> m (NValue m)

--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -817,20 +817,10 @@ fetchurl v = v >>= \case
  where
     go :: Maybe (NThunk m) -> NValue m -> m (NValue m)
     go msha = \case
-        NVStr uri _ -> fetch uri msha
-        NVConstant (NUri uri) -> fetch uri msha
+        NVStr uri _ -> getURL uri -- msha
+        NVConstant (NUri uri) -> getURL uri -- msha
         v -> throwError @String $ "builtins.fetchurl: Expected URI or string, got "
                 ++ show v
-
-    fetch :: Text -> Maybe (NThunk m) -> m (NValue m)
-    fetch uri Nothing =
-        nixInstantiateExpr $ "builtins.fetchurl \"" ++
-            Text.unpack uri ++ "\""
-    fetch url (Just m) = fromValue m >>= \sha ->
-        nixInstantiateExpr $ "builtins.fetchurl { "
-          ++ "url    = \"" ++ Text.unpack url ++ "\"; "
-          ++ "sha256 = \"" ++ Text.unpack sha ++ "\"; }"
-
 
 partition_ :: forall e m. MonadNix e m
            => m (NValue m) -> m (NValue m) -> m (NValue m)

--- a/src/Nix/Effects.hs
+++ b/src/Nix/Effects.hs
@@ -31,4 +31,4 @@ class MonadFile m => MonadEffects m where
 
     nixInstantiateExpr :: String -> m (NValue m)
 
-    getURL :: String -> m (NValue m)
+    getURL :: Text -> m (NValue m)

--- a/src/Nix/Effects.hs
+++ b/src/Nix/Effects.hs
@@ -31,4 +31,4 @@ class MonadFile m => MonadEffects m where
 
     nixInstantiateExpr :: String -> m (NValue m)
 
-    simpleHTTP :: String -> m (NValue m)
+    getURL :: String -> m (NValue m)

--- a/src/Nix/Effects.hs
+++ b/src/Nix/Effects.hs
@@ -30,3 +30,5 @@ class MonadFile m => MonadEffects m where
     derivationStrict :: NValue m -> m (NValue m)
 
     nixInstantiateExpr :: String -> m (NValue m)
+
+    simpleHTTP :: String -> m (NValue m)

--- a/src/Nix/Exec.hs
+++ b/src/Nix/Exec.hs
@@ -46,6 +46,8 @@ import           Data.Text (Text)
 import qualified Data.Text as Text
 import           Data.Typeable
 import           Data.Void
+import           Network.HTTP.Client
+
 import           Nix.Atoms
 import           Nix.Context
 import           Nix.Convert
@@ -546,8 +548,17 @@ instance (MonadFix m, MonadCatch m, MonadThrow m, MonadIO m,
                 Success v -> evalExprLoc v
             err -> throwError $ "nix-instantiate failed: " ++ show err
 
-    -- simpleHTTP expr = do
-    --         traceM $ "fetching HTTP URL: " ++ expr
+    getURL url = do
+        traceM $ "fetching HTTP URL: " ++ url
+        liftIO $ do
+          manager - newManager defaultManagerSettings
+          initialRequest <- parseRequest url
+          let request = initialRequest { method = "GET" }
+          response <- httpLbs request manager
+          print response
+
+          throwError $ "just for now" 
+        
         
 
 

--- a/src/Nix/Exec.hs
+++ b/src/Nix/Exec.hs
@@ -546,6 +546,12 @@ instance (MonadFix m, MonadCatch m, MonadThrow m, MonadIO m,
                 Success v -> evalExprLoc v
             err -> throwError $ "nix-instantiate failed: " ++ show err
 
+    -- simpleHTTP expr = do
+    --         traceM $ "fetching HTTP URL: " ++ expr
+        
+
+
+
 runLazyM :: Options -> MonadIO m => Lazy m a -> m a
 runLazyM opts = (`evalStateT` M.empty)
               . (`runReaderT` newContext opts)

--- a/src/Nix/Exec.hs
+++ b/src/Nix/Exec.hs
@@ -47,7 +47,6 @@ import           Data.List.Split
 import           Data.Text (Text)
 import qualified Data.Text as Text
 import           Data.Typeable
-import           Data.Void
 import           Network.HTTP.Client
 import           Network.HTTP.Client.TLS
 import           Network.HTTP.Types
@@ -615,7 +614,7 @@ instance (MonadFix m, MonadCatch m, MonadIO m, Alternative m,
           then throwError $ ErrorCall $ 
                  "fail, got " ++ show status ++ " when fetching url:" ++ urlstr
           else do
-            let bstr = responseBody response
+            -- let bstr = responseBody response
             -- liftIO $ print bstr
             throwError $ ErrorCall $ 
               "success in downloading but hnix-store is not yet ready; url = " ++ urlstr

--- a/src/Nix/Exec.hs
+++ b/src/Nix/Exec.hs
@@ -594,18 +594,20 @@ instance (MonadFix m, MonadCatch m, MonadIO m, Alternative m,
           req <- parseRequest urlstr
           manager <-
             if secure req
-               then newTlsManager
-               else newManager defaultManagerSettings
+            then newTlsManager
+            else newManager defaultManagerSettings
           -- print req
           httpLbs (req { method = "GET" }) manager
           -- return response
         let status = statusCode (responseStatus response)
         if  status /= 200
-          then throwError ("fail, got " ++ show status ++ " when fetching url:" ++ urlstr)
+          then throwError $ ErrorCall $ 
+                 "fail, got " ++ show status ++ " when fetching url:" ++ urlstr
           else do
             let bstr = responseBody response
             -- liftIO $ print bstr
-            throwError ("success in downloading but hnix store is not ready yet. so fail here. url is " ++ urlstr)
+            throwError $ ErrorCall $ 
+              "success in downloading but hnix-store is not yet ready; url = " ++ urlstr
 
     traceEffect = liftIO . putStrLn
 


### PR DESCRIPTION
For implementing various network operation, getURL is introduced as a method for `MonadEffects`.
I use http-client and http-client-tls for fetching the content from a designated URL.
Since we do not have a full implementation of hnix store yet, it just throws an error after downloading for now.

