### PR TITLE
Fix function equals test

### DIFF
--- a/tests/EvalTests.hs
+++ b/tests/EvalTests.hs
@@ -313,7 +313,13 @@ case_fixed_points_attrsets =
 --     constantEqualText "true" "[(x: x)] == [(x: x)]"
 
 case_function_equals3 =
-    constantEqualText "false" "(x: x) == (x: x)"
+    constantEqualText "false" "(let a = (x: x); in a == a)"
+
+case_function_equals4 =
+    constantEqualText "true" "(let a = {f = x: x;}; in a == a)"
+
+case_function_equals5 =
+    constantEqualText "true" "(let a = [(x: x)]; in a == a)"
 
 case_directory_pathexists =
     constantEqualText "false" "builtins.pathExists \"/bin/sh/invalid-directory\""


### PR DESCRIPTION
I still don’t understand what Nix is doing behind the scenes here.
This is the original test case that *does* work with my changes.
I've left the broken ones with hopes that hey can be fixed.
Apparently it only happens with let bindings?

Fixes #340