### PR TITLE
Distinguish string with or without context when revealing type

### DIFF
--- a/src/Nix/Convert.hs
+++ b/src/Nix/Convert.hs
@@ -156,7 +156,7 @@ instance (Convertible e m, MonadEffects m)
         _ -> pure Nothing
     fromValue v = fromValueMay v >>= \case
         Just b -> pure b
-        _ -> throwError $ ExpectationNF TString v
+        _ -> throwError $ ExpectationNF (TString NoContext) v
 
 instance (Convertible e m, MonadThunk (NValue m) (NThunk m) m, MonadEffects m)
       => FromValue Text m (NValue m) where
@@ -169,7 +169,7 @@ instance (Convertible e m, MonadThunk (NValue m) (NThunk m) m, MonadEffects m)
         _ -> pure Nothing
     fromValue v = fromValueMay v >>= \case
         Just b -> pure b
-        _ -> throwError $ Expectation TString v
+        _ -> throwError $ Expectation (TString NoContext) v
 
 instance (Convertible e m, MonadEffects m)
       => FromValue NixString m (NValueNF m) where
@@ -182,7 +182,7 @@ instance (Convertible e m, MonadEffects m)
         _ -> pure Nothing
     fromValue v = fromValueMay v >>= \case
         Just b -> pure b
-        _ -> throwError $ ExpectationNF TString v
+        _ -> throwError $ ExpectationNF (TString NoContext) v
 
 instance (Convertible e m, MonadThunk (NValue m) (NThunk m) m, MonadEffects m)
       => FromValue NixString m (NValue m) where
@@ -195,7 +195,7 @@ instance (Convertible e m, MonadThunk (NValue m) (NThunk m) m, MonadEffects m)
         _ -> pure Nothing
     fromValue v = fromValueMay v >>= \case
         Just b -> pure b
-        _ -> throwError $ Expectation TString v
+        _ -> throwError $ Expectation (TString NoContext) v
 
 instance Convertible e m
       => FromValue ByteString m (NValueNF m) where
@@ -204,7 +204,7 @@ instance Convertible e m
         _ -> pure Nothing
     fromValue v = fromValueMay v >>= \case
         Just b -> pure b
-        _ -> throwError $ ExpectationNF TString v
+        _ -> throwError $ ExpectationNF (TString NoContext) v
 
 instance Convertible e m
       => FromValue ByteString m (NValue m) where
@@ -213,7 +213,7 @@ instance Convertible e m
         _ -> pure Nothing
     fromValue v = fromValueMay v >>= \case
         Just b -> pure b
-        _ -> throwError $ Expectation TString v
+        _ -> throwError $ Expectation (TString NoContext) v
 
 newtype Path = Path { getPath :: FilePath }
     deriving Show

--- a/src/Nix/Value.hs
+++ b/src/Nix/Value.hs
@@ -275,12 +275,16 @@ valueEq = curry $ \case
     (NVPath lp, NVPath rp) -> pure $ lp == rp
     _ -> pure False
 
+
+data TStringContext = NoContext | HasContext
+  deriving Show
+
 data ValueType
     = TInt
     | TFloat
     | TBool
     | TNull
-    | TString
+    | TString TStringContext
     | TList
     | TSet
     | TClosure
@@ -295,7 +299,8 @@ valueType = \case
         NFloat _  -> TFloat
         NBool _   -> TBool
         NNull     -> TNull
-    NVStrF {}     -> TString
+    NVStrF ns | stringHasContext ns ->  TString HasContext
+              | otherwise -> TString NoContext
     NVListF {}    -> TList
     NVSetF {}     -> TSet
     NVClosureF {} -> TClosure
@@ -304,16 +309,17 @@ valueType = \case
 
 describeValue :: ValueType -> String
 describeValue = \case
-    TInt     -> "an integer"
-    TFloat   -> "a float"
-    TBool    -> "a boolean"
-    TNull    -> "a null"
-    TString  -> "a string"
-    TList    -> "a list"
-    TSet     -> "an attr set"
-    TClosure -> "a function"
-    TPath    -> "a path"
-    TBuiltin -> "a builtin function"
+    TInt               -> "an integer"
+    TFloat             -> "a float"
+    TBool              -> "a boolean"
+    TNull              -> "a null"
+    TString NoContext  -> "a string"
+    TString HasContext -> "a string with context"
+    TList              -> "a list"
+    TSet               -> "an attr set"
+    TClosure           -> "a function"
+    TPath              -> "a path"
+    TBuiltin           -> "a builtin function"
 
 instance Show (NValueF m (NThunk m)) where
     show = show . describeValue . valueType


### PR DESCRIPTION
Now mimics upstream (once repl can do `:t`):

```
nix-repl> :t "${ ./hnix.cabal }"
a string with context
```