### PR TITLE
Make nix dep match the submodule version

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -19,6 +19,16 @@
            inherit sha256; }) {
            config.allowUnfree = true;
            config.allowBroken = false;
+           config.packageOverrides = pkgs: rec {
+             nix = pkgs.nixUnstable.overrideDerivation (attrs: {
+               src = data/nix;
+               configureFlags = attrs.configureFlags ++ [ "--disable-doc-gen" ];
+               buildInputs = attrs.buildInputs ++
+                 [ pkgs.editline.dev
+                 ];
+               outputs = builtins.filter (s: s != "doc" && s != "man" ) attrs.outputs;
+             });
+           };
          }
 
 , mkDerivation   ? null


### PR DESCRIPTION
This is needed because the earlier bump of our nix submodule does not change the version of nix used by our test suite.