### PR TITLE
Builtins.div cannot divide by 0

### DIFF
--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -356,11 +356,14 @@ mul_ x y = x >>= \x' -> y >>= \y' -> case (x', y') of
 
 div_ :: MonadNix e m => m (NValue m) -> m (NValue m) -> m (NValue m)
 div_ x y = x >>= \x' -> y >>= \y' -> case (x', y') of
-    (NVConstant (NInt x),   NVConstant (NInt y))   ->
+    (NVConstant (NInt x),   NVConstant (NInt y))   | y /= 0 ->
         toNix (floor (fromInteger x / fromInteger y :: Double) :: Integer)
-    (NVConstant (NFloat x), NVConstant (NInt y))   -> toNix (x / fromInteger y)
-    (NVConstant (NInt x),   NVConstant (NFloat y)) -> toNix (fromInteger x / y)
-    (NVConstant (NFloat x), NVConstant (NFloat y)) -> toNix (x / y)
+    (NVConstant (NFloat x), NVConstant (NInt y))   | y /= 0 ->
+        toNix (x / fromInteger y)
+    (NVConstant (NInt x),   NVConstant (NFloat y)) | y /= 0 -> 
+        toNix (fromInteger x / y)
+    (NVConstant (NFloat x), NVConstant (NFloat y)) | y /= 0 -> 
+        toNix (x / y)
     (_, _) ->
         throwError $ Division x' y'
 

--- a/tests/EvalTests.hs
+++ b/tests/EvalTests.hs
@@ -31,6 +31,12 @@ case_basic_sum =
 case_basic_div =
     constantEqualText "3" "builtins.div 6 2"
 
+case_zero_div = do
+  assertNixEvalThrows "builtins.div 1 0"
+  assertNixEvalThrows "builtins.div 1.0 0"
+  assertNixEvalThrows "builtins.div 1 0.0"
+  assertNixEvalThrows "builtins.div 1.0 0.0"
+
 case_basic_function =
     constantEqualText "2" "(a: a) 2"
 


### PR DESCRIPTION
Add a pre-condition on builtin.div to prevent division by zero.

Fixes #277.