### PR TITLE
Add back cabal-install to default.nix

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -93,7 +93,16 @@ in haskellPackages.developPackage {
         # .cabal file will be. Otherwise, Travis may error out claiming that
         # the cabal file needs to be updated because the result is different
         # that the version we committed to Git.
-        pkgs.haskell.packages.ghc822.hpack ];
+        pkgs.haskell.packages.ghc822.hpack
+
+        (let cabalInstallVersion = {
+               ghc802 = "1.24.0.2";
+               ghc822 = "2.0.0.1";
+               ghc842 = "2.2.0.0";
+             }; in
+         haskellPackages.callHackage "cabal-install"
+          cabalInstallVersion.${compiler} {})
+      ];
 
     enableLibraryProfiling    = doProfiling;
     enableExecutableProfiling = doProfiling;

--- a/default.nix
+++ b/default.nix
@@ -81,6 +81,7 @@ in haskellPackages.developPackage {
                ghc802 = "1.24.0.2";
                ghc822 = "2.0.0.1";
                ghc842 = "2.2.0.0";
+               ghc843 = "2.2.0.0";
              }; in
          haskellPackages.callHackage "cabal-install"
           cabalInstallVersion.${compiler} {})


### PR DESCRIPTION
I'm not sure if this is the proper fix, but I can't follow the README instructions since https://github.com/haskell-nix/hnix/commit/c9e1393391dd454b3ae9c49b489d8c4b97fe4617 removed cabal-install.