### PR TITLE
Remove unused dependency on hspec-discover

### DIFF
--- a/hnix.cabal
+++ b/hnix.cabal
@@ -684,7 +684,6 @@ test-suite hnix-tests
   else
     buildable: True
   default-language: Haskell2010
-  build-tool-depends: hspec-discover:hspec-discover == 2.*
 
 benchmark hnix-benchmarks
   type: exitcode-stdio-1.0


### PR DESCRIPTION
This should fix #429 regardless of what's in the local GHC environment.