### PR TITLE
Change builtins.storeDir type to String

### DIFF
--- a/hnix.cabal
+++ b/hnix.cabal
@@ -400,6 +400,7 @@ extra-source-files:
     tests/eval-compare/builtins.split-02.nix
     tests/eval-compare/builtins.split-03.nix
     tests/eval-compare/builtins.split-04.nix
+    tests/eval-compare/builtins.string.store.nix
     tests/eval-compare/ind-string-01.nix
     tests/eval-compare/ind-string-02.nix
     tests/eval-compare/ind-string-03.nix

--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -252,7 +252,7 @@ builtinsList = sequence [
     , add2 Normal   "sort"                       sort_
     , add2 Normal   "split"                      split_
     , add  Normal   "splitVersion"               splitVersion_
-    , add0 Normal   "storeDir"                   (return $ nvPath "/nix/store")
+    , add0 Normal   "storeDir"                   (return $ nvStr $ principledMakeNixStringWithoutContext "/nix/store")
     , add' Normal   "stringLength"               (arity1 Text.length)
     , add' Normal   "sub"                        (arity2 ((-) @Integer))
     , add' Normal   "substring"                  substring

--- a/tests/eval-compare/builtins.string.store.nix
+++ b/tests/eval-compare/builtins.string.store.nix
@@ -1,0 +1,1 @@
+"${builtins.storeDir}"


### PR DESCRIPTION
Co-authored-by: Basile Henry <bjm.henry@gmail.com>

Closes #355

Turns out the problem with `builtins.storeDir` is a type error. It was a Path and needed to be a String.

Here is nix at work (it looks like a String):
```sh
$ nix-instantiate --eval -E '"${builtins.storeDir}"'
"/nix/store"
```

We have also added a regression test.