### PR TITLE
Add HPACK_TESTS and an ALL_TESTS env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,9 @@ $ cabal configure --enable-tests
 $ cabal build
 $ cabal test
 # To run all of the tests, which takes up to a minute:
-$ LANGUAGE_TESTS=yes NIXPKGS_TESTS=yes cabal test
+$ env ALL_TESTS=yes cabal test
+# To run only specific tests (see `tests/Main.hs` for a list)
+$ env NIXPKGS_TESTS=yes PRETTY_TESTS=yes cabal test
 $ ./dist/build/hnix/hnix --help
 ```
 

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -86,12 +86,14 @@ main = do
   evalComparisonTests <- EvalTests.genEvalCompareTests
   nixpkgsTestsEnv     <- lookupEnv "NIXPKGS_TESTS"
   prettyTestsEnv      <- lookupEnv "PRETTY_TESTS"
+  hpackTestsEnv       <- lookupEnv "HPACK_TESTS"
 
   pwd <- getCurrentDirectory
   setEnv "NIX_REMOTE" ("local?root=" ++ pwd ++ "/")
 
   defaultMain $ testGroup "hnix" $
-    [ testCase "hnix.cabal correctly generated" cabalCorrectlyGenerated ] ++
+    [ testCase "hnix.cabal correctly generated" cabalCorrectlyGenerated
+      | isJust hpackTestsEnv ] ++
     [ ParserTests.tests
     , EvalTests.tests
     , PrettyTests.tests ] ++

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -7,6 +7,7 @@ module Main where
 
 import           Control.DeepSeq
 import qualified Control.Exception as Exc
+import           Control.Applicative ((<|>))
 import           Control.Monad
 import           Control.Monad.IO.Class
 import           Data.Fix
@@ -84,9 +85,11 @@ main :: IO ()
 main = do
   nixLanguageTests    <- NixLanguageTests.genTests
   evalComparisonTests <- EvalTests.genEvalCompareTests
-  nixpkgsTestsEnv     <- lookupEnv "NIXPKGS_TESTS"
-  prettyTestsEnv      <- lookupEnv "PRETTY_TESTS"
-  hpackTestsEnv       <- lookupEnv "HPACK_TESTS"
+  let allOrLookup = \var ->
+        lookupEnv "ALL_TESTS" <|> lookupEnv var
+  nixpkgsTestsEnv     <- allOrLookup "NIXPKGS_TESTS"
+  prettyTestsEnv      <- allOrLookup "PRETTY_TESTS"
+  hpackTestsEnv       <- allOrLookup "HPACK_TESTS"
 
   pwd <- getCurrentDirectory
   setEnv "NIX_REMOTE" ("local?root=" ++ pwd ++ "/")


### PR DESCRIPTION
See PR description, `HPACK_TESTS` is used to be able to run the tests in nixpkgs without pulling in `hpack`, `ALL_TESTS` should be convenient.