### PR TITLE
Add basic NSelect reduction strategy

### DIFF
--- a/hnix.cabal
+++ b/hnix.cabal
@@ -623,6 +623,7 @@ test-suite hnix-tests
       ParserTests
       PrettyParseTests
       PrettyTests
+      ReduceExprTests
       TestCommon
       Paths_hnix
   hs-source-dirs:

--- a/src/Nix/Reduce.hs
+++ b/src/Nix/Reduce.hs
@@ -114,7 +114,7 @@ staticImport pann path = do
 
 reduceExpr :: MonadIO m => Maybe FilePath -> NExprLoc -> m NExprLoc
 reduceExpr mpath expr
-  = trace "reducing.." $ (`evalStateT` M.empty)
+  = (`evalStateT` M.empty)
     . (`runReaderT` (mpath, emptyScopes))
     . runReducer
     $ cata reduce expr
@@ -185,6 +185,7 @@ reduce base@(NSelect_ _ _ attr _)
   where
     sId = Fix <$> sequence base
     sAttrPath (StaticKey _:xs) = sAttrPath xs
+    sAttrPath [] = True
     sAttrPath _ = False
     findBind [] _ = Nothing
     findBind (x:xs) attrs@(a:|_) = case x of

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -26,6 +26,7 @@ import           Nix.Value
 import qualified NixLanguageTests
 import qualified ParserTests
 import qualified PrettyTests
+import qualified ReduceExprTests
 -- import qualified PrettyParseTests
 import           System.Directory
 import           System.Environment
@@ -98,7 +99,8 @@ main = do
       | isJust hpackTestsEnv ] ++
     [ ParserTests.tests
     , EvalTests.tests
-    , PrettyTests.tests ] ++
+    , PrettyTests.tests
+    , ReduceExprTests.tests] ++
     -- [ PrettyParseTests.tests
     --     (fromIntegral (read (fromMaybe "0" prettyTestsEnv) :: Int)) ] ++
     [ evalComparisonTests ] ++

--- a/tests/ReduceExprTests.hs
+++ b/tests/ReduceExprTests.hs
@@ -1,0 +1,34 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# OPTIONS_GHC -fno-warn-name-shadowing #-}
+module ReduceExprTests (tests) where
+import Data.Fix
+import Test.Tasty
+import Test.Tasty.HUnit
+
+import Nix.Atoms
+import Nix.Expr.Types
+import Nix.Expr.Types.Annotated
+import Nix.Reduce (reduceExpr)
+import Nix.Parser
+
+
+tests :: TestTree
+tests = testGroup "Expr Reductions"
+    [ testCase "Non nested NSelect on set should be reduced" $ 
+        cmpReduceResult nonNestedSelect nonNestedSelectExpect 
+    ]
+
+cmpReduceResult :: Result NExprLoc -> NExpr -> Assertion 
+cmpReduceResult r e = do
+    r <- assertSucc r
+    r <- stripAnnotation <$> reduceExpr Nothing r
+    r @?= e
+    where
+        assertSucc (Success a) = pure a
+        assertSucc (Failure d) = assertFailure $ show d
+
+nonNestedSelect :: Result NExprLoc
+nonNestedSelect = parseNixTextLoc "{a=42;}.a"
+
+nonNestedSelectExpect :: NExpr
+nonNestedSelectExpect = Fix . NConstant $ NInt 42

--- a/tests/ReduceExprTests.hs
+++ b/tests/ReduceExprTests.hs
@@ -8,27 +8,52 @@ import Test.Tasty.HUnit
 import Nix.Atoms
 import Nix.Expr.Types
 import Nix.Expr.Types.Annotated
-import Nix.Reduce (reduceExpr)
 import Nix.Parser
+import Nix.Reduce (reduceExpr)
 
 
 tests :: TestTree
 tests = testGroup "Expr Reductions"
     [ testCase "Non nested NSelect on set should be reduced" $ 
-        cmpReduceResult nonNestedSelect nonNestedSelectExpect 
+        cmpReduceResult selectBasic selectBasicExpect,
+      testCase "Nested NSelect on set should be reduced" $ 
+        cmpReduceResult selectNested selectNestedExpect,
+      testCase "Non nested NSelect with incorrect attrpath shouldn't be reduced" $ 
+        shouldntReduce selectIncorrectAttrPath,
+      testCase "Nested NSelect with incorrect attrpath shouldn't be reduced" $ 
+        shouldntReduce selectNestedIncorrectAttrPath 
     ]
+
+assertSucc :: Result a -> IO a
+assertSucc (Success a) = pure a
+assertSucc (Failure d) = assertFailure $ show d
 
 cmpReduceResult :: Result NExprLoc -> NExpr -> Assertion 
 cmpReduceResult r e = do
     r <- assertSucc r
     r <- stripAnnotation <$> reduceExpr Nothing r
     r @?= e
-    where
-        assertSucc (Success a) = pure a
-        assertSucc (Failure d) = assertFailure $ show d
 
-nonNestedSelect :: Result NExprLoc
-nonNestedSelect = parseNixTextLoc "{a=42;}.a"
+shouldntReduce :: Result NExprLoc -> Assertion
+shouldntReduce r = do
+    r <- assertSucc r
+    rReduced <- reduceExpr Nothing r
+    r @?= rReduced
 
-nonNestedSelectExpect :: NExpr
-nonNestedSelectExpect = Fix . NConstant $ NInt 42
+selectBasic :: Result NExprLoc
+selectBasic = parseNixTextLoc "{b=2;a=42;}.a"
+
+selectBasicExpect :: NExpr
+selectBasicExpect = Fix . NConstant $ NInt 42
+
+selectNested :: Result NExprLoc
+selectNested = parseNixTextLoc "{a={b=2;a=42;};b={a=2;};}.a.a"
+
+selectNestedExpect :: NExpr
+selectNestedExpect = Fix . NConstant $ NInt 42
+
+selectIncorrectAttrPath :: Result NExprLoc
+selectIncorrectAttrPath = parseNixTextLoc "{a=42;}.b"
+
+selectNestedIncorrectAttrPath :: Result NExprLoc
+selectNestedIncorrectAttrPath = parseNixTextLoc "{a={a=42;};}.a.b"


### PR DESCRIPTION
Hi,

I tried to create a reduction for NSelect.

Basically, if

- The select is performed on a Set.
- The select attrpath is composed of statickeys.
- This attrpath exists in the set.

The select expression is reduced to the selected expression.

To be honest, I am pretty unsure about this. I still don't get the whole picture.

I have some trouble testing the reduction part of HNix, I am still wondering how this will behave in case of nested sets (ie. `{a={b=1;};}.a.b`.

This is close to be untested: I did not manage find a way to write automated tests for this. How could I do that?