### PR TITLE
Avoid corrupting the value being printed in Pretty.dethunk

### DIFF
--- a/src/Nix/Pretty.hs
+++ b/src/Nix/Pretty.hs
@@ -317,6 +317,8 @@ dethunk = \case
             then pure $ Free $ NVStrF "<thunk>" mempty
             else do
                 eres <- readVar ref
-                case eres of
+                res <- case eres of
                     Computed v -> removeEffectsM (_baseValue v)
                     _ -> pure $ Free $ NVStrF "<thunk>" mempty
+                _ <- atomicModifyVar active (False,)
+                return res


### PR DESCRIPTION
Calling `prettyNValue` on the value leaves it in a corrupted state where trying to force a thunk in it results in a `ThunkLoop`.

This is because `dethunk` sets the `active` flag to `True` (for loop detection, I assume) but never sets it back to `False`. This PR makes sure the flag is set back to `False` when we're done with the value.

Additional note: I think this logic also appears in `Thunk.forceThunk`, so maybe it could also be deduplicated.