### PR TITLE
Fix missing parenthesis in pretty printing selector

### DIFF
--- a/src/Nix/Pretty.hs
+++ b/src/Nix/Pretty.hs
@@ -202,10 +202,11 @@ exprFNixDoc = \case
     NUnary op r1 ->
         mkNixDoc (text (unpack (operatorName opInfo)) <> wrapParens opInfo r1) opInfo
       where opInfo = getUnaryOperator op
-    NSelect r attr o ->
+    NSelect r' attr o ->
       (if isJust o then leastPrecedence else flip mkNixDoc selectOp) $
           wrapPath selectOp r <> dot <> prettySelector attr <> ordoc
       where
+        r = flip mkNixDoc selectOp $ wrapParens appOpNonAssoc r'
         ordoc = maybe empty (((space <> text "or") <+>) . wrapParens appOpNonAssoc) o
     NHasAttr r attr ->
         mkNixDoc (wrapParens hasAttrOp r <+> text "?" <+> prettySelector attr) hasAttrOp


### PR DESCRIPTION
Fixes #327

Another case of missing parenthesis. From the issue:

> prettyNix $ ("x" @@ "y") @. "z"
  x y.z

When it should be:
  (x y).z

Adding non-associative wrapParens seems to fix it. Not sure if this is
the best way but trying a few things & running the test suite still
seem to work.

/cc @jwiegley @Profpatsch 