### PR TITLE
Bump minimum supported version to GHC 8.4.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,8 @@ env:
     - secure: "dm6I+M4+V+C7QMTpcSADdKPE633SvmToXZrTbZ7miNDGmMN+/SfHeN2ybi1+PW6oViMlbPN/7J/aEfiGjSJI8vLk72Y4uCWGmpSb8TXZLu6+whnxtZzzW8+z4tsM4048QJg7CF3N/25U8thRFgs3DqUub1Sf3nG9LrNWdz6ZcDQ="
 
   matrix:
-    - GHCVERSION=ghc843 STRICT=false TRACING=false
-    - GHCVERSION=ghc843 STRICT=false TRACING=true
+    - GHCVERSION=ghc844 STRICT=false TRACING=false
+    - GHCVERSION=ghc844 STRICT=false TRACING=true
 #     - GHCVERSION=ghcjs
 # 
 # matrix:

--- a/default.nix
+++ b/default.nix
@@ -1,11 +1,11 @@
-{ compiler ? "ghc843"
+{ compiler ? "ghc844"
 
 , doBenchmark ? false
 , doTracing   ? false
 , doStrict    ? false
 
-, rev     ? "7c1b85cf6de1dc431e5736bff8adf01224e6abe5"
-, sha256  ? "1i8nvc4r0zx263ch5k3b6nkg78sc9ggx2d4lzri6kmng315pcs05"
+, rev     ? "b37872d4268164614e3ecef6e1f730d48cf5a90f"
+, sha256  ? "05km33sz4srf05vvmkidz3k59phm5a3k9wpj1jc6ly9yqws0dbn4"
 , pkgs    ?
     if builtins.compareVersions builtins.nixVersion "2.0" < 0
     then abort "hnix requires at least nix 2.0"
@@ -80,8 +80,8 @@ drv = haskellPackages.developPackage {
         # .cabal file will be. Otherwise, Travis may error out claiming that
         # the cabal file needs to be updated because the result is different
         # that the version we committed to Git.
-        pkgs.haskell.packages.ghc843.hpack
-        pkgs.haskell.packages.ghc843.criterion
+        pkgs.haskell.packages.ghc844.hpack
+        pkgs.haskell.packages.ghc844.criterion
       ];
 
     inherit doBenchmark;

--- a/hnix.cabal
+++ b/hnix.cabal
@@ -2,9 +2,8 @@
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: d6ddd115698a11c74ef8507fa6e00df1f8888a254bed435e6a75b154a4906cb3
+-- hash: b1520c3cc7c409e4c172b14158f72de30a59786bd55cf6d3da2c294cf8120b7a
 
-cabal-version:  >= 1.10
 name:           hnix
 version:        0.5.2
 synopsis:       Haskell implementation of the Nix language
@@ -17,6 +16,7 @@ maintainer:     johnw@newartisans.com
 license:        BSD3
 license-file:   LICENSE
 build-type:     Simple
+cabal-version:  >= 1.10
 extra-source-files:
     data/let-comments-multiline.nix
     data/let-comments.nix

--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -59,7 +59,6 @@ import           Data.Foldable (foldrM)
 import qualified Data.HashMap.Lazy as M
 import           Data.List
 import           Data.Maybe
-import           Data.Semigroup
 import           Data.Set (Set)
 import qualified Data.Set as S
 import           Data.String.Interpolate.IsString

--- a/src/Nix/Exec.hs
+++ b/src/Nix/Exec.hs
@@ -46,7 +46,6 @@ import           Data.List
 import qualified Data.List.NonEmpty as NE
 import           Data.List.Split
 import           Data.Maybe (maybeToList)
-import           Data.Monoid
 import           Data.Text (Text)
 import qualified Data.Text as Text
 import           Data.Typeable

--- a/src/Nix/Expr/Shorthands.hs
+++ b/src/Nix/Expr/Shorthands.hs
@@ -9,7 +9,6 @@ module Nix.Expr.Shorthands where
 
 import Data.Fix
 import Data.List.NonEmpty (NonEmpty(..))
-import Data.Monoid
 import Data.Text (Text)
 import Nix.Atoms
 import Nix.Expr.Types

--- a/src/Nix/Expr/Types.hs
+++ b/src/Nix/Expr/Types.hs
@@ -50,7 +50,6 @@ import           Data.List (inits, tails)
 import           Data.List.NonEmpty (NonEmpty(..))
 import qualified Data.List.NonEmpty as NE
 import           Data.Maybe (fromMaybe)
-import           Data.Monoid
 import           Data.Ord.Deriving
 import           Data.Text (Text, pack, unpack)
 import           Data.Traversable

--- a/src/Nix/Expr/Types/Annotated.hs
+++ b/src/Nix/Expr/Types/Annotated.hs
@@ -38,7 +38,6 @@ import Data.Hashable
 import Data.Hashable.Lifted
 #endif
 import Data.Ord.Deriving
-import Data.Semigroup
 import Data.Text (Text, pack)
 import GHC.Generics
 import Nix.Atoms

--- a/src/Nix/Normal.hs
+++ b/src/Nix/Normal.hs
@@ -19,13 +19,8 @@ import           Control.Monad.Trans.State
 import qualified Data.HashMap.Lazy as M
 import           Data.List (find)
 import           Data.Maybe (isJust)
-import           Data.Text (Text)
-import qualified Data.Text as Text
-import           Nix.Atoms
-import           Nix.Effects
 import           Nix.Frames
 -- import           Nix.Pretty
-import           Nix.String
 import           Nix.Thunk
 import           Nix.Utils
 import           Nix.Value

--- a/src/Nix/Options/Parser.hs
+++ b/src/Nix/Options/Parser.hs
@@ -8,7 +8,6 @@ import qualified Data.Text as Text
 import           Data.Time
 import           Nix.Options
 import           Options.Applicative hiding (ParserResult(..))
-import           Text.PrettyPrint.ANSI.Leijen hiding ((<$>))
 
 decodeVerbosity :: Int -> Verbosity
 decodeVerbosity 0 = ErrorsOnly

--- a/src/Nix/Scope.hs
+++ b/src/Nix/Scope.hs
@@ -16,7 +16,6 @@ module Nix.Scope where
 import           Control.Applicative
 import           Control.Monad.Reader
 import qualified Data.HashMap.Lazy as M
-import           Data.Semigroup
 import           Data.Text (Text)
 import           Lens.Family2
 import           Nix.Utils

--- a/src/Nix/String.hs
+++ b/src/Nix/String.hs
@@ -26,7 +26,6 @@ import           Data.Hashable
 import           Data.Text (Text)
 import qualified Data.Text as Text
 import           GHC.Generics
-import           Data.Semigroup
 
 -- {-# WARNING hackyGetStringNoContext, hackyStringIgnoreContext, hackyMakeNixStringWithoutContext "This NixString function needs to be replaced" #-}
 

--- a/src/Nix/Type/Env.hs
+++ b/src/Nix/Type/Env.hs
@@ -19,7 +19,6 @@ import           Nix.Type.Type
 
 import           Data.Foldable hiding (toList)
 import qualified Data.Map as Map
-import           Data.Semigroup
 
 -------------------------------------------------------------------------------
 -- Typing Environment

--- a/src/Nix/Type/Infer.hs
+++ b/src/Nix/Type/Infer.hs
@@ -40,7 +40,6 @@ import           Data.Map (Map)
 import qualified Data.Map as Map
 import           Data.Maybe (fromJust)
 import           Data.STRef
-import           Data.Semigroup
 import qualified Data.Set as Set
 import           Data.Text (Text)
 import           Nix.Atoms

--- a/tests/ParserTests.hs
+++ b/tests/ParserTests.hs
@@ -10,7 +10,6 @@ module ParserTests (tests) where
 
 import Data.Fix
 import Data.List.NonEmpty (NonEmpty(..))
-import Data.Semigroup
 import Data.String.Interpolate.IsString
 import Data.Text (Text, unpack, pack)
 import Nix.Atoms


### PR DESCRIPTION
This involved:

  - Changing `default.nix`
  - Changing `.travis.yml`
  - Remove a lot of unnecessary imports, to fix warnings.