### PR TITLE
Fix Nix build for external imports

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -26,6 +26,7 @@
 let haskellPackages = pkgs.haskell.packages.${compiler};
 
 drv = haskellPackages.developPackage {
+  name = "hnix";
   root = ./.;
 
   overrides = with pkgs.haskell.lib; self: super: {


### PR DESCRIPTION
Previously `import (pkgs.fetchgit { url = ...; rev = ...; sha256 = ...; })`
would give a cabal2nix error