### PR TITLE
Remove incorrect cases in valueEq which make empty string and null equal

### DIFF
--- a/src/Nix/Value.hs
+++ b/src/Nix/Value.hs
@@ -260,8 +260,6 @@ valueEq :: MonadThunk (NValue m) (NThunk m) m
 valueEq = curry $ \case
     (NVConstant lc, NVConstant rc) -> pure $ lc == rc
     (NVStr ls, NVStr rs) -> pure $ principledStringIgnoreContext ls == principledStringIgnoreContext rs
-    (NVStr ns, NVConstant NNull) -> pure (hackyGetStringNoContext ns == Just "")
-    (NVConstant NNull, NVStr ns) -> pure (Just "" == hackyGetStringNoContext ns)
     (NVList ls, NVList rs) -> alignEqM thunkEq ls rs
     (NVSet lm _, NVSet rm _) -> do
         let compareAttrs = alignEqM thunkEq lm rm


### PR DESCRIPTION
This adds on to #391.