### PR TITLE
Revert "Fix compilation"

### DIFF
--- a/main/Main.hs
+++ b/main/Main.hs
@@ -139,7 +139,7 @@ main = do
             | finder opts =
               fromValue @(AttrSet (NThunk m)) >=> findAttrs
             | xml opts =
-              liftIO . Text.putStrLn . hackyStringIgnoreContext .toXML <=< normalForm
+              liftIO . putStrLn . toXML <=< normalForm
             | json opts =
               liftIO . TL.putStrLn
                      . TL.decodeUtf8

--- a/main/Repl.hs
+++ b/main/Repl.hs
@@ -54,7 +54,7 @@ import           System.Exit
 main :: (MonadNix e m, MonadIO m, MonadException m) => m ()
 main = flip evalStateT initState $
 #if MIN_VERSION_repline(0, 2, 0)
-    evalRepl (return prefix) cmd options (Just ':') completer init
+    evalRepl (return prefix) cmd options (Just ':') completer welcomeText
 #else
     evalRepl prefix cmd options completer welcomeText
 #endif

--- a/main/Repl.hs
+++ b/main/Repl.hs
@@ -54,7 +54,7 @@ import           System.Exit
 main :: (MonadNix e m, MonadIO m, MonadException m) => m ()
 main = flip evalStateT initState $
 #if MIN_VERSION_repline(0, 2, 0)
-    evalRepl (return prefix) cmd options (Just ':') completer welcomeText
+    evalRepl (return prefix) cmd options (Just ':') completer init
 #else
     evalRepl prefix cmd options completer welcomeText
 #endif

--- a/tests/NixLanguageTests.hs
+++ b/tests/NixLanguageTests.hs
@@ -22,7 +22,6 @@ import           Nix.Options
 import           Nix.Options.Parser
 import           Nix.Parser
 import           Nix.Pretty
-import           Nix.String
 import           Nix.Utils
 import           Nix.XML
 import qualified Options.Applicative as Opts
@@ -111,7 +110,7 @@ assertLangOkXml :: Options -> FilePath -> Assertion
 assertLangOkXml opts file = do
   actual <- toXML <$> hnixEvalFile opts (file ++ ".nix")
   expected <- Text.readFile $ file ++ ".exp.xml"
-  assertEqual "" expected $ hackyStringIgnoreContext actual
+  assertEqual "" expected $ Text.pack actual
 
 assertEval :: Options -> [FilePath] -> Assertion
 assertEval _opts files = do


### PR DESCRIPTION
This fix isn't necessary now that the XML context change is
reverted.

This reverts commit 51d493f4842bb2e3119ae5630a087c1f125c233f.