### PR TITLE
Pretty printer tests fix

### DIFF
--- a/src/Nix/Pretty.hs
+++ b/src/Nix/Pretty.hs
@@ -205,7 +205,8 @@ exprFNixDoc = \case
     NSelect r attr o ->
       (if isJust o then leastPrecedence else flip mkNixDoc selectOp) $
           wrapPath selectOp r <> dot <> prettySelector attr <> ordoc
-      where ordoc = maybe empty (((space <> text "or") <+>) . wrapParens selectOp) o
+      where
+        ordoc = maybe empty (((space <> text "or") <+>) . wrapParens appOpNonAssoc) o
     NHasAttr r attr ->
         mkNixDoc (wrapParens hasAttrOp r <+> text "?" <+> prettySelector attr) hasAttrOp
     NEnvPath p -> simpleExpr $ text ("<" ++ p ++ ">")

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -27,7 +27,7 @@ import qualified NixLanguageTests
 import qualified ParserTests
 import qualified PrettyTests
 import qualified ReduceExprTests
--- import qualified PrettyParseTests
+import qualified PrettyParseTests
 import           System.Directory
 import           System.Environment
 import           System.FilePath.Glob
@@ -88,7 +88,7 @@ main = do
   evalComparisonTests <- EvalTests.genEvalCompareTests
   let allOrLookup var = lookupEnv "ALL_TESTS" <|> lookupEnv var
   nixpkgsTestsEnv     <- allOrLookup "NIXPKGS_TESTS"
-  -- prettyTestsEnv      <- lookupEnv "PRETTY_TESTS"
+  prettyTestsEnv      <- lookupEnv "PRETTY_TESTS"
   hpackTestsEnv       <- allOrLookup "HPACK_TESTS"
 
   pwd <- getCurrentDirectory
@@ -101,11 +101,10 @@ main = do
     , EvalTests.tests
     , PrettyTests.tests
     , ReduceExprTests.tests] ++
-    -- [ PrettyParseTests.tests
-    --     (fromIntegral (read (fromMaybe "0" prettyTestsEnv) :: Int)) ] ++
+    [ PrettyParseTests.tests
+        (fromIntegral (read (fromMaybe "0" prettyTestsEnv) :: Int)) ] ++
     [ evalComparisonTests ] ++
     [ testCase "Nix language tests present" ensureLangTestsPresent
     , nixLanguageTests ] ++
     [ testCase "Nixpkgs parses without errors" ensureNixpkgsCanParse
       | isJust nixpkgsTestsEnv ]
-


### PR DESCRIPTION
Should fix #305. I have run ```env PRETTY_TESTS=10000000 cabal test``` a few times with no errors.