### PR TITLE
Parser exports

### DIFF
--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -81,7 +81,7 @@ import           Nix.Expr.Types.Annotated
 import           Nix.Frames
 import           Nix.Normal
 import           Nix.Options
-import           Nix.Parser
+import           Nix.Parser hiding (nixPath)
 import           Nix.Render
 import           Nix.Scope
 import           Nix.Thunk

--- a/src/Nix/Parser.hs
+++ b/src/Nix/Parser.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveDataTypeable #-}
+{-# LANGUAGE DeriveFunctor      #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
@@ -417,7 +418,7 @@ reservedNames = HashSet.fromList
 
 type Parser = ParsecT Void Text Identity
 
-data Result a = Success a | Failure Doc deriving Show
+data Result a = Success a | Failure Doc deriving (Show, Functor)
 
 parseFromFileEx :: MonadIO m => Parser a -> FilePath -> m (Result a)
 parseFromFileEx p path = do

--- a/src/Nix/Parser.hs
+++ b/src/Nix/Parser.hs
@@ -15,6 +15,7 @@ module Nix.Parser
     , parseNixText
     , parseNixTextLoc
     , parseFromFileEx
+    , Parser
     , parseFromText
     , Result(..)
     , reservedNames
@@ -25,6 +26,22 @@ module Nix.Parser
     , getUnaryOperator
     , getBinaryOperator
     , getSpecialOperator
+
+    , nixToplevelForm
+    , nixExpr
+    , nixSet
+    , nixBinders
+    , nixSelector
+
+    , nixSym
+    , nixPath
+    , nixString
+    , nixUri
+    , nixSearchPath
+    , nixFloat
+    , nixInt
+    , nixBool
+    , nixNull
     ) where
 
 import           Control.Applicative hiding (many, some)

--- a/src/Nix/Parser.hs
+++ b/src/Nix/Parser.hs
@@ -42,6 +42,8 @@ module Nix.Parser
     , nixInt
     , nixBool
     , nixNull
+    , symbol
+    , whiteSpace
     ) where
 
 import           Control.Applicative hiding (many, some)


### PR DESCRIPTION
- Make `Result` a `Functor`
- Rename some parsers for more consistent exports
- Export useful internal parsers and the `Parser` type

I need these non-full-expression parsers for my nixbot.