### PR TITLE
Harmonize the two different value representations

### DIFF
--- a/README-design.md
+++ b/README-design.md
@@ -41,15 +41,3 @@ points in the code are generic over both.
 Having said that, I should mention that there are two different types of
 values: `NValue` and `NValueNF`. The former is created by evaluating an
 `NExpr`, and then latter by calling `normalForm` on an `NValue`.
-
-However, not every term can be reduced to normal form. There are cases where
-Nix allows a cycle to exist in the data, so that it can printed simply as
-`<CYCLE>`. To represent this, we use a simple recursive type for `NValue`, but
-a `Free` construction for `NValueNF`:
-
-    type NValueNF t f m = Free (NValue' t f m) t
-
-The idea here is that `Free` values are those we were able to normalize (since
-it has its own terminating base cases of constants, strings, etc), while the
-`Pure` thunk is the thunk we'd seen before while normalizing, indicating the
-beginning of the cycle.

--- a/hnix.cabal
+++ b/hnix.cabal
@@ -482,7 +482,7 @@ library
       Paths_hnix
   hs-source-dirs:
       src
-  ghc-options: -Wall
+  ghc-options: -Wall -fprint-potential-instances
   build-depends:
       aeson
     , array >=0.4 && <0.6

--- a/hnix.cabal
+++ b/hnix.cabal
@@ -586,6 +586,7 @@ executable hnix
     , deepseq >=1.4.2 && <1.5
     , exceptions
     , filepath
+    , free
     , hashing
     , haskeline
     , hnix

--- a/hnix.cabal
+++ b/hnix.cabal
@@ -1,5 +1,5 @@
 name:           hnix
-version:        0.5.2
+version:        0.6.0
 synopsis:       Haskell implementation of the Nix language
 description:    Haskell implementation of the Nix language.
 category:       System, Data, Nix
@@ -394,7 +394,6 @@ extra-source-files:
     data/simple-pretty.nix
     data/simple.nix
     LICENSE
-    package.yaml
     README.md
     tests/eval-compare/builtins.split-01.nix
     tests/eval-compare/builtins.split-02.nix

--- a/hnix.cabal
+++ b/hnix.cabal
@@ -475,6 +475,7 @@ library
       Nix.Utils
       Nix.Value
       Nix.Value.Equal
+      Nix.Value.Monad
       Nix.Var
       Nix.XML
   other-modules:

--- a/main/Main.hs
+++ b/main/Main.hs
@@ -14,6 +14,7 @@ import qualified Control.DeepSeq               as Deep
 import qualified Control.Exception             as Exc
 import           Control.Monad
 import           Control.Monad.Catch
+import           Control.Monad.Free
 import           Control.Monad.IO.Class
 -- import           Control.Monad.ST
 import qualified Data.Aeson.Text               as A
@@ -39,6 +40,7 @@ import qualified Nix.Type.Env                  as Env
 import qualified Nix.Type.Infer                as HM
 import           Nix.Utils
 import           Nix.Var
+import           Nix.Value.Monad
 import           Options.Applicative     hiding ( ParserResult(..) )
 import qualified Repl
 import           System.FilePath
@@ -132,7 +134,7 @@ main = do
    where
     printer
       | finder opts
-      = fromValue @(AttrSet (StandardThunk IO)) >=> findAttrs
+      = fromValue @(AttrSet (StandardValue IO)) >=> findAttrs
       | xml opts
       = liftIO
         .   putStrLn
@@ -152,14 +154,15 @@ main = do
       | otherwise
       = liftIO . print <=< prettyNValue
      where
+      findAttrs :: AttrSet (StandardValue IO) -> StandardT IO ()
       findAttrs = go ""
        where
         go prefix s = do
           xs <-
             forM (sortOn fst (M.toList s))
-              $ \(k, nv@(StdThunk (extract -> t))) -> case t of
-                  Value v       -> pure (k, Just v)
-                  Thunk _ _ ref -> do
+              $ \(k, nv) -> case nv of
+                  Free v       -> pure (k, Just (Free v))
+                  Pure (StdThunk (extract -> Thunk _ _ ref)) -> do
                     let path         = prefix ++ Text.unpack k
                         (_, descend) = filterEntry path k
                     val <- readVar @(StandardT IO) ref
@@ -197,7 +200,7 @@ main = do
             _                              -> (True, True)
 
           forceEntry k v =
-            catch (Just <$> force v pure) $ \(NixException frames) -> do
+            catch (Just <$> demand v pure) $ \(NixException frames) -> do
               liftIO
                 .   putStrLn
                 .   ("Exception forcing " ++)

--- a/main/Main.hs
+++ b/main/Main.hs
@@ -158,18 +158,16 @@ main = do
       findAttrs = go ""
        where
         go prefix s = do
-          xs <-
-            forM (sortOn fst (M.toList s))
-              $ \(k, nv) -> case nv of
-                  Free v       -> pure (k, Just (Free v))
-                  Pure (StdThunk (extract -> Thunk _ _ ref)) -> do
-                    let path         = prefix ++ Text.unpack k
-                        (_, descend) = filterEntry path k
-                    val <- readVar @(StandardT IO) ref
-                    case val of
-                      Computed _ -> pure (k, Nothing)
-                      _ | descend   -> (k, ) <$> forceEntry path nv
-                        | otherwise -> pure (k, Nothing)
+          xs <- forM (sortOn fst (M.toList s)) $ \(k, nv) -> case nv of
+            Free v -> pure (k, Just (Free v))
+            Pure (StdThunk (extract -> Thunk _ _ ref)) -> do
+              let path         = prefix ++ Text.unpack k
+                  (_, descend) = filterEntry path k
+              val <- readVar @(StandardT IO) ref
+              case val of
+                Computed _ -> pure (k, Nothing)
+                _ | descend   -> (k, ) <$> forceEntry path nv
+                  | otherwise -> pure (k, Nothing)
 
           forM_ xs $ \(k, mv) -> do
             let path              = prefix ++ Text.unpack k

--- a/main/Repl.hs
+++ b/main/Repl.hs
@@ -225,6 +225,3 @@ completer
   :: (MonadNix e t f m, MonadIO m)
   => CompleterStyle (StateT (IState t f m) m)
 completer = Prefix (wordCompleter comp) defaultMatcher
-
-
-

--- a/main/Repl.hs
+++ b/main/Repl.hs
@@ -115,7 +115,7 @@ exec update source = do
   -- tyctx' <- hoistErr $ inferTop (tyctx st) expr
 
   -- TODO: track scope with (tmctx st)
-  mVal <- lift $ lift $ try $ pushScope @t M.empty (evalExprLoc expr)
+  mVal <- lift $ lift $ try $ pushScope M.empty (evalExprLoc expr)
 
   case mVal of
     Left (NixException frames) -> do
@@ -171,7 +171,8 @@ typeof args = do
   val <- case M.lookup line (tmctx st) of
     Just val -> return val
     Nothing  -> exec False line
-  liftIO $ putStrLn $ describeValue . valueType . extract . _nValue $ val
+  str <- lift $ lift $ showValueType val
+  liftIO $ putStrLn str
   where line = Text.pack (unwords args)
 
 -- :quit command

--- a/src/Nix.hs
+++ b/src/Nix.hs
@@ -135,7 +135,7 @@ processResult
 processResult h val = do
   opts :: Options <- asks (view hasLens)
   case attr opts of
-    Nothing                        -> h val
+    Nothing                         -> h val
     Just (Text.splitOn "." -> keys) -> go keys val
  where
   go :: [Text.Text] -> NValue t f m -> m a

--- a/src/Nix.hs
+++ b/src/Nix.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE ViewPatterns #-}
 
 module Nix
@@ -51,6 +51,7 @@ import           Nix.Render.Frame
 import           Nix.Thunk
 import           Nix.Utils
 import           Nix.Value
+import           Nix.Value.Monad
 import           Nix.XML
 
 -- | This is the entry point for all evaluations, whatever the expression tree
@@ -82,7 +83,7 @@ nixEvalExprLoc
   -> m (NValue t f m)
 nixEvalExprLoc mpath = nixEval
   mpath
-  (Eval.addStackFrames @t . Eval.addSourcePositions)
+  (Eval.addStackFrames . Eval.addSourcePositions)
   (Eval.eval . annotated . getCompose)
 
 -- | Evaluate a nix expression with tracing in the default context. Note that
@@ -117,13 +118,12 @@ evaluateExpression mpath evaluator handler expr = do
 
   eval' = (normalForm =<<) . nixEvalExpr mpath
 
-  argmap args = pure $ nvSet (M.fromList args') mempty
-    where args' = map (fmap (wrapValue . nValueFromNF)) args
+  argmap args = nvSet (M.fromList args') mempty
+    where args' = map (fmap nValueFromNF) args
 
-  compute ev x args p = do
-    f :: NValue t f m <- ev mpath x
-    processResult p =<< case f of
-      NVClosure _ g -> force ?? pure =<< g args
+  compute ev x args p = ev mpath x >>= \f -> demand f $ \f' ->
+    processResult p =<< case f' of
+      NVClosure _ g -> g args
       _             -> pure f
 
 processResult
@@ -135,22 +135,22 @@ processResult
 processResult h val = do
   opts :: Options <- asks (view hasLens)
   case attr opts of
-    Nothing                         -> h val
+    Nothing                        -> h val
     Just (Text.splitOn "." -> keys) -> go keys val
  where
   go :: [Text.Text] -> NValue t f m -> m a
   go [] v = h v
-  go ((Text.decimal -> Right (n,"")) : ks) v = case v of
+  go ((Text.decimal -> Right (n,"")) : ks) v = demand v $ \case
     NVList xs -> case ks of
-      [] -> force @t @m @(NValue t f m) (xs !! n) h
-      _  -> force (xs !! n) (go ks)
+      [] -> h (xs !! n)
+      _  -> go ks (xs !! n)
     _ ->
       errorWithoutStackTrace
         $  "Expected a list for selector '"
         ++ show n
         ++ "', but got: "
         ++ show v
-  go (k : ks) v = case v of
+  go (k : ks) v = demand v $ \case
     NVSet xs _ -> case M.lookup k xs of
       Nothing ->
         errorWithoutStackTrace
@@ -158,8 +158,8 @@ processResult h val = do
           ++ Text.unpack k
           ++ "'"
       Just v' -> case ks of
-        [] -> force v' h
-        _  -> force v' (go ks)
+        [] -> h v'
+        _  -> go ks v'
     _ ->
       errorWithoutStackTrace
         $  "Expected a set for selector '"

--- a/src/Nix/Atoms.hs
+++ b/src/Nix/Atoms.hs
@@ -43,11 +43,3 @@ atomText (NInt   i) = pack (show i)
 atomText (NFloat f) = pack (show f)
 atomText (NBool  b) = if b then "true" else "false"
 atomText NNull      = "null"
-
-
-
-
-
-
-
-

--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -126,7 +126,8 @@ withNixContext mpath action = do
       let ref = wrapValue @t @m @(NValue t f m) $ nvPath path
       pushScope (M.singleton "__cur_file" ref) action
 
-builtins :: (MonadNix e t f m, Scoped t m) => m (Scopes m t)
+builtins :: (MonadNix e t f m, Scoped (NValue t f m) m)
+         => m (Scopes m (NValue t f m))
 builtins = do
   ref <- thunk $ flip nvSet M.empty <$> buildMap
   lst <- ([("builtins", ref)] ++) <$> topLevelBuiltins

--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -174,7 +174,7 @@ builtinsList = sequence
   , add2 Normal   "catAttrs"         catAttrs
   , add2 Normal   "compareVersions"  compareVersions_
   , add  Normal   "concatLists"      concatLists
-  , add' Normal   "concatStringsSep" (arity2 principledIntercalateNixString)
+  -- , add' Normal   "concatStringsSep" (arity2 principledIntercalateNixString)
   , add0 Normal   "currentSystem"    currentSystem
   , add0 Normal   "currentTime"      currentTime_
   , add2 Normal   "deepSeq"          deepSeq

--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -173,7 +173,7 @@ builtinsList = sequence
   , add2 Normal   "catAttrs"         catAttrs
   , add2 Normal   "compareVersions"  compareVersions_
   , add  Normal   "concatLists"      concatLists
-  -- , add' Normal   "concatStringsSep" (arity2 principledIntercalateNixString)
+  , add' Normal   "concatStringsSep" (arity2 principledIntercalateNixString)
   , add0 Normal   "currentSystem"    currentSystem
   , add0 Normal   "currentTime"      currentTime_
   , add2 Normal   "deepSeq"          deepSeq

--- a/src/Nix/Convert.hs
+++ b/src/Nix/Convert.hs
@@ -252,7 +252,7 @@ instance (Convertible e t f m, Show r, FromValue a m r)
     Just b -> pure b
     _      -> throwError $ Expectation TSet (getDeeper v)
 
-instance (Convertible e t f m, FromValue a m r) => FromValue a m (Deeper r) where
+instance (Convertible e t f m, FromValue a m (NValue' t f m (NValue t f m))) => FromValue a m (Deeper (NValue' t f m (NValue t f m))) where
   fromValueMay = fromValueMay . getDeeper
   fromValue    = fromValue . getDeeper
 

--- a/src/Nix/Convert.hs
+++ b/src/Nix/Convert.hs
@@ -8,7 +8,6 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE MultiWayIf #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE QuantifiedConstraints #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TupleSections #-}
 {-# LANGUAGE TypeApplications #-}
@@ -217,11 +216,11 @@ class ToValue a m v where
 instance (Monad m, ToValue a m v) => ToValue a m (m v) where
   toValue = pure . toValue
 
-instance (Convertible e t f m, forall r. Show r => ToValue a m (NValue' t f m r))
+instance (Convertible e t f m, ToValue a m (NValue' t f m (NValueNF t f m)))
   => ToValue a m (NValueNF t f m) where
   toValue = fmap Fix . toValue
 
-instance (Convertible e t f m, forall r. Show r => ToValue a m (NValue' t f m r))
+instance (Convertible e t f m, ToValue a m (NValue' t f m (NValue t f m)))
   => ToValue a m (NValue t f m) where
   toValue = fmap Free . toValue
 

--- a/src/Nix/Convert.hs
+++ b/src/Nix/Convert.hs
@@ -8,6 +8,7 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE MultiWayIf #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE QuantifiedConstraints #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TupleSections #-}
 {-# LANGUAGE TypeApplications #-}
@@ -27,10 +28,9 @@
 
 module Nix.Convert where
 
-import           Control.Monad
-import           Control.Monad.Catch
+import           Control.Monad.Free
 import           Data.ByteString
-import           Data.HashMap.Lazy              ( HashMap )
+import           Data.Fix
 import qualified Data.HashMap.Lazy             as M
 import           Data.Maybe
 import           Data.Text                      ( Text )
@@ -44,8 +44,9 @@ import           Nix.Expr.Types
 import           Nix.Expr.Types.Annotated
 import           Nix.Frames
 import           Nix.String
-import           Nix.Thunk
 import           Nix.Value
+import           Nix.Value.Monad
+import           Nix.Utils
 
 {-
 
@@ -60,144 +61,104 @@ Do not add these instances back!
 
 -}
 
+{-----------------------------------------------------------------------
+   FromValue
+ -----------------------------------------------------------------------}
+
 class FromValue a m v where
     fromValue    :: v -> m a
     fromValueMay :: v -> m (Maybe a)
 
-type Convertible e t f m
-  = (Framed e m, MonadThunk t m (NValue t f m), MonadDataErrorContext t f m)
+type Convertible e t f m = (Framed e m, MonadDataErrorContext t f m)
 
-instance Convertible e t f m => FromValue () m (NValueNF t f m) where
-  fromValueMay = \case
-    NVConstantNF NNull -> pure $ Just ()
-    _                  -> pure Nothing
-  fromValue v = fromValueMay v >>= \case
-    Just b -> pure b
-    _      -> throwError $ ExpectationNF TNull v
+instance (Monad m, FromValue a m v) => FromValue a m (m v) where
+  fromValueMay = (>>= fromValueMay)
+  fromValue    = (>>= fromValue)
 
-instance Convertible e t f m => FromValue () m (NValue t f m) where
+instance ( Convertible e t f m
+         , MonadValue (NValueNF t f m) m
+         , FromValue a m (NValue' t f m (NValueNF t f m))
+         )
+  => FromValue a m (NValueNF t f m) where
+  fromValueMay = flip demand $ \(Fix v) -> fromValueMay v
+  fromValue    = flip demand $ \(Fix v) -> fromValue v
+
+instance ( Convertible e t f m
+         , MonadValue (NValue t f m) m
+         , FromValue a m (NValue' t f m (NValue t f m))
+         )
+  => FromValue a m (NValue t f m) where
+  fromValueMay = flip demand $ \case
+    Pure _ -> pure Nothing
+    Free v -> fromValueMay v
+  fromValue    = flip demand $ \case
+    Pure t -> throwError $ ForcingThunk @t @f @m t
+    Free v -> fromValue v
+
+instance (Convertible e t f m, Show r) => FromValue () m (NValue' t f m r) where
   fromValueMay = \case
-    NVConstant NNull -> pure $ Just ()
-    _                -> pure Nothing
+    NVConstant' NNull -> pure $ Just ()
+    _                 -> pure Nothing
   fromValue v = fromValueMay v >>= \case
     Just b -> pure b
     _      -> throwError $ Expectation TNull v
 
-instance Convertible e t f m => FromValue Bool m (NValueNF t f m) where
+instance (Convertible e t f m, Show r) => FromValue Bool m (NValue' t f m r) where
   fromValueMay = \case
-    NVConstantNF (NBool b) -> pure $ Just b
-    _                      -> pure Nothing
-  fromValue v = fromValueMay v >>= \case
-    Just b -> pure b
-    _      -> throwError $ ExpectationNF TBool v
-
-instance Convertible e t f m => FromValue Bool m (NValue t f m) where
-  fromValueMay = \case
-    NVConstant (NBool b) -> pure $ Just b
-    _                    -> pure Nothing
+    NVConstant' (NBool b) -> pure $ Just b
+    _                     -> pure Nothing
   fromValue v = fromValueMay v >>= \case
     Just b -> pure b
     _      -> throwError $ Expectation TBool v
 
-instance Convertible e t f m => FromValue Int m (NValueNF t f m) where
+instance (Convertible e t f m, Show r) => FromValue Int m (NValue' t f m r) where
   fromValueMay = \case
-    NVConstantNF (NInt b) -> pure $ Just (fromInteger b)
-    _                     -> pure Nothing
-  fromValue v = fromValueMay v >>= \case
-    Just b -> pure b
-    _      -> throwError $ ExpectationNF TInt v
-
-instance Convertible e t f m => FromValue Int m (NValue t f m) where
-  fromValueMay = \case
-    NVConstant (NInt b) -> pure $ Just (fromInteger b)
-    _                   -> pure Nothing
+    NVConstant' (NInt b) -> pure $ Just (fromInteger b)
+    _                    -> pure Nothing
   fromValue v = fromValueMay v >>= \case
     Just b -> pure b
     _      -> throwError $ Expectation TInt v
 
-instance Convertible e t f m => FromValue Integer m (NValueNF t f m) where
+instance (Convertible e t f m, Show r) => FromValue Integer m (NValue' t f m r) where
   fromValueMay = \case
-    NVConstantNF (NInt b) -> pure $ Just b
-    _                     -> pure Nothing
-  fromValue v = fromValueMay v >>= \case
-    Just b -> pure b
-    _      -> throwError $ ExpectationNF TInt v
-
-instance Convertible e t f m => FromValue Integer m (NValue t f m) where
-  fromValueMay = \case
-    NVConstant (NInt b) -> pure $ Just b
-    _                   -> pure Nothing
+    NVConstant' (NInt b) -> pure $ Just b
+    _                    -> pure Nothing
   fromValue v = fromValueMay v >>= \case
     Just b -> pure b
     _      -> throwError $ Expectation TInt v
 
-instance Convertible e t f m => FromValue Float m (NValueNF t f m) where
+instance (Convertible e t f m, Show r) => FromValue Float m (NValue' t f m r) where
   fromValueMay = \case
-    NVConstantNF (NFloat b) -> pure $ Just b
-    NVConstantNF (NInt   i) -> pure $ Just (fromInteger i)
-    _                       -> pure Nothing
-  fromValue v = fromValueMay v >>= \case
-    Just b -> pure b
-    _      -> throwError $ ExpectationNF TFloat v
-
-instance Convertible e t f m => FromValue Float m (NValue t f m) where
-  fromValueMay = \case
-    NVConstant (NFloat b) -> pure $ Just b
-    NVConstant (NInt   i) -> pure $ Just (fromInteger i)
-    _                     -> pure Nothing
+    NVConstant' (NFloat b) -> pure $ Just b
+    NVConstant' (NInt   i) -> pure $ Just (fromInteger i)
+    _                      -> pure Nothing
   fromValue v = fromValueMay v >>= \case
     Just b -> pure b
     _      -> throwError $ Expectation TFloat v
 
-instance (Convertible e t f m, MonadEffects t f m)
-      => FromValue NixString m (NValueNF t f m) where
+instance (Convertible e t f m, Show r, MonadEffects t f m,
+          FromValue NixString m r)
+      => FromValue NixString m (NValue' t f m r) where
   fromValueMay = \case
-    NVStrNF ns -> pure $ Just ns
-    NVPathNF p ->
+    NVStr' ns -> pure $ Just ns
+    NVPath' p ->
       Just
         .   hackyMakeNixStringWithoutContext
         .   Text.pack
         .   unStorePath
         <$> addPath p
-    NVSetNF s _ -> case M.lookup "outPath" s of
+    NVSet' s _ -> case M.lookup "outPath" s of
       Nothing -> pure Nothing
       Just p  -> fromValueMay p
     _ -> pure Nothing
   fromValue v = fromValueMay v >>= \case
     Just b -> pure b
-    _      -> throwError $ ExpectationNF (TString NoContext) v
-
-instance (Convertible e t f m, MonadEffects t f m)
-      => FromValue NixString m (NValue t f m) where
-  fromValueMay = \case
-    NVStr ns -> pure $ Just ns
-    NVPath p ->
-      Just
-        .   hackyMakeNixStringWithoutContext
-        .   Text.pack
-        .   unStorePath
-        <$> addPath p
-    NVSet s _ -> case M.lookup "outPath" s of
-      Nothing -> pure Nothing
-      Just p  -> force p fromValueMay
-    _ -> pure Nothing
-  fromValue v = fromValueMay v >>= \case
-    Just b -> pure b
     _      -> throwError $ Expectation (TString NoContext) v
 
-instance Convertible e t f m
-      => FromValue ByteString m (NValueNF t f m) where
+instance (Convertible e t f m, Show r)
+      => FromValue ByteString m (NValue' t f m r) where
   fromValueMay = \case
-    NVStrNF ns -> pure $ encodeUtf8 <$> hackyGetStringNoContext ns
-    _          -> pure Nothing
-  fromValue v = fromValueMay v >>= \case
-    Just b -> pure b
-    _      -> throwError $ ExpectationNF (TString NoContext) v
-
-instance Convertible e t f m
-      => FromValue ByteString m (NValue t f m) where
-  fromValueMay = \case
-    NVStr ns -> pure $ encodeUtf8 <$> hackyGetStringNoContext ns
+    NVStr' ns -> pure $ encodeUtf8 <$> hackyGetStringNoContext ns
     _        -> pure Nothing
   fromValue v = fromValueMay v >>= \case
     Just b -> pure b
@@ -206,191 +167,125 @@ instance Convertible e t f m
 newtype Path = Path { getPath :: FilePath }
     deriving Show
 
-instance Convertible e t f m => FromValue Path m (NValueNF t f m) where
+instance (Convertible e t f m, Show r, FromValue Path m r)
+  => FromValue Path m (NValue' t f m r) where
   fromValueMay = \case
-    NVPathNF p  -> pure $ Just (Path p)
-    NVStrNF  ns -> pure $ Path . Text.unpack <$> hackyGetStringNoContext ns
-    NVSetNF s _ -> case M.lookup "outPath" s of
+    NVPath' p  -> pure $ Just (Path p)
+    NVStr'  ns -> pure $ Path . Text.unpack <$> hackyGetStringNoContext ns
+    NVSet' s _ -> case M.lookup "outPath" s of
       Nothing -> pure Nothing
       Just p  -> fromValueMay @Path p
     _ -> pure Nothing
   fromValue v = fromValueMay v >>= \case
     Just b -> pure b
-    _      -> throwError $ ExpectationNF TPath v
-
-instance Convertible e t f m => FromValue Path m (NValue t f m) where
-  fromValueMay = \case
-    NVPath p  -> pure $ Just (Path p)
-    NVStr  ns -> pure $ Path . Text.unpack <$> hackyGetStringNoContext ns
-    NVSet s _ -> case M.lookup "outPath" s of
-      Nothing -> pure Nothing
-      Just p  -> force p $ fromValueMay @Path
-    _ -> pure Nothing
-  fromValue v = fromValueMay v >>= \case
-    Just b -> pure b
     _      -> throwError $ Expectation TPath v
 
-instance (Convertible e t f m, FromValue a m (NValueNF t f m), Show a)
-      => FromValue [a] m (NValueNF t f m) where
+instance (Convertible e t f m, Show r)
+  => FromValue [r] m (NValue' t f m r) where
   fromValueMay = \case
-    NVListNF l -> sequence <$> traverse fromValueMay l
-    _          -> pure Nothing
-  fromValue v = fromValueMay v >>= \case
-    Just b -> pure b
-    _      -> throwError $ ExpectationNF TList v
-
-instance Convertible e t f m => FromValue [t] m (NValue t f m) where
-  fromValueMay = \case
-    NVList l -> pure $ Just l
-    _        -> pure Nothing
+    NVList' l -> pure $ Just l
+    _         -> pure Nothing
   fromValue v = fromValueMay v >>= \case
     Just b -> pure b
     _      -> throwError $ Expectation TList v
 
-instance Convertible e t f m
-      => FromValue (HashMap Text (NValueNF t f m)) m (NValueNF t f m) where
+instance (Convertible e t f m, Show r)
+      => FromValue (AttrSet r) m (NValue' t f m r) where
   fromValueMay = \case
-    NVSetNF s _ -> pure $ Just s
-    _           -> pure Nothing
-  fromValue v = fromValueMay v >>= \case
-    Just b -> pure b
-    _      -> throwError $ ExpectationNF TSet v
-
-instance Convertible e t f m
-      => FromValue (HashMap Text t) m (NValue t f m) where
-  fromValueMay = \case
-    NVSet s _ -> pure $ Just s
-    _         -> pure Nothing
+    NVSet' s _ -> pure $ Just s
+    _          -> pure Nothing
   fromValue v = fromValueMay v >>= \case
     Just b -> pure b
     _      -> throwError $ Expectation TSet v
 
-instance Convertible e t f m
-      => FromValue (HashMap Text (NValueNF t f m),
-                 HashMap Text SourcePos) m (NValueNF t f m) where
+instance (Convertible e t f m, Show r)
+      => FromValue (AttrSet r, AttrSet SourcePos) m (NValue' t f m r) where
   fromValueMay = \case
-    NVSetNF s p -> pure $ Just (s, p)
-    _           -> pure Nothing
-  fromValue v = fromValueMay v >>= \case
-    Just b -> pure b
-    _      -> throwError $ ExpectationNF TSet v
-
-instance Convertible e t f m
-      => FromValue (HashMap Text t,
-                   HashMap Text SourcePos) m (NValue t f m) where
-  fromValueMay = \case
-    NVSet s p -> pure $ Just (s, p)
-    _         -> pure Nothing
+    NVSet' s p -> pure $ Just (s, p)
+    _          -> pure Nothing
   fromValue v = fromValueMay v >>= \case
     Just b -> pure b
     _      -> throwError $ Expectation TSet v
 
-instance (Monad m, FromValue a m v) => FromValue a m (m v) where
-  fromValueMay = (>>= fromValueMay)
-  fromValue    = (>>= fromValue)
+{-----------------------------------------------------------------------
+   ToValue
+ -----------------------------------------------------------------------}
 
 class ToValue a m v where
     toValue :: a -> m v
 
-instance Convertible e t f m => ToValue () m (NValueNF t f m) where
-  toValue _ = pure . nvConstantNF $ NNull
+instance (Monad m, ToValue a m v) => ToValue a m (m v) where
+  toValue = pure . toValue
 
-instance Convertible e t f m => ToValue () m (NValue t f m) where
-  toValue _ = pure . nvConstant $ NNull
+instance (Convertible e t f m, forall r. Show r => ToValue a m (NValue' t f m r))
+  => ToValue a m (NValueNF t f m) where
+  toValue = fmap Fix . toValue
 
-instance Convertible e t f m => ToValue Bool m (NValueNF t f m) where
-  toValue = pure . nvConstantNF . NBool
+instance (Convertible e t f m, forall r. Show r => ToValue a m (NValue' t f m r))
+  => ToValue a m (NValue t f m) where
+  toValue = fmap Free . toValue
 
-instance Convertible e t f m => ToValue Bool m (NValue t f m) where
-  toValue = pure . nvConstant . NBool
+instance Convertible e t f m => ToValue () m (NValue' t f m r) where
+  toValue _ = pure . nvConstant' $ NNull
 
-instance Convertible e t f m => ToValue Int m (NValueNF t f m) where
-  toValue = pure . nvConstantNF . NInt . toInteger
+instance Convertible e t f m => ToValue Bool m (NValue' t f m r) where
+  toValue = pure . nvConstant' . NBool
 
-instance Convertible e t f m => ToValue Int m (NValue t f m) where
-  toValue = pure . nvConstant . NInt . toInteger
+instance Convertible e t f m => ToValue Int m (NValue' t f m r) where
+  toValue = pure . nvConstant' . NInt . toInteger
 
-instance Convertible e t f m => ToValue Integer m (NValueNF t f m) where
-  toValue = pure . nvConstantNF . NInt
+instance Convertible e t f m => ToValue Integer m (NValue' t f m r) where
+  toValue = pure . nvConstant' . NInt
 
-instance Convertible e t f m => ToValue Integer m (NValue t f m) where
-  toValue = pure . nvConstant . NInt
+instance Convertible e t f m => ToValue Float m (NValue' t f m r) where
+  toValue = pure . nvConstant' . NFloat
 
-instance Convertible e t f m => ToValue Float m (NValueNF t f m) where
-  toValue = pure . nvConstantNF . NFloat
+instance Convertible e t f m => ToValue NixString m (NValue' t f m r) where
+  toValue = pure . nvStr'
 
-instance Convertible e t f m => ToValue Float m (NValue t f m) where
-  toValue = pure . nvConstant . NFloat
+instance Convertible e t f m => ToValue ByteString m (NValue' t f m r) where
+  toValue = pure . nvStr' . hackyMakeNixStringWithoutContext . decodeUtf8
 
-instance Convertible e t f m => ToValue NixString m (NValueNF t f m) where
-  toValue = pure . nvStrNF
+instance Convertible e t f m => ToValue Path m (NValue' t f m r) where
+  toValue = pure . nvPath' . getPath
 
-instance Convertible e t f m => ToValue NixString m (NValue t f m) where
-  toValue = pure . nvStr
-
-instance Convertible e t f m => ToValue ByteString m (NValueNF t f m) where
-  toValue = pure . nvStrNF . hackyMakeNixStringWithoutContext . decodeUtf8
-
-instance Convertible e t f m => ToValue ByteString m (NValue t f m) where
-  toValue = pure . nvStr . hackyMakeNixStringWithoutContext . decodeUtf8
-
-instance Convertible e t f m => ToValue Path m (NValueNF t f m) where
-  toValue = pure . nvPathNF . getPath
-
-instance Convertible e t f m => ToValue Path m (NValue t f m) where
-  toValue = pure . nvPath . getPath
-
-instance Convertible e t f m => ToValue StorePath m (NValueNF t f m) where
+instance Convertible e t f m => ToValue StorePath m (NValue' t f m r) where
   toValue = toValue . Path . unStorePath
 
-instance Convertible e t f m => ToValue StorePath m (NValue t f m) where
-  toValue = toValue . Path . unStorePath
-
-instance Convertible e t f m => ToValue SourcePos m (NValue t f m) where
+instance ( Convertible e t f m
+         , ToValue NixString m r
+         , ToValue Int m r
+         )
+  => ToValue SourcePos m (NValue' t f m r) where
   toValue (SourcePos f l c) = do
-    f' <- pure $ nvStr $ principledMakeNixStringWithoutContext (Text.pack f)
+    f' <- toValue (principledMakeNixStringWithoutContext (Text.pack f))
     l' <- toValue (unPos l)
     c' <- toValue (unPos c)
     let pos = M.fromList
-          [ ("file" :: Text, wrapValue f')
-          , ("line"        , wrapValue l')
-          , ("column"      , wrapValue c')
+          [ ("file" :: Text, f')
+          , ("line"       , l')
+          , ("column"     , c')
           ]
-    pure $ nvSet pos mempty
+    pure $ nvSet' pos mempty
 
-instance (Convertible e t f m, ToValue a m (NValueNF t f m))
-      => ToValue [a] m (NValueNF t f m) where
-  toValue = fmap nvListNF . traverse toValue
+instance Convertible e t f m => ToValue [r] m (NValue' t f m r) where
+  toValue = pure . nvList'
 
-instance Convertible e t f m => ToValue [t] m (NValue t f m) where
-  toValue = pure . nvList
+instance Convertible e t f m => ToValue (AttrSet r) m (NValue' t f m r) where
+  toValue = pure . flip nvSet' M.empty
 
 instance Convertible e t f m
-      => ToValue (HashMap Text (NValueNF t f m)) m (NValueNF t f m) where
-  toValue = pure . flip nvSetNF M.empty
+  => ToValue (AttrSet r, AttrSet SourcePos) m (NValue' t f m r) where
+  toValue (s, p) = pure $ nvSet' s p
 
-instance Convertible e t f m => ToValue (HashMap Text t) m (NValue t f m) where
-  toValue = pure . flip nvSet M.empty
-
-instance Convertible e t f m => ToValue (HashMap Text (NValueNF t f m),
-                HashMap Text SourcePos) m (NValueNF t f m) where
-  toValue (s, p) = pure $ nvSetNF s p
-
-instance Convertible e t f m => ToValue (HashMap Text t,
-                HashMap Text SourcePos) m (NValue t f m) where
-  toValue (s, p) = pure $ nvSet s p
-
-instance Convertible e t f m => ToValue Bool m (NExprF r) where
-  toValue = pure . NConstant . NBool
-
-instance Convertible e t f m => ToValue () m (NExprF r) where
-  toValue _ = pure . NConstant $ NNull
-
-instance ( MonadThunk t m (NValue t f m)
+instance ( MonadValue (NValue t f m) m
          , MonadDataErrorContext t f m
          , Framed e m
+         , ToValue NixString m r
+         , ToValue Bool m r
+         , ToValue [r] m r
          )
-    => ToValue NixLikeContextValue m (NValue t f m) where
+    => ToValue NixLikeContextValue m (NValue' t f m r) where
   toValue nlcv = do
     path <- if nlcvPath nlcv then Just <$> toValue True else return Nothing
     allOutputs <- if nlcvAllOutputs nlcv
@@ -399,130 +294,18 @@ instance ( MonadThunk t m (NValue t f m)
     outputs <- do
       let outputs =
             fmap principledMakeNixStringWithoutContext $ nlcvOutputs nlcv
-      outputsM :: [NValue t f m] <- traverse toValue outputs
-      let ts :: [t] = fmap wrapValue outputsM
+      ts :: [r] <- traverse toValue outputs
       case ts of
         [] -> return Nothing
         _  -> Just <$> toValue ts
-    pure $ flip nvSet M.empty $ M.fromList $ catMaybes
-      [ (\p -> ("path", wrapValue p)) <$> path
-      , (\ao -> ("allOutputs", wrapValue ao)) <$> allOutputs
-      , (\os -> ("outputs", wrapValue os)) <$> outputs
+    pure $ flip nvSet' M.empty $ M.fromList $ catMaybes
+      [ (\p  -> ("path",       p))  <$> path
+      , (\ao -> ("allOutputs", ao)) <$> allOutputs
+      , (\os -> ("outputs",    os)) <$> outputs
       ]
 
-whileForcingThunk
-  :: forall t f m s e r . (Exception s, Convertible e t f m) => s -> m r -> m r
-whileForcingThunk frame =
-  withFrame Debug (ForcingThunk @t @f @m) . withFrame Debug frame
+instance Convertible e t f m => ToValue () m (NExprF r) where
+  toValue _ = pure . NConstant $ NNull
 
-class FromNix a m v where
-    fromNix :: v -> m a
-    default fromNix :: FromValue a m v => v -> m a
-    fromNix = fromValue
-
-    fromNixMay :: v -> m (Maybe a)
-    default fromNixMay :: FromValue a m v => v -> m (Maybe a)
-    fromNixMay = fromValueMay
-
-instance (Convertible e t f m, FromNix a m (NValue t f m))
-      => FromNix [a] m (NValue t f m) where
-  fromNixMay = \case
-    NVList l -> sequence <$> traverse (`force` fromNixMay) l
-    _        -> pure Nothing
-  fromNix v = fromNixMay v >>= \case
-    Just b -> pure b
-    _      -> throwError $ Expectation TList v
-
-instance (Convertible e t f m, FromNix a m (NValue t f m))
-      => FromNix (HashMap Text a) m (NValue t f m) where
-  fromNixMay = \case
-    NVSet s _ -> sequence <$> traverse (`force` fromNixMay) s
-    _         -> pure Nothing
-  fromNix v = fromNixMay v >>= \case
-    Just b -> pure b
-    _      -> throwError $ Expectation TSet v
-
-instance Convertible e t f m => FromNix () m (NValueNF t f m) where
-instance Convertible e t f m => FromNix () m (NValue t f m) where
-instance Convertible e t f m => FromNix Bool m (NValueNF t f m) where
-instance Convertible e t f m => FromNix Bool m (NValue t f m) where
-instance Convertible e t f m => FromNix Int m (NValueNF t f m) where
-instance Convertible e t f m => FromNix Int m (NValue t f m) where
-instance Convertible e t f m => FromNix Integer m (NValueNF t f m) where
-instance Convertible e t f m => FromNix Integer m (NValue t f m) where
-instance Convertible e t f m => FromNix Float m (NValueNF t f m) where
-instance Convertible e t f m => FromNix Float m (NValue t f m) where
-instance (Convertible e t f m, MonadEffects t f m)
-  => FromNix NixString m (NValueNF t f m) where
-instance (Convertible e t f m, MonadEffects t f m)
-  => FromNix NixString m (NValue t f m) where
-instance Convertible e t f m => FromNix ByteString m (NValueNF t f m) where
-instance Convertible e t f m => FromNix ByteString m (NValue t f m) where
-instance Convertible e t f m => FromNix Path m (NValueNF t f m) where
-instance Convertible e t f m => FromNix Path m (NValue t f m) where
-instance (Convertible e t f m, FromValue a m (NValueNF t f m), Show a)
-  => FromNix [a] m (NValueNF t f m) where
-instance Convertible e t f m
-  => FromNix (HashMap Text (NValueNF t f m)) m (NValueNF t f m) where
-instance Convertible e t f m
-  => FromNix (HashMap Text (NValueNF t f m),
-             HashMap Text SourcePos) m (NValueNF t f m) where
-instance Convertible e t f m
-  => FromNix (HashMap Text t, HashMap Text SourcePos) m (NValue t f m) where
-
-instance (Monad m, FromNix a m v) => FromNix a m (m v) where
-  fromNixMay = (>>= fromNixMay)
-  fromNix    = (>>= fromNix)
-
-class ToNix a m v where
-    toNix :: a -> m v
-    default toNix :: ToValue a m v => a -> m v
-    toNix = toValue
-
-instance (Convertible e t f m, ToNix a m (NValue t f m))
-      => ToNix [a] m (NValue t f m) where
-  toNix = fmap nvList . traverse (thunk . go)
-   where
-    go =
-      (\v -> whileForcingThunk @t @f @m (ConcerningValue v) (pure v)) <=< toNix
-
-instance (Convertible e t f m, ToNix a m (NValue t f m))
-      => ToNix (HashMap Text a) m (NValue t f m) where
-  toNix = fmap (flip nvSet M.empty) . traverse (thunk . go)
-   where
-    go =
-      (\v -> whileForcingThunk @t @f @m (ConcerningValue v) (pure v)) <=< toNix
-
-instance Convertible e t f m => ToNix () m (NValueNF t f m) where
-instance Convertible e t f m => ToNix () m (NValue t f m) where
-instance Convertible e t f m => ToNix Bool m (NValueNF t f m) where
-instance Convertible e t f m => ToNix Bool m (NValue t f m) where
-instance Convertible e t f m => ToNix Int m (NValueNF t f m) where
-instance Convertible e t f m => ToNix Int m (NValue t f m) where
-instance Convertible e t f m => ToNix Integer m (NValueNF t f m) where
-instance Convertible e t f m => ToNix Integer m (NValue t f m) where
-instance Convertible e t f m => ToNix Float m (NValueNF t f m) where
-instance Convertible e t f m => ToNix Float m (NValue t f m) where
-instance Convertible e t f m => ToNix NixString m (NValueNF t f m) where
-instance Convertible e t f m => ToNix NixString m (NValue t f m) where
-instance Convertible e t f m => ToNix ByteString m (NValueNF t f m) where
-instance Convertible e t f m => ToNix ByteString m (NValue t f m) where
-instance Convertible e t f m => ToNix Path m (NValueNF t f m) where
-instance Convertible e t f m => ToNix Path m (NValue t f m) where
-instance Convertible e t f m
-  => ToNix (HashMap Text (NValueNF t f m)) m (NValueNF t f m) where
-instance Convertible e t f m
-  => ToNix (HashMap Text (NValueNF t f m),
-           HashMap Text SourcePos) m (NValueNF t f m) where
-instance Convertible e t f m
-  => ToNix (HashMap Text t, HashMap Text SourcePos) m (NValue t f m) where
-
-instance Convertible e t f m => ToNix Bool m (NExprF r) where
-  toNix = pure . NConstant . NBool
-
-instance Convertible e t f m => ToNix () m (NExprF r) where
-  toNix _ = pure $ NConstant NNull
-
-instance (Convertible e t f m, ToNix a m (NValueNF t f m))
-  => ToNix [a] m (NValueNF t f m) where
-  toNix = fmap nvListNF . traverse toNix
+instance Convertible e t f m => ToValue Bool m (NExprF r) where
+  toValue = pure . NConstant . NBool

--- a/src/Nix/Effects.hs
+++ b/src/Nix/Effects.hs
@@ -249,10 +249,3 @@ addPath p = either throwError return =<< addPath' p
 
 toFile_ :: (Framed e m, MonadStore m) => FilePath -> String -> m StorePath
 toFile_ p contents = either throwError return =<< toFile_' p contents
-
-
-
-
-
-
-

--- a/src/Nix/Effects.hs
+++ b/src/Nix/Effects.hs
@@ -51,7 +51,7 @@ class (MonadFile m,
 
     -- | Having an explicit list of sets corresponding to the NIX_PATH
     -- and a file path try to find an existing path
-    findPath :: [t] -> FilePath -> m FilePath
+    findPath :: [NValue t f m] -> FilePath -> m FilePath
 
     importPath :: FilePath -> m (NValue t f m)
     pathToDefaultNix :: FilePath -> m FilePath

--- a/src/Nix/Eval.hs
+++ b/src/Nix/Eval.hs
@@ -38,81 +38,89 @@ import           Nix.Frames
 import           Nix.String
 import           Nix.Scope
 import           Nix.Strings                    ( runAntiquoted )
-import           Nix.Thunk
 import           Nix.Utils
+import           Nix.Value.Monad
+
+-- instance MonadThunk t m (NValue t f m) => MonadValue (NValue t f m) m where
+--   defer = fmap Pure . thunk
+--   demand (Pure t) f = force t f
+--   demand v@(Free _) f = f v
 
 class (Show v, Monad m) => MonadEval v m where
-    freeVariable    :: Text -> m v
-    synHole         :: Text -> m v
-    attrMissing     :: NonEmpty Text -> Maybe v -> m v
-    evaledSym       :: Text -> v -> m v
-    evalCurPos      :: m v
-    evalConstant    :: NAtom -> m v
-    evalString      :: NString (m v) -> m v
-    evalLiteralPath :: FilePath -> m v
-    evalEnvPath     :: FilePath -> m v
-    evalUnary       :: NUnaryOp -> v -> m v
-    evalBinary      :: NBinaryOp -> v -> m v -> m v
-    -- ^ The second argument is an action because operators such as boolean &&
-    -- and || may not evaluate the second argument.
-    evalWith        :: m v -> m v -> m v
-    evalIf          :: v -> m v -> m v -> m v
-    evalAssert      :: v -> m v -> m v
-    evalApp         :: v -> m v -> m v
-    evalAbs         :: Params (m v)
-                    -> (forall a. m v -> (AttrSet (m v) -> m v -> m (a, v)) -> m (a, v))
-                    -> m v
+  freeVariable    :: Text -> m v
+  synHole         :: Text -> m v
+  attrMissing     :: NonEmpty Text -> Maybe v -> m v
+  evaledSym       :: Text -> v -> m v
+  evalCurPos      :: m v
+  evalConstant    :: NAtom -> m v
+  evalString      :: NString (m v) -> m v
+  evalLiteralPath :: FilePath -> m v
+  evalEnvPath     :: FilePath -> m v
+  evalUnary       :: NUnaryOp -> v -> m v
+  evalBinary      :: NBinaryOp -> v -> m v -> m v
+  -- ^ The second argument is an action because operators such as boolean &&
+  -- and || may not evaluate the second argument.
+  evalWith        :: m v -> m v -> m v
+  evalIf          :: v -> m v -> m v -> m v
+  evalAssert      :: v -> m v -> m v
+  evalApp         :: v -> m v -> m v
+  evalAbs         :: Params (m v)
+                  -> (forall a. m v -> (AttrSet (m v) -> m v -> m (a, v)) -> m (a, v))
+                  -> m v
 {-
-    evalSelect     :: v -> NonEmpty Text -> Maybe (m v) -> m v
-    evalHasAttr    :: v -> NonEmpty Text -> m v
+  evalSelect     :: v -> NonEmpty Text -> Maybe (m v) -> m v
+  evalHasAttr    :: v -> NonEmpty Text -> m v
 
-    -- | This and the following methods are intended to allow things like
-    --   adding provenance information.
-    evalListElem   :: [m v] -> Int -> m v -> m v
-    evalList       :: [t] -> m v
-    evalSetElem    :: AttrSet (m v) -> Text -> m v -> m v
-    evalSet        :: AttrSet t -> AttrSet SourcePos -> m v
-    evalRecSetElem :: AttrSet (m v) -> Text -> m v -> m v
-    evalRecSet     :: AttrSet t -> AttrSet SourcePos -> m v
-    evalLetElem    :: Text -> m v -> m v
-    evalLet        :: m v -> m v
+  -- | This and the following methods are intended to allow things like
+  --   adding provenance information.
+  evalListElem   :: [m v] -> Int -> m v -> m v
+  evalList       :: [v] -> m v
+  evalSetElem    :: AttrSet (m v) -> Text -> m v -> m v
+  evalSet        :: AttrSet v -> AttrSet SourcePos -> m v
+  evalRecSetElem :: AttrSet (m v) -> Text -> m v -> m v
+  evalRecSet     :: AttrSet v -> AttrSet SourcePos -> m v
+  evalLetElem    :: Text -> m v -> m v
+  evalLet        :: m v -> m v
 -}
-    evalError :: Exception s => s -> m a
+  evalError :: Exception s => s -> m a
 
-type MonadNixEval v t m
+type MonadNixEval v m
   = ( MonadEval v m
-  , Scoped t m
-  , MonadThunk t m v
+  , Scoped v m
+  , MonadValue v m
   , MonadFix m
   , ToValue Bool m v
-  , ToValue [t] m v
+  , ToValue [v] m v
   , FromValue NixString m v
-  , ToValue (AttrSet t, AttrSet SourcePos) m v
-  , FromValue (AttrSet t, AttrSet SourcePos) m v
+  , ToValue (AttrSet v, AttrSet SourcePos) m v
+  , FromValue (AttrSet v, AttrSet SourcePos) m v
   )
 
-data EvalFrame m t
-    = EvaluatingExpr (Scopes m t) NExprLoc
-    | ForcingExpr (Scopes m t) NExprLoc
+data EvalFrame m v
+    = EvaluatingExpr (Scopes m v) NExprLoc
+    | ForcingExpr (Scopes m v) NExprLoc
     | Calling String SrcSpan
-    | SynHole (SynHoleInfo m t)
+    | SynHole (SynHoleInfo m v)
     deriving (Show, Typeable)
 
-instance (Typeable m, Typeable t) => Exception (EvalFrame m t)
+instance (Typeable m, Typeable v) => Exception (EvalFrame m v)
 
-data SynHoleInfo m t = SynHoleInfo
+data SynHoleInfo m v = SynHoleInfo
    { _synHoleInfo_expr :: NExprLoc
-   , _synHoleInfo_scope :: Scopes m t
+   , _synHoleInfo_scope :: Scopes m v
    } deriving (Show, Typeable)
 
-instance (Typeable m, Typeable t) => Exception (SynHoleInfo m t)
+instance (Typeable m, Typeable v) => Exception (SynHoleInfo m v)
 
-eval :: forall v t m . MonadNixEval v t m => NExprF (m v) -> m v
+-- jww (2019-03-18): By deferring only those things which must wait until
+-- context of us, this can be written as:
+-- eval :: forall v m . MonadNixEval v m => NExprF v -> m v
+eval :: forall v m . MonadNixEval v m => NExprF (m v) -> m v
 
 eval (NSym "__curPos") = evalCurPos
 
-eval (NSym var       ) = (lookupVar var :: m (Maybe t))
-  >>= maybe (freeVariable var) (force ?? evaledSym var)
+eval (NSym var       ) = (lookupVar var :: m (Maybe v))
+  >>= maybe (freeVariable var) (demand ?? evaledSym var)
 
 eval (NConstant    x      ) = evalConstant x
 eval (NStr         str    ) = evalString str
@@ -121,7 +129,7 @@ eval (NEnvPath     p      ) = evalEnvPath p
 eval (NUnary op arg       ) = evalUnary op =<< arg
 
 eval (NBinary NApp fun arg) = do
-  scope <- currentScopes :: m (Scopes m t)
+  scope <- currentScopes :: m (Scopes m v)
   fun >>= (`evalApp` withScopes scope arg)
 
 eval (NBinary op   larg rarg) = larg >>= evalBinary op ?? rarg
@@ -133,7 +141,7 @@ eval (NHasAttr aset attr) = evalSelect aset attr >>= toValue . isRight
 
 eval (NList l           ) = do
   scope <- currentScopes
-  for l (thunk @t @m @v . withScopes @t scope) >>= toValue
+  for l (defer @v @m . withScopes @v scope) >>= toValue
 
 eval (NSet binds) =
   evalBinds False (desugarBinds (eval . NSet) binds) >>= toValue
@@ -154,32 +162,32 @@ eval (NAbs    params body) = do
     -- needs to be used when evaluating the body and default arguments, hence
     -- we defer here so the present scope is restored when the parameters and
     -- body are forced during application.
-  scope <- currentScopes :: m (Scopes m t)
+  scope <- currentScopes :: m (Scopes m v)
   evalAbs params $ \arg k -> withScopes scope $ do
     args <- buildArgument params arg
-    pushScope args (k (M.map (`force` pure) args) body)
+    pushScope args (k (M.map (`demand` pure) args) body)
 
 eval (NSynHole name) = synHole name
 
--- | If you know that the 'scope' action will result in an 'AttrSet t', then
+-- | If you know that the 'scope' action will result in an 'AttrSet v', then
 --   this implementation may be used as an implementation for 'evalWith'.
-evalWithAttrSet :: forall v t m . MonadNixEval v t m => m v -> m v -> m v
+evalWithAttrSet :: forall v m . MonadNixEval v m => m v -> m v -> m v
 evalWithAttrSet aset body = do
     -- The scope is deliberately wrapped in a thunk here, since it is
     -- evaluated each time a name is looked up within the weak scope, and
     -- we want to be sure the action it evaluates is to force a thunk, so
     -- its value is only computed once.
-  scope <- currentScopes :: m (Scopes m t)
-  s     <- thunk @t @m @v $ withScopes scope aset
+  scope <- currentScopes :: m (Scopes m v)
+  s     <- defer @v @m $ withScopes scope aset
   pushWeakScope
     ?? body
-    $  force s
+    $  demand s
     $  fmap fst
-    .  fromValue @(AttrSet t, AttrSet SourcePos)
+    .  fromValue @(AttrSet v, AttrSet SourcePos)
 
 attrSetAlter
-  :: forall v t m
-   . MonadNixEval v t m
+  :: forall v m
+   . MonadNixEval v m
   => [Text]
   -> SourcePos
   -> AttrSet (m v)
@@ -196,17 +204,16 @@ attrSetAlter (k : ks) pos m p val = case M.lookup k m of
     | null ks
     -> go
     | otherwise
-    -> x >>= fromValue @(AttrSet t, AttrSet SourcePos) >>= \(st, sp) ->
-      recurse (force ?? pure <$> st) sp
+    -> x >>= fromValue @(AttrSet v, AttrSet SourcePos) >>= \(st, sp) ->
+      recurse (demand ?? pure <$> st) sp
  where
   go = return (M.insert k val m, M.insert k pos p)
 
   recurse st sp = attrSetAlter ks pos st sp val <&> \(st', _) ->
     ( M.insert
       k
-      (   toValue @(AttrSet t, AttrSet SourcePos)
+      (   toValue @(AttrSet v, AttrSet SourcePos)
       =<< (, mempty)
-      .   fmap wrapValue
       <$> sequence st'
       )
       st
@@ -240,13 +247,13 @@ desugarBinds embed binds = evalState (mapM (go <=< collect) binds) M.empty
       Just (p, v) -> pure $ NamedVar (StaticKey x :| []) (embed v) p
 
 evalBinds
-  :: forall v t m
-   . MonadNixEval v t m
+  :: forall v m
+   . MonadNixEval v m
   => Bool
   -> [Binding (m v)]
-  -> m (AttrSet t, AttrSet SourcePos)
+  -> m (AttrSet v, AttrSet SourcePos)
 evalBinds recursive binds = do
-  scope <- currentScopes :: m (Scopes m t)
+  scope <- currentScopes :: m (Scopes m v)
   buildResult scope . concat =<< mapM (go scope) (moveOverridesLast binds)
  where
   moveOverridesLast = uncurry (++) . partition
@@ -255,12 +262,12 @@ evalBinds recursive binds = do
       _ -> True
     )
 
-  go :: Scopes m t -> Binding (m v) -> m [([Text], SourcePos, m v)]
+  go :: Scopes m v -> Binding (m v) -> m [([Text], SourcePos, m v)]
   go _ (NamedVar (StaticKey "__overrides" :| []) finalValue pos) =
     finalValue >>= fromValue >>= \(o', p') ->
           -- jww (2018-05-09): What to do with the key position here?
                                               return $ map
-      (\(k, v) -> ([k], fromMaybe pos (M.lookup k p'), force @t @m @v v pure))
+      (\(k, v) -> ([k], fromMaybe pos (M.lookup k p'), demand @v @m v pure))
       (M.toList o')
 
   go _ (NamedVar pathExpr finalValue pos) = do
@@ -271,7 +278,7 @@ evalBinds recursive binds = do
               pure
                 ( []
                 , nullPos
-                , toValue @(AttrSet t, AttrSet SourcePos) (mempty, mempty)
+                , toValue @(AttrSet v, AttrSet SourcePos) (mempty, mempty)
                 )
             Just k -> case t of
               []     -> pure ([k], pos, finalValue)
@@ -294,31 +301,31 @@ evalBinds recursive binds = do
           mv <- case ms of
             Nothing -> withScopes scope $ lookupVar key
             Just s ->
-              s >>= fromValue @(AttrSet t, AttrSet SourcePos) >>= \(s, _) ->
-                clearScopes @t $ pushScope s $ lookupVar key
+              s >>= fromValue @(AttrSet v, AttrSet SourcePos) >>= \(s, _) ->
+                clearScopes @v $ pushScope s $ lookupVar key
           case mv of
             Nothing -> attrMissing (key :| []) Nothing
-            Just v  -> force v pure
+            Just v  -> demand v pure
         )
 
   buildResult
-    :: Scopes m t
+    :: Scopes m v
     -> [([Text], SourcePos, m v)]
-    -> m (AttrSet t, AttrSet SourcePos)
+    -> m (AttrSet v, AttrSet SourcePos)
   buildResult scope bindings = do
     (s, p) <- foldM insert (M.empty, M.empty) bindings
     res <- if recursive then loebM (encapsulate <$> s) else traverse mkThunk s
     return (res, p)
    where
-    mkThunk = thunk . withScopes scope
+    mkThunk = defer . withScopes scope
 
     encapsulate f attrs = mkThunk . pushScope attrs $ f
 
     insert (m, p) (path, pos, value) = attrSetAlter path pos m p value
 
 evalSelect
-  :: forall v t m
-   . MonadNixEval v t m
+  :: forall v m
+   . MonadNixEval v m
   => m v
   -> NAttrPath (m v)
   -> m (Either (v, NonEmpty Text) (m v))
@@ -328,10 +335,10 @@ evalSelect aset attr = do
   extract s path
  where
   extract x path@(k :| ks) = fromValueMay x >>= \case
-    Just (s :: AttrSet t, p :: AttrSet SourcePos)
+    Just (s :: AttrSet v, p :: AttrSet SourcePos)
       | Just t <- M.lookup k s -> case ks of
-        []     -> pure $ Right $ force t pure
-        y : ys -> force t $ extract ?? (y :| ys)
+        []     -> pure $ Right $ demand t pure
+        y : ys -> demand t $ extract ?? (y :| ys)
       | otherwise -> Left . (, path) <$> toValue (s, p)
     Nothing -> return $ Left (x, path)
 
@@ -376,16 +383,16 @@ assembleString = \case
                      (>>= fromValueMay)
 
 buildArgument
-  :: forall v t m . MonadNixEval v t m => Params (m v) -> m v -> m (AttrSet t)
+  :: forall v m . MonadNixEval v m => Params (m v) -> m v -> m (AttrSet v)
 buildArgument params arg = do
-  scope <- currentScopes :: m (Scopes m t)
+  scope <- currentScopes :: m (Scopes m v)
   case params of
-    Param name -> M.singleton name <$> thunk (withScopes scope arg)
+    Param name -> M.singleton name <$> defer (withScopes scope arg)
     ParamSet s isVariadic m ->
-      arg >>= fromValue @(AttrSet t, AttrSet SourcePos) >>= \(args, _) -> do
+      arg >>= fromValue @(AttrSet v, AttrSet SourcePos) >>= \(args, _) -> do
         let inject = case m of
               Nothing -> id
-              Just n  -> M.insert n $ const $ thunk (withScopes scope arg)
+              Just n  -> M.insert n $ const $ defer (withScopes scope arg)
         loebM
           (inject $ M.mapMaybe id $ alignWithKey (assemble scope isVariadic)
                                                  args
@@ -393,11 +400,11 @@ buildArgument params arg = do
           )
  where
   assemble
-    :: Scopes m t
+    :: Scopes m v
     -> Bool
     -> Text
-    -> These t (Maybe (m v))
-    -> Maybe (AttrSet t -> m t)
+    -> These v (Maybe (m v))
+    -> Maybe (AttrSet v -> m v)
   assemble scope isVariadic k = \case
     That Nothing ->
       Just
@@ -407,7 +414,7 @@ buildArgument params arg = do
         $  "Missing value for parameter: "
         ++ show k
     That (Just f) ->
-      Just $ \args -> thunk $ withScopes scope $ pushScope args f
+      Just $ \args -> defer $ withScopes scope $ pushScope args f
     This _
       | isVariadic
       -> Nothing
@@ -426,17 +433,17 @@ addSourcePositions f v@(Fix (Compose (Ann ann _))) =
   local (set hasLens ann) (f v)
 
 addStackFrames
-  :: forall t e m a
-   . (Scoped t m, Framed e m, Typeable t, Typeable m)
+  :: forall v e m a
+   . (Scoped v m, Framed e m, Typeable v, Typeable m)
   => Transform NExprLocF (m a)
 addStackFrames f v = do
-  scopes <- currentScopes :: m (Scopes m t)
+  scopes <- currentScopes :: m (Scopes m v)
   withFrame Info (EvaluatingExpr scopes v) (f v)
 
 framedEvalExprLoc
-  :: forall t e v m
-   . (MonadNixEval v t m, Framed e m, Has e SrcSpan, Typeable t, Typeable m)
+  :: forall e v m
+   . (MonadNixEval v m, Framed e m, Has e SrcSpan, Typeable m, Typeable v)
   => NExprLoc
   -> m v
 framedEvalExprLoc =
-  adi (eval . annotated . getCompose) (addStackFrames @t . addSourcePositions)
+  adi (eval . annotated . getCompose) (addStackFrames @v . addSourcePositions)

--- a/src/Nix/Eval.hs
+++ b/src/Nix/Eval.hs
@@ -212,10 +212,7 @@ attrSetAlter (k : ks) pos m p val = case M.lookup k m of
   recurse st sp = attrSetAlter ks pos st sp val <&> \(st', _) ->
     ( M.insert
       k
-      (   toValue @(AttrSet v, AttrSet SourcePos)
-      =<< (, mempty)
-      <$> sequence st'
-      )
+      (toValue @(AttrSet v, AttrSet SourcePos) =<< (, mempty) <$> sequence st')
       st
     , M.insert k pos sp
     )

--- a/src/Nix/Exec.hs
+++ b/src/Nix/Exec.hs
@@ -818,7 +818,7 @@ findPathBy finder l name = do
   resolvePath s = case M.lookup "path" s of
     Just t  -> return t
     Nothing -> case M.lookup "uri" s of
-      Just ut -> defer $ fetchTarball (demand ut pure)
+      Just ut -> defer $ fetchTarball ut
       Nothing ->
         throwError
           $  ErrorCall
@@ -893,8 +893,8 @@ evalExprLoc expr = do
   raise k f x = ReaderT $ \e -> k (\t -> runReaderT (f t) e) x
 
 fetchTarball
-  :: forall e t f m . MonadNix e t f m => m (NValue t f m) -> m (NValue t f m)
-fetchTarball v = v >>= \case
+  :: forall e t f m . MonadNix e t f m => NValue t f m -> m (NValue t f m)
+fetchTarball = flip demand $ \case
   NVSet s _ -> case M.lookup "url" s of
     Nothing ->
       throwError $ ErrorCall "builtins.fetchTarball: Missing url attribute"

--- a/src/Nix/Exec.hs
+++ b/src/Nix/Exec.hs
@@ -553,7 +553,7 @@ coerceToString
   -> m NixString
 coerceToString ctsm clevel = go
  where
-  go = \case
+  go x = demand x $ \case
     NVConstant (NBool b)
       |
         -- TODO Return a singleton for "" and "1"
@@ -734,10 +734,9 @@ instance ( MonadFix m
 
       coerceNixList :: NValue t f (Lazy t f m) -> Lazy t f m (NValue t f (Lazy t f m))
       coerceNixList v = do
-        xs :: [NValue t f (Lazy t f m)] <- fromValue @[NValue t f (Lazy t f m)] v
-        ys :: [NValue t f (Lazy t f m)] <- traverse (\x -> demand x coerceNix) xs
-        v' :: NValue t f (Lazy t f m)   <- toValue @[NValue t f (Lazy t f m)] ys
-        return v'
+        xs <- fromValue @[NValue t f (Lazy t f m)] v
+        ys <- traverse (\x -> demand x coerceNix) xs
+        toValue @[NValue t f (Lazy t f m)] ys
 
   traceEffect = putStrLn
 

--- a/src/Nix/Expr/Types.hs
+++ b/src/Nix/Expr/Types.hs
@@ -573,6 +573,3 @@ stripPositionInfo = transport phi
 
 nullPos :: SourcePos
 nullPos = SourcePos "<string>" (mkPos 1) (mkPos 1)
-
-
-

--- a/src/Nix/Fresh.hs
+++ b/src/Nix/Fresh.hs
@@ -104,10 +104,3 @@ instance MonadAtomicRef (ST s) where
     let (a, b) = f v
     writeRef r $! a
     return b
-
-
-
-
-
-
-

--- a/src/Nix/Fresh/Basic.hs
+++ b/src/Nix/Fresh/Basic.hs
@@ -45,4 +45,3 @@ instance (MonadEffects t f m, MonadDataContext f m)
     p <- lift $ derivationStrict @t @f @m (unliftNValue (runFreshIdT i) v)
     return $ liftNValue (runFreshIdT i) p
   traceEffect = lift . traceEffect @t @f @m
-

--- a/src/Nix/Fresh/Basic.hs
+++ b/src/Nix/Fresh/Basic.hs
@@ -31,7 +31,10 @@ instance (MonadEffects t f m, MonadDataContext f m)
   => MonadEffects t f (StdIdT m) where
   makeAbsolutePath = lift . makeAbsolutePath @t @f @m
   findEnvPath      = lift . findEnvPath @t @f @m
-  findPath         = (lift .) . findPath @t @f @m
+  findPath vs path = do
+    i <- FreshIdT ask
+    let vs' = map (unliftNValue (runFreshIdT i)) vs
+    lift $ findPath @t @f @m vs' path
   importPath path = do
     i <- FreshIdT ask
     p <- lift $ importPath @t @f @m path

--- a/src/Nix/Json.hs
+++ b/src/Nix/Json.hs
@@ -18,9 +18,9 @@ import           Nix.Effects
 import           Nix.Exec
 import           Nix.Frames
 import           Nix.String
-import           Nix.Thunk
 import           Nix.Utils
 import           Nix.Value
+import           Nix.Value.Monad
 
 nvalueToJSONNixString :: MonadNix e t f m => NValue t f m -> m NixString
 nvalueToJSONNixString =
@@ -43,11 +43,11 @@ nvalueToJSON = \case
   NVList l ->
     A.Array
       .   V.fromList
-      <$> traverse (join . lift . flip force (return . nvalueToJSON)) l
+      <$> traverse (join . lift . flip demand (return . nvalueToJSON)) l
   NVSet m _ -> case HM.lookup "outPath" m of
     Nothing ->
-      A.Object <$> traverse (join . lift . flip force (return . nvalueToJSON)) m
-    Just outPath -> join $ lift $ force outPath (return . nvalueToJSON)
+      A.Object <$> traverse (join . lift . flip demand (return . nvalueToJSON)) m
+    Just outPath -> join $ lift $ demand outPath (return . nvalueToJSON)
   NVPath p -> do
     fp <- lift $ unStorePath <$> addPath p
     addSingletonStringContext $ StringContext (Text.pack fp) DirectPath

--- a/src/Nix/Json.hs
+++ b/src/Nix/Json.hs
@@ -46,7 +46,8 @@ nvalueToJSON = \case
       <$> traverse (join . lift . flip demand (return . nvalueToJSON)) l
   NVSet m _ -> case HM.lookup "outPath" m of
     Nothing ->
-      A.Object <$> traverse (join . lift . flip demand (return . nvalueToJSON)) m
+      A.Object
+        <$> traverse (join . lift . flip demand (return . nvalueToJSON)) m
     Just outPath -> join $ lift $ demand outPath (return . nvalueToJSON)
   NVPath p -> do
     fp <- lift $ unStorePath <$> addPath p

--- a/src/Nix/Lint.hs
+++ b/src/Nix/Lint.hs
@@ -49,10 +49,11 @@ import           Nix.Fresh
 import           Nix.String
 import           Nix.Options
 import           Nix.Scope
-import           Nix.Thunk
-import           Nix.Thunk.Basic
+-- import           Nix.Thunk
+-- import           Nix.Thunk.Basic
 import           Nix.Utils
 import           Nix.Var
+import           Nix.Value.Monad
 
 data TAtom
   = TInt
@@ -68,7 +69,7 @@ data NTypeF (m :: * -> *) r
     | TSet (Maybe (HashMap Text r))
     | TClosure (Params ())
     | TPath
-    | TBuiltin String (SThunk m -> m (Symbolic m))
+    | TBuiltin String (Symbolic m -> m r)
     deriving Functor
 
 compareTypes :: NTypeF m r -> NTypeF m r -> Ordering
@@ -97,10 +98,10 @@ data NSymbolicF r
     | NMany [r]
     deriving (Show, Eq, Ord, Functor, Foldable, Traversable)
 
-newtype SThunk m = SThunk { getSThunk :: NThunkF m (Symbolic m) }
+-- newtype SThunk m = SThunk { getSThunk :: NThunkF m (Symbolic m) }
 
 newtype Symbolic m =
-    Symbolic { getSymbolic :: Var m (NSymbolicF (NTypeF m (SThunk m))) }
+    Symbolic { getSymbolic :: Var m (NSymbolicF (NTypeF m (Symbolic m))) }
 
 instance Show (Symbolic m) where
   show _ = "<symbolic>"
@@ -108,18 +109,18 @@ instance Show (Symbolic m) where
 everyPossible :: MonadVar m => m (Symbolic m)
 everyPossible = packSymbolic NAny
 
-mkSymbolic :: MonadVar m => [NTypeF m (SThunk m)] -> m (Symbolic m)
+mkSymbolic :: MonadVar m => [NTypeF m (Symbolic m)] -> m (Symbolic m)
 mkSymbolic xs = packSymbolic (NMany xs)
 
-packSymbolic :: MonadVar m => NSymbolicF (NTypeF m (SThunk m)) -> m (Symbolic m)
+packSymbolic :: MonadVar m => NSymbolicF (NTypeF m (Symbolic m)) -> m (Symbolic m)
 packSymbolic = fmap coerce . newVar
 
 unpackSymbolic
-  :: MonadVar m => Symbolic m -> m (NSymbolicF (NTypeF m (SThunk m)))
+  :: MonadVar m => Symbolic m -> m (NSymbolicF (NTypeF m (Symbolic m)))
 unpackSymbolic = readVar . coerce
 
 type MonadLint e m
-  = (Scoped (SThunk m) m, Framed e m, MonadVar m, MonadCatch m, MonadThunkId m)
+  = (Scoped (Symbolic m) m, Framed e m, MonadVar m, MonadCatch m {-, MonadThunkId m-})
 
 symerr :: forall e m a . MonadLint e m => String -> m a
 symerr = evalError @(Symbolic m) . ErrorCall
@@ -135,11 +136,11 @@ renderSymbolic = unpackSymbolic >=> \case
       TNull  -> return "null"
     TStr    -> return "string"
     TList r -> do
-      x <- force r renderSymbolic
+      x <- demand r renderSymbolic
       return $ "[" ++ x ++ "]"
     TSet Nothing  -> return "<any set>"
     TSet (Just s) -> do
-      x <- traverse (`force` renderSymbolic) s
+      x <- traverse (`demand` renderSymbolic) s
       return $ "{" ++ show x ++ "}"
     f@(TClosure p) -> do
       (args, sym) <- do
@@ -156,13 +157,13 @@ merge
   :: forall e m
    . MonadLint e m
   => NExprF ()
-  -> [NTypeF m (SThunk m)]
-  -> [NTypeF m (SThunk m)]
-  -> m [NTypeF m (SThunk m)]
+  -> [NTypeF m (Symbolic m)]
+  -> [NTypeF m (Symbolic m)]
+  -> m [NTypeF m (Symbolic m)]
 merge context = go
  where
   go
-    :: [NTypeF m (SThunk m)] -> [NTypeF m (SThunk m)] -> m [NTypeF m (SThunk m)]
+    :: [NTypeF m (Symbolic m)] -> [NTypeF m (Symbolic m)] -> m [NTypeF m (Symbolic m)]
   go []       _        = return []
   go _        []       = return []
   go (x : xs) (y : ys) = case (x, y) of
@@ -170,8 +171,8 @@ merge context = go
     (TPath, TPath) -> (TPath :) <$> go xs ys
     (TConstant ls, TConstant rs) ->
       (TConstant (ls `intersect` rs) :) <$> go xs ys
-    (TList l, TList r) -> force l $ \l' -> force r $ \r' -> do
-      m <- thunk $ unify context l' r'
+    (TList l, TList r) -> demand l $ \l' -> demand r $ \r' -> do
+      m <- defer $ unify context l' r'
       (TList m :) <$> go xs ys
     (TSet x       , TSet Nothing ) -> (TSet x :) <$> go xs ys
     (TSet Nothing , TSet x       ) -> (TSet x :) <$> go xs ys
@@ -179,8 +180,8 @@ merge context = go
       m <- sequenceA $ M.intersectionWith
         (\i j -> i >>= \i' ->
           j
-            >>= \j' -> force i'
-                  $ \i'' -> force j' $ \j'' -> thunk $ unify context i'' j''
+            >>= \j' -> demand i'
+                  $ \i'' -> demand j' $ \j'' -> defer $ unify context i'' j''
         )
         (return <$> l)
         (return <$> r)
@@ -249,14 +250,15 @@ unify context (Symbolic x) (Symbolic y) = do
 
 instance ToValue Bool m (Symbolic m) where
 
-instance ToValue [SThunk m] m (Symbolic m) where
+instance ToValue [Symbolic m] m (Symbolic m) where
 
 instance FromValue NixString m (Symbolic m) where
 
-instance FromValue (AttrSet (SThunk m), AttrSet SourcePos) m (Symbolic m) where
+instance FromValue (AttrSet (Symbolic m), AttrSet SourcePos) m (Symbolic m) where
 
-instance ToValue (AttrSet (SThunk m), AttrSet SourcePos) m (Symbolic m) where
+instance ToValue (AttrSet (Symbolic m), AttrSet SourcePos) m (Symbolic m) where
 
+{-
 instance MonadLint e m => MonadThunk (SThunk m) m (Symbolic m) where
   thunk   = fmap SThunk . thunk
   thunkId = thunkId . getSThunk
@@ -266,6 +268,11 @@ instance MonadLint e m => MonadThunk (SThunk m) m (Symbolic m) where
   forceEff  = forceEff . getSThunk
   wrapValue = SThunk . wrapValue
   getValue  = getValue . getSThunk
+-}
+
+instance MonadValue (Symbolic m) m where
+  defer = id
+  demand = flip ($)
 
 instance MonadLint e m => MonadEval (Symbolic m) m where
   freeVariable var = symerr $ "Undefined variable '" ++ Text.unpack var ++ "'"
@@ -285,9 +292,9 @@ instance MonadLint e m => MonadEval (Symbolic m) m where
       ++ show s
 
   evalCurPos = do
-    f <- wrapValue <$> mkSymbolic [TPath]
-    l <- wrapValue <$> mkSymbolic [TConstant [TInt]]
-    c <- wrapValue <$> mkSymbolic [TConstant [TInt]]
+    f <- mkSymbolic [TPath]
+    l <- mkSymbolic [TConstant [TInt]]
+    c <- mkSymbolic [TConstant [TInt]]
     mkSymbolic [TSet (Just (M.fromList (go f l c)))]
    where
     go f l c =
@@ -315,8 +322,8 @@ instance MonadLint e m => MonadEval (Symbolic m) m where
   -- sure the action it evaluates is to force a thunk, so its value is only
   -- computed once.
   evalWith scope body = do
-    s <- thunk @(SThunk m) @m @(Symbolic m) scope
-    pushWeakScope ?? body $ force s $ unpackSymbolic >=> \case
+    s <- defer scope
+    pushWeakScope ?? body $ demand s $ unpackSymbolic >=> \case
       NMany [TSet (Just s')] -> return s'
       NMany [TSet Nothing] -> error "NYI: with unknown"
       _ -> throwError $ ErrorCall "scope must be a set in with statement"
@@ -348,7 +355,7 @@ lintBinaryOp
   -> m (Symbolic m)
 lintBinaryOp op lsym rarg = do
   rsym <- rarg
-  y    <- thunk everyPossible
+  y    <- defer everyPossible
   case op of
     NApp    -> symerr "lintBinaryOp:NApp: should never get here"
     NEq     -> check lsym rsym [TConstant [TInt, TBool, TNull], TStr, TList y]
@@ -409,14 +416,14 @@ lintApp context fun arg = unpackSymbolic fun >>= \case
     (head args, ) <$> foldM (unify context) y ys
 
 newtype Lint s a = Lint
-  { runLint :: ReaderT (Context (Lint s) (SThunk (Lint s))) (FreshIdT Int (ST s)) a }
+  { runLint :: ReaderT (Context (Lint s) (Symbolic (Lint s))) (FreshIdT Int (ST s)) a }
   deriving
     ( Functor
     , Applicative
     , Monad
     , MonadFix
-    , MonadReader (Context (Lint s) (SThunk (Lint s)))
-    , MonadThunkId
+    , MonadReader (Context (Lint s) (Symbolic (Lint s)))
+    -- , MonadThunkId
     , MonadRef
     , MonadAtomicRef
     )
@@ -432,7 +439,7 @@ runLintM opts action = do
   i <- newVar (1 :: Int)
   runFreshIdT i $ flip runReaderT (newContext opts) $ runLint action
 
-symbolicBaseEnv :: Monad m => m (Scopes m (SThunk m))
+symbolicBaseEnv :: Monad m => m (Scopes m (Symbolic m))
 symbolicBaseEnv = return emptyScopes
 
 lint :: Options -> NExprLoc -> ST s (Symbolic (Lint s))
@@ -444,8 +451,8 @@ lint opts expr =
                           expr
         )
 
-instance Scoped (SThunk (Lint s)) (Lint s) where
+instance Scoped (Symbolic (Lint s)) (Lint s) where
   currentScopes = currentScopesReader
-  clearScopes   = clearScopesReader @(Lint s) @(SThunk (Lint s))
+  clearScopes   = clearScopesReader @(Lint s) @(Symbolic (Lint s))
   pushScopes    = pushScopesReader
   lookupVar     = lookupVarReader

--- a/src/Nix/Lint.hs
+++ b/src/Nix/Lint.hs
@@ -112,16 +112,23 @@ everyPossible = packSymbolic NAny
 mkSymbolic :: MonadVar m => [NTypeF m (Symbolic m)] -> m (Symbolic m)
 mkSymbolic xs = packSymbolic (NMany xs)
 
-packSymbolic :: MonadVar m
-             => NSymbolicF (NTypeF m (Symbolic m)) -> m (Symbolic m)
+packSymbolic
+  :: MonadVar m => NSymbolicF (NTypeF m (Symbolic m)) -> m (Symbolic m)
 packSymbolic = fmap SV . newVar
 
-unpackSymbolic :: (MonadVar m, MonadThunkId m, MonadCatch m)
-               => Symbolic m -> m (NSymbolicF (NTypeF m (Symbolic m)))
+unpackSymbolic
+  :: (MonadVar m, MonadThunkId m, MonadCatch m)
+  => Symbolic m
+  -> m (NSymbolicF (NTypeF m (Symbolic m)))
 unpackSymbolic = flip demand $ readVar . getSV
 
 type MonadLint e m
-  = (Scoped (Symbolic m) m, Framed e m, MonadVar m, MonadCatch m, MonadThunkId m)
+  = ( Scoped (Symbolic m) m
+  , Framed e m
+  , MonadVar m
+  , MonadCatch m
+  , MonadThunkId m
+  )
 
 symerr :: forall e m a . MonadLint e m => String -> m a
 symerr = evalError @(Symbolic m) . ErrorCall
@@ -164,7 +171,9 @@ merge
 merge context = go
  where
   go
-    :: [NTypeF m (Symbolic m)] -> [NTypeF m (Symbolic m)] -> m [NTypeF m (Symbolic m)]
+    :: [NTypeF m (Symbolic m)]
+    -> [NTypeF m (Symbolic m)]
+    -> m [NTypeF m (Symbolic m)]
   go []       _        = return []
   go _        []       = return []
   go (x : xs) (y : ys) = case (x, y) of

--- a/src/Nix/Normal.hs
+++ b/src/Nix/Normal.hs
@@ -75,20 +75,21 @@ normalize f = run . iterNValueM run go (fmap Free . sequenceNValue' run)
 
 stubCycles
   :: forall t f m
-  . ( Applicative f
-    , Functor m
-    , HasCitations m (NValue t f m) t
-    , HasCitations1 m (NValue t f m) f
-    )
-  => NValue t f m -> NValueNF t f m
-stubCycles = freeToFix $ \t -> Fix
-  $ NValue
-  $ Prelude.foldr (addProvenance1 @m @(NValue t f m)) cyc
-  $ reverse
-  $ citations @m @(NValue t f m) t
-  where
-  Fix (NValue cyc) =
-    nvStrNF (principledMakeNixStringWithoutContext "<CYCLE>")
+   . ( Applicative f
+     , Functor m
+     , HasCitations m (NValue t f m) t
+     , HasCitations1 m (NValue t f m) f
+     )
+  => NValue t f m
+  -> NValueNF t f m
+stubCycles = freeToFix $ \t ->
+  Fix
+    $ NValue
+    $ Prelude.foldr (addProvenance1 @m @(NValue t f m)) cyc
+    $ reverse
+    $ citations @m @(NValue t f m) t
+ where
+  Fix (NValue cyc) = nvStrNF (principledMakeNixStringWithoutContext "<CYCLE>")
 
 normalForm
   :: ( Framed e m

--- a/src/Nix/Normal.hs
+++ b/src/Nix/Normal.hs
@@ -13,21 +13,26 @@
 module Nix.Normal where
 
 import           Control.Monad
+import           Control.Monad.Free
 import           Control.Monad.Trans.Class
 import           Control.Monad.Trans.Reader
 import           Control.Monad.Trans.State
+import           Data.Fix
 import           Data.Set
+import           Nix.Cited
 import           Nix.Frames
 import           Nix.String
 import           Nix.Thunk
 import           Nix.Value
+import           Nix.Utils
 
 newtype NormalLoop t f m = NormalLoop (NValue t f m)
     deriving Show
 
 instance MonadDataErrorContext t f m => Exception (NormalLoop t f m)
 
-normalForm'
+-- | Normalize the value as much as possible, leaving only detected cycles.
+normalize
   :: forall e t m f
    . ( Framed e m
      , MonadThunk t m (NValue t f m)
@@ -36,8 +41,8 @@ normalForm'
      )
   => (forall r . t -> (NValue t f m -> m r) -> m r)
   -> NValue t f m
-  -> m (NValueNF t f m)
-normalForm' f = run . nValueToNFM run go
+  -> m (NValue t f m)
+normalize f = run . iterNValueM run go (fmap Free . sequenceNValue' run)
  where
   start = 0 :: Int
   table = mempty
@@ -48,39 +53,54 @@ normalForm' f = run . nValueToNFM run go
   go
     :: t
     -> (  NValue t f m
-       -> ReaderT Int (StateT (Set (ThunkId m)) m) (NValueNF t f m)
+       -> ReaderT Int (StateT (Set (ThunkId m)) m) (NValue t f m)
        )
-    -> ReaderT Int (StateT (Set (ThunkId m)) m) (NValueNF t f m)
+    -> ReaderT Int (StateT (Set (ThunkId m)) m) (NValue t f m)
   go t k = do
     b <- seen t
     if b
-      then return $ pure t
+      then return $ Pure t
       else do
         i <- ask
         when (i > 2000)
           $ error "Exceeded maximum normalization depth of 2000 levels"
-        s         <- lift get
-        (res, s') <- lift $ lift $ f t $ \v ->
-          (`runStateT` s) . (`runReaderT` i) $ local succ $ k v
-        lift $ put s'
-        return res
+        lifted (lifted (f t)) $ local succ . k
 
-  seen t = case thunkId t of
-    Just tid -> lift $ do
+  seen t = do
+    let tid = thunkId t
+    lift $ do
       res <- gets (member tid)
       unless res $ modify (insert tid)
       return res
-    Nothing -> return False
+
+stubCycles
+  :: forall t f m
+  . ( Applicative f
+    , Functor m
+    , HasCitations m (NValue t f m) t
+    , HasCitations1 m (NValue t f m) f
+    )
+  => NValue t f m -> NValueNF t f m
+stubCycles = freeToFix $ \t -> Fix
+  $ NValue
+  $ Prelude.foldr (addProvenance1 @m @(NValue t f m)) cyc
+  $ reverse
+  $ citations @m @(NValue t f m) t
+  where
+  Fix (NValue cyc) =
+    nvStrNF (principledMakeNixStringWithoutContext "<CYCLE>")
 
 normalForm
   :: ( Framed e m
      , MonadThunk t m (NValue t f m)
      , MonadDataErrorContext t f m
+     , HasCitations m (NValue t f m) t
+     , HasCitations1 m (NValue t f m) f
      , Ord (ThunkId m)
      )
   => NValue t f m
   -> m (NValueNF t f m)
-normalForm = normalForm' force
+normalForm = fmap stubCycles . normalize force
 
 normalForm_
   :: ( Framed e m
@@ -90,19 +110,13 @@ normalForm_
      )
   => NValue t f m
   -> m ()
-normalForm_ = void <$> normalForm' forceEff
+normalForm_ = void <$> normalize forceEff
 
 removeEffects
   :: (MonadThunk t m (NValue t f m), MonadDataContext f m)
   => NValue t f m
-  -> NValueNF t f m
-removeEffects = nValueToNF (flip query opaque)
-
-removeEffectsM
-  :: (MonadThunk t m (NValue t f m), MonadDataContext f m)
-  => NValue t f m
   -> m (NValueNF t f m)
-removeEffectsM = nValueToNFM id (flip queryM (pure opaque))
+removeEffects = nValueToNFM id (flip queryM (pure opaque))
 
 opaque
   :: (MonadThunk t m (NValue t f m), MonadDataContext f m) => NValueNF t f m
@@ -112,4 +126,4 @@ dethunk
   :: (MonadThunk t m (NValue t f m), MonadDataContext f m)
   => t
   -> m (NValueNF t f m)
-dethunk t = queryM t (pure opaque) removeEffectsM
+dethunk t = queryM t (pure opaque) removeEffects

--- a/src/Nix/Parser.hs
+++ b/src/Nix/Parser.hs
@@ -664,11 +664,3 @@ getSpecialOperator o         = m Map.! o where
   buildEntry i = concatMap $ \case
     (NSpecialDef name op assoc, _) -> [(op, OperatorInfo i assoc name)]
     _                              -> []
-
-
-
-
-
-
-
-

--- a/src/Nix/Pretty.hs
+++ b/src/Nix/Pretty.hs
@@ -343,9 +343,10 @@ valueToExpr = iterNValueNF phi
 
   mkStr ns = Fix $ NStr $ DoubleQuoted [Plain (hackyStringIgnoreContext ns)]
 
-prettyNValueNF :: MonadDataContext f m => NValueNF t f m -> Doc ann
+prettyNValueNF :: forall t f m ann. MonadDataContext f m => NValueNF t f m -> Doc ann
 prettyNValueNF = prettyNix . valueToExpr
 
+-- | This function is used only by the testing code.
 printNix :: forall t f m . MonadDataContext f m => NValueNF t f m -> String
 printNix = iterNValueNF phi
  where
@@ -424,11 +425,3 @@ prettyNThunk t = do
       $ "thunk from: "
       : map (prettyOriginExpr . _originExpr) ps
       ]
-
-
-
-
-
-
-
-

--- a/src/Nix/Pretty.hs
+++ b/src/Nix/Pretty.hs
@@ -18,6 +18,7 @@ module Nix.Pretty where
 
 import           Control.Applicative            ( (<|>) )
 import           Control.Comonad
+import           Control.Monad.Free
 import           Data.Fix
 import           Data.HashMap.Lazy              ( toList )
 import qualified Data.HashMap.Lazy             as M
@@ -192,14 +193,25 @@ prettyAtom atom = simpleExpr $ pretty $ unpack $ atomText atom
 prettyNix :: NExpr -> Doc ann
 prettyNix = withoutParens . cata exprFNixDoc
 
-instance HasCitations1 t m v f
-  => HasCitations t m v (NValue' t f m a) where
+instance HasCitations1 m v f
+  => HasCitations m v (NValue' t f m a) where
   citations (NValue f) = citations1 f
   addProvenance x (NValue f) = NValue (addProvenance1 x f)
 
+instance (HasCitations1 m v f, HasCitations m v t)
+  => HasCitations m v (NValue t f m) where
+  citations (Pure t) = citations t
+  citations (Free v) = citations v
+  addProvenance x (Pure t) = Pure (addProvenance x t)
+  addProvenance x (Free v) = Free (addProvenance x v)
+
+instance HasCitations1 m v f => HasCitations m v (NValueNF t f m) where
+  citations (Fix v) = citations v
+  addProvenance x (Fix v) = Fix (addProvenance x v)
+
 prettyOriginExpr
   :: forall t f m ann
-   . HasCitations1 t m (NValue t f m) f
+   . HasCitations1 m (NValue t f m) f
   => NExprLocF (Maybe (NValue t f m))
   -> Doc ann
 prettyOriginExpr = withoutParens . go
@@ -208,7 +220,7 @@ prettyOriginExpr = withoutParens . go
 
   render :: Maybe (NValue t f m) -> NixDoc ann
   render Nothing = simpleExpr $ "_"
-  render (Just (reverse . citations @t @m -> p:_)) = go (_originExpr p)
+  render (Just (Free (reverse . citations @m -> p:_))) = go (_originExpr p)
   render _       = simpleExpr "?"
     -- render (Just (NValue (citations -> ps))) =
         -- simpleExpr $ foldr ((\x y -> vsep [x, y]) . parens . indent 2 . withoutParens
@@ -314,21 +326,19 @@ exprFNixDoc = \case
   where recPrefix = "rec" <> space
 
 valueToExpr :: forall t f m . MonadDataContext f m => NValueNF t f m -> NExpr
-valueToExpr = iterNValueNF
-  (const (mkStr (principledMakeNixStringWithoutContext "<CYCLE>")))
-  phi
+valueToExpr = iterNValueNF phi
  where
   phi :: NValue' t f m NExpr -> NExpr
-  phi (NVConstant a ) = Fix $ NConstant a
-  phi (NVStr      ns) = mkStr ns
-  phi (NVList     l ) = Fix $ NList l
-  phi (NVSet s p    ) = Fix $ NSet
+  phi (NVConstant' a ) = Fix $ NConstant a
+  phi (NVStr'      ns) = mkStr ns
+  phi (NVList'     l ) = Fix $ NList l
+  phi (NVSet' s p    ) = Fix $ NSet
     [ NamedVar (StaticKey k :| []) v (fromMaybe nullPos (M.lookup k p))
     | (k, v) <- toList s
     ]
-  phi (NVClosure _ _   ) = Fix . NSym . pack $ "<closure>"
-  phi (NVPath p        ) = Fix $ NLiteralPath p
-  phi (NVBuiltin name _) = Fix . NSym . pack $ "builtins." ++ name
+  phi (NVClosure' _ _   ) = Fix . NSym . pack $ "<closure>"
+  phi (NVPath' p        ) = Fix $ NLiteralPath p
+  phi (NVBuiltin' name _) = Fix . NSym . pack $ "builtins." ++ name
   phi _                  = error "Pattern synonyms foil completeness check"
 
   mkStr ns = Fix $ NStr $ DoubleQuoted [Plain (hackyStringIgnoreContext ns)]
@@ -337,13 +347,13 @@ prettyNValueNF :: MonadDataContext f m => NValueNF t f m -> Doc ann
 prettyNValueNF = prettyNix . valueToExpr
 
 printNix :: forall t f m . MonadDataContext f m => NValueNF t f m -> String
-printNix = iterNValueNF (const "<CYCLE>") phi
+printNix = iterNValueNF phi
  where
   phi :: NValue' t f m String -> String
-  phi (NVConstant a ) = unpack $ atomText a
-  phi (NVStr      ns) = show $ hackyStringIgnoreContext ns
-  phi (NVList     l ) = "[ " ++ unwords l ++ " ]"
-  phi (NVSet s _) =
+  phi (NVConstant' a ) = unpack $ atomText a
+  phi (NVStr'      ns) = show $ hackyStringIgnoreContext ns
+  phi (NVList'     l ) = "[ " ++ unwords l ++ " ]"
+  phi (NVSet' s _) =
     "{ "
       ++ concat
            [ check (unpack k) ++ " = " ++ v ++ "; "
@@ -357,27 +367,28 @@ printNix = iterNValueNF (const "<CYCLE>") phi
       <|> (fmap (surround . show) (readMaybe v :: Maybe Float))
       )
       where surround s = "\"" ++ s ++ "\""
-  phi NVClosure{}        = "<<lambda>>"
-  phi (NVPath fp       ) = fp
-  phi (NVBuiltin name _) = "<<builtin " ++ name ++ ">>"
+  phi NVClosure'{}        = "<<lambda>>"
+  phi (NVPath' fp       ) = fp
+  phi (NVBuiltin' name _) = "<<builtin " ++ name ++ ">>"
   phi _                  = error "Pattern synonyms foil completeness check"
 
 prettyNValue
   :: (MonadThunk t m (NValue t f m), MonadDataContext f m)
   => NValue t f m
   -> m (Doc ann)
-prettyNValue = fmap prettyNValueNF . removeEffectsM
+prettyNValue = fmap prettyNValueNF . removeEffects
 
 prettyNValueProv
   :: forall t f m ann
-   . ( HasCitations1 t m (NValue t f m) f
+   . ( HasCitations m (NValue t f m) t
+     , HasCitations1 m (NValue t f m) f
      , MonadThunk t m (NValue t f m)
      , MonadDataContext f m
      )
   => NValue t f m
   -> m (Doc ann)
-prettyNValueProv v@(NValue nv) = do
-  let ps = citations1 @t @m @(NValue t f m) @f nv
+prettyNValueProv v = do
+  let ps = citations @m @(NValue t f m) v
   case ps of
     [] -> prettyNValue v
     ps -> do
@@ -394,15 +405,15 @@ prettyNValueProv v@(NValue nv) = do
 
 prettyNThunk
   :: forall t f m ann
-   . ( HasCitations t m (NValue t f m) t
-     , HasCitations1 t m (NValue t f m) f
+   . ( HasCitations m (NValue t f m) t
+     , HasCitations1 m (NValue t f m) f
      , MonadThunk t m (NValue t f m)
      , MonadDataContext f m
      )
   => t
   -> m (Doc ann)
 prettyNThunk t = do
-  let ps = citations @t @m @(NValue t f m) @t t
+  let ps = citations @m @(NValue t f m) @t t
   v' <- prettyNValueNF <$> dethunk t
   pure
     $ fillSep

--- a/src/Nix/Pretty.hs
+++ b/src/Nix/Pretty.hs
@@ -339,11 +339,12 @@ valueToExpr = iterNValueNF phi
   phi (NVClosure' _ _   ) = Fix . NSym . pack $ "<closure>"
   phi (NVPath' p        ) = Fix $ NLiteralPath p
   phi (NVBuiltin' name _) = Fix . NSym . pack $ "builtins." ++ name
-  phi _                  = error "Pattern synonyms foil completeness check"
+  phi _                   = error "Pattern synonyms foil completeness check"
 
   mkStr ns = Fix $ NStr $ DoubleQuoted [Plain (hackyStringIgnoreContext ns)]
 
-prettyNValueNF :: forall t f m ann. MonadDataContext f m => NValueNF t f m -> Doc ann
+prettyNValueNF
+  :: forall t f m ann . MonadDataContext f m => NValueNF t f m -> Doc ann
 prettyNValueNF = prettyNix . valueToExpr
 
 -- | This function is used only by the testing code.
@@ -371,7 +372,7 @@ printNix = iterNValueNF phi
   phi NVClosure'{}        = "<<lambda>>"
   phi (NVPath' fp       ) = fp
   phi (NVBuiltin' name _) = "<<builtin " ++ name ++ ">>"
-  phi _                  = error "Pattern synonyms foil completeness check"
+  phi _                   = error "Pattern synonyms foil completeness check"
 
 prettyNValue
   :: (MonadThunk t m (NValue t f m), MonadDataContext f m)

--- a/src/Nix/Render/Frame.hs
+++ b/src/Nix/Render/Frame.hs
@@ -13,7 +13,6 @@
 
 module Nix.Render.Frame where
 
-import           Control.Monad.Free
 import           Control.Monad.Reader
 import           Data.Fix
 import           Data.Typeable

--- a/src/Nix/Render/Frame.hs
+++ b/src/Nix/Render/Frame.hs
@@ -239,11 +239,3 @@ renderNormalLoop level = fmap (: []) . \case
   NormalLoop v -> do
     v' <- renderValue level "" "" v
     pure $ "Infinite recursion during normalization forcing " <> v'
-
-
-
-
-
-
-
-

--- a/src/Nix/Render/Frame.hs
+++ b/src/Nix/Render/Frame.hs
@@ -159,16 +159,12 @@ renderExpr _level longLabel shortLabel e@(Fix (Compose (Ann _ x))) = do
 
 renderValueFrame
   :: forall e t f m ann
-  . ( MonadReader e m
-    , Has e Options
-    , MonadFile m
-    , MonadCitedThunks t f m
-    )
+   . (MonadReader e m, Has e Options, MonadFile m, MonadCitedThunks t f m)
   => NixLevel
   -> ValueFrame t f m
   -> m [Doc ann]
 renderValueFrame level = fmap (: []) . \case
-  ForcingThunk   _t  -> pure "ForcingThunk" -- jww (2019-03-18): NYI
+  ForcingThunk    _t -> pure "ForcingThunk" -- jww (2019-03-18): NYI
   ConcerningValue _v -> pure "ConcerningValue"
   Comparison     _ _ -> pure "Comparing"
   Addition       _ _ -> pure "Adding"
@@ -185,7 +181,7 @@ renderValueFrame level = fmap (: []) . \case
     v' <- renderValue level "" "" v
     pure $ "CoercionToJson " <> v'
   CoercionFromJson _j -> pure "CoercionFromJson"
-  Expectation   t  r  -> case getEitherOr r of
+  Expectation t r     -> case getEitherOr r of
     Left nf -> do
       let v' = prettyNValueNF @t @f @m nf
       pure $ "Saw " <> v' <> " but expected " <> pretty (describeValue t)
@@ -195,11 +191,7 @@ renderValueFrame level = fmap (: []) . \case
 
 renderValue
   :: forall e t f m ann
-  . ( MonadReader e m
-    , Has e Options
-    , MonadFile m
-    , MonadCitedThunks t f m
-    )
+   . (MonadReader e m, Has e Options, MonadFile m, MonadCitedThunks t f m)
   => NixLevel
   -> String
   -> String

--- a/src/Nix/Render/Frame.hs
+++ b/src/Nix/Render/Frame.hs
@@ -163,7 +163,7 @@ renderValueFrame
   -> ValueFrame t f m
   -> m [Doc ann]
 renderValueFrame level = fmap (: []) . \case
-  ForcingThunk       -> pure "ForcingThunk"
+  ForcingThunk   _t  -> pure "ForcingThunk" -- jww (2019-03-18): NYI
   ConcerningValue _v -> pure "ConcerningValue"
   Comparison     _ _ -> pure "Comparing"
   Addition       _ _ -> pure "Adding"
@@ -180,10 +180,9 @@ renderValueFrame level = fmap (: []) . \case
     v' <- renderValue level "" "" v
     pure $ "CoercionToJson " <> v'
   CoercionFromJson _j -> pure "CoercionFromJson"
-  ExpectationNF _t _v -> pure "ExpectationNF"
-  Expectation   t  v  -> do
-    v' <- renderValue level "" "" v
-    pure $ "Saw " <> v' <> " but expected " <> pretty (describeValue t)
+  Expectation   t  v  -> undefined {- jww (2019-03-18): NYI v -} -- do
+    -- v' <- renderValue level "" "" v
+    -- pure $ "Saw " <> v' <> " but expected " <> pretty (describeValue t)
 
 renderValue
   :: (MonadReader e m, Has e Options, MonadFile m, MonadCitedThunks t f m)

--- a/src/Nix/Thunk.hs
+++ b/src/Nix/Thunk.hs
@@ -29,18 +29,15 @@ class ( Monad m
       => m (ThunkId m)
   freshId = lift freshId
 
-class MonadThunkId m => MonadThunk t m v | t -> m, t -> v where
-    thunk :: m v -> m t
+class MonadThunkId m => MonadThunk t m a | t -> m, t -> a where
+    thunk :: m a -> m t
     -- | Return an identifier for the thunk unless it is a pure value (i.e.,
-    --   strictly an encapsulation of some 'v' without any additional
+    --   strictly an encapsulation of some 'a' without any additional
     --   structure). For pure values represented as thunks, returns Nothing.
-    thunkId :: t -> Maybe (ThunkId m)
-    query :: t -> r -> (v -> r) -> r
-    queryM :: t -> m r -> (v -> m r) -> m r
-    force :: t -> (v -> m r) -> m r
-    forceEff :: t -> (v -> m r) -> m r
-    wrapValue :: v -> t
-    getValue :: t -> Maybe v
+    thunkId :: t -> ThunkId m
+    queryM :: t -> m r -> (a -> m r) -> m r
+    force :: t -> (a -> m r) -> m r
+    forceEff :: t -> (a -> m r) -> m r
 
 newtype ThunkLoop = ThunkLoop String -- contains rendering of ThunkId
     deriving Typeable

--- a/src/Nix/Thunk.hs
+++ b/src/Nix/Thunk.hs
@@ -40,7 +40,7 @@ class MonadThunkId m => MonadThunk t m a | t -> m, t -> a where
     forceEff :: t -> (a -> m r) -> m r
     -- | Modify the action to be performed by the thunk. For some implicits
     --   this modifies the thunk, for others it may create a new thunk.
-    further :: t -> (m a -> m a) -> m t
+    -- further :: t -> (m a -> m a) -> m t
 
 newtype ThunkLoop = ThunkLoop String -- contains rendering of ThunkId
     deriving Typeable

--- a/src/Nix/Thunk.hs
+++ b/src/Nix/Thunk.hs
@@ -38,6 +38,9 @@ class MonadThunkId m => MonadThunk t m a | t -> m, t -> a where
     queryM :: t -> m r -> (a -> m r) -> m r
     force :: t -> (a -> m r) -> m r
     forceEff :: t -> (a -> m r) -> m r
+    -- | Modify the action to be performed by the thunk. For some implicits
+    --   this modifies the thunk, for others it may create a new thunk.
+    further :: t -> (m a -> m a) -> m t
 
 newtype ThunkLoop = ThunkLoop String -- contains rendering of ThunkId
     deriving Typeable

--- a/src/Nix/Thunk/Basic.hs
+++ b/src/Nix/Thunk/Basic.hs
@@ -39,11 +39,11 @@ type MonadBasicThunk m = (MonadThunkId m, MonadVar m)
 
 instance (MonadBasicThunk m, MonadCatch m)
   => MonadThunk (NThunkF m v) m v where
-  thunk   = buildThunk
+  thunk = buildThunk
   thunkId (Thunk n _ _) = n
-  queryM    = queryThunk
-  force     = forceThunk
-  forceEff  = forceEffects
+  queryM   = queryThunk
+  force    = forceThunk
+  forceEff = forceEffects
 
 buildThunk :: MonadBasicThunk m => m v -> m (NThunkF m v)
 buildThunk action = do

--- a/src/Nix/Thunk/Basic.hs
+++ b/src/Nix/Thunk/Basic.hs
@@ -27,16 +27,12 @@ data Deferred m v = Deferred (m v) | Computed v
 
 -- | The type of very basic thunks
 data NThunkF m v
-    = Value v
-    | Thunk (ThunkId m) (Var m Bool) (Var m (Deferred m v))
+    = Thunk (ThunkId m) (Var m Bool) (Var m (Deferred m v))
 
 instance (Eq v, Eq (ThunkId m)) => Eq (NThunkF m v) where
-  Value x     == Value y     = x == y
   Thunk x _ _ == Thunk y _ _ = x == y
-  _           == _           = False              -- jww (2019-03-16): not accurate...
 
 instance Show v => Show (NThunkF m v) where
-  show (Value v    ) = show v
   show (Thunk _ _ _) = "<thunk>"
 
 type MonadBasicThunk m = (MonadThunkId m, MonadVar m)
@@ -44,34 +40,17 @@ type MonadBasicThunk m = (MonadThunkId m, MonadVar m)
 instance (MonadBasicThunk m, MonadCatch m)
   => MonadThunk (NThunkF m v) m v where
   thunk   = buildThunk
-  thunkId = \case
-    Value _     -> Nothing
-    Thunk n _ _ -> Just n
-  query     = queryValue
+  thunkId (Thunk n _ _) = n
   queryM    = queryThunk
   force     = forceThunk
   forceEff  = forceEffects
-  wrapValue = valueRef
-  getValue  = thunkValue
-
-valueRef :: v -> NThunkF m v
-valueRef = Value
-
-thunkValue :: NThunkF m v -> Maybe v
-thunkValue (Value v) = Just v
-thunkValue _         = Nothing
 
 buildThunk :: MonadBasicThunk m => m v -> m (NThunkF m v)
 buildThunk action = do
   freshThunkId <- freshId
   Thunk freshThunkId <$> newVar False <*> newVar (Deferred action)
 
-queryValue :: MonadVar m => NThunkF m v -> a -> (v -> a) -> a
-queryValue (Value v) _ k = k v
-queryValue _         n _ = n
-
 queryThunk :: MonadVar m => NThunkF m v -> m a -> (v -> m a) -> m a
-queryThunk (Value v           ) _ k = k v
 queryThunk (Thunk _ active ref) n k = do
   nowActive <- atomicModifyVar active (True, )
   if nowActive
@@ -90,7 +69,6 @@ forceThunk
   => NThunkF m v
   -> (v -> m a)
   -> m a
-forceThunk (Value v           ) k = k v
 forceThunk (Thunk n active ref) k = do
   eres <- readVar ref
   case eres of
@@ -109,7 +87,6 @@ forceThunk (Thunk n active ref) k = do
           k v
 
 forceEffects :: MonadVar m => NThunkF m v -> (v -> m r) -> m r
-forceEffects (Value v           ) k = k v
 forceEffects (Thunk _ active ref) k = do
   nowActive <- atomicModifyVar active (True, )
   if nowActive

--- a/src/Nix/Thunk/Standard.hs
+++ b/src/Nix/Thunk/Standard.hs
@@ -106,3 +106,8 @@ runStandard opts action = do
 
 runStandardIO :: Options -> StdLazy StdIdT IO a -> IO a
 runStandardIO = runStandard
+
+whileForcingThunk
+  :: forall t f m s e r . (Exception s, Convertible e t f m) => s -> m r -> m r
+whileForcingThunk frame =
+  withFrame Debug (ForcingThunk @t @f @m) . withFrame Debug frame

--- a/src/Nix/Thunk/Standard.hs
+++ b/src/Nix/Thunk/Standard.hs
@@ -78,8 +78,8 @@ instance ( MonadStdThunk (u m)
   thunk   = fmap (StdThunk . StdCited) . thunk
   thunkId = thunkId . _stdCited . _stdThunk
   queryM x b f = queryM (_stdCited (_stdThunk x)) b f
-  force     = force . _stdCited . _stdThunk
-  forceEff  = forceEff . _stdCited . _stdThunk
+  force    = force . _stdCited . _stdThunk
+  forceEff = forceEff . _stdCited . _stdThunk
   -- query x b f = query (_stdCited (_stdThunk x)) b f
   -- wrapValue = StdThunk . StdCited . wrapValue
   -- getValue  = getValue . _stdCited . _stdThunk

--- a/src/Nix/Thunk/Standard.hs
+++ b/src/Nix/Thunk/Standard.hs
@@ -51,7 +51,7 @@ newtype StdCited u m a = StdCited
         , Foldable
         , Traversable
         , Comonad
-        , ComonadEnv [Provenance (StdThunk u m) (StdLazy u m) (StdValue u m)]
+        , ComonadEnv [Provenance (StdLazy u m) (StdValue u m)]
         )
 
 type StdValue u m = NValue (StdThunk u m) (StdCited u m) (StdLazy u m)
@@ -75,14 +75,14 @@ instance ( MonadStdThunk (u m)
   => MonadThunk (StdThunk u m) (StdLazy u m) (StdValue u m) where
   thunk   = fmap (StdThunk . StdCited) . thunk
   thunkId = thunkId . _stdCited . _stdThunk
-  query x b f = query (_stdCited (_stdThunk x)) b f
   queryM x b f = queryM (_stdCited (_stdThunk x)) b f
   force     = force . _stdCited . _stdThunk
   forceEff  = forceEff . _stdCited . _stdThunk
-  wrapValue = StdThunk . StdCited . wrapValue
-  getValue  = getValue . _stdCited . _stdThunk
+  -- query x b f = query (_stdCited (_stdThunk x)) b f
+  -- wrapValue = StdThunk . StdCited . wrapValue
+  -- getValue  = getValue . _stdCited . _stdThunk
 
-instance HasCitations1 (StdThunk u m) (StdLazy u m) (StdValue u m) (StdCited u m) where
+instance HasCitations1 (StdLazy u m) (StdValue u m) (StdCited u m) where
   citations1 (StdCited c) = citations1 c
   addProvenance1 x (StdCited c) = StdCited (addProvenance1 x c)
 

--- a/src/Nix/Type/Infer.hs
+++ b/src/Nix/Type/Infer.hs
@@ -59,13 +59,14 @@ import           Nix.Expr.Types.Annotated
 import           Nix.Fresh
 import           Nix.String
 import           Nix.Scope
-import           Nix.Thunk
-import           Nix.Thunk.Basic
+-- import           Nix.Thunk
+-- import           Nix.Thunk.Basic
 import qualified Nix.Type.Assumption           as As
 import           Nix.Type.Env
 import qualified Nix.Type.Env                  as Env
 import           Nix.Type.Type
 import           Nix.Utils
+import           Nix.Value.Monad
 import           Nix.Var
 
 -------------------------------------------------------------------------------
@@ -75,7 +76,7 @@ import           Nix.Var
 -- | Inference monad
 newtype InferT s m a = InferT
     { getInfer ::
-        ReaderT (Set.Set TVar, Scopes (InferT s m) (JThunkT s m))
+        ReaderT (Set.Set TVar, Scopes (InferT s m) (Judgment s))
             (StateT InferState (ExceptT InferError m)) a
     }
     deriving
@@ -85,7 +86,7 @@ newtype InferT s m a = InferT
         , Monad
         , MonadPlus
         , MonadFix
-        , MonadReader (Set.Set TVar, Scopes (InferT s m) (JThunkT s m))
+        , MonadReader (Set.Set TVar, Scopes (InferT s m) (Judgment s))
         , MonadFail
         , MonadState InferState
         , MonadError InferError
@@ -94,8 +95,8 @@ newtype InferT s m a = InferT
 instance MonadTrans (InferT s) where
   lift = InferT . lift . lift . lift
 
-instance MonadThunkId m => MonadThunkId (InferT s m) where
-  type ThunkId (InferT s m) = ThunkId m
+-- instance MonadThunkId m => MonadThunkId (InferT s m) where
+--   type ThunkId (InferT s m) = ThunkId m
 
 -- | Inference state
 newtype InferState = InferState { count :: Int }
@@ -389,7 +390,7 @@ instance MonadAtomicRef m => MonadAtomicRef (InferT s m) where
     _   <- modifyRef x (fst . f)
     return res
 
-newtype JThunkT s m = JThunk (NThunkF (InferT s m) (Judgment s))
+-- newtype JThunkT s m = JThunk (NThunkF (InferT s m) (Judgment s))
 
 instance Monad m => MonadThrow (InferT s m) where
   throwM = throwError . EvaluationError
@@ -402,27 +403,30 @@ instance Monad m => MonadCatch (InferT s m) where
       (fromException (toException e))
     err -> error $ "Unexpected error: " ++ show err
 
-type MonadInfer m = (MonadThunkId m, MonadVar m, MonadFix m)
+type MonadInfer m = ({- MonadThunkId m,-} MonadVar m, MonadFix m)
 
+instance MonadValue (Judgment s) (InferT s m) where
+  defer = id
+  demand = flip ($)
+
+{-
 instance MonadInfer m
   => MonadThunk (JThunkT s m) (InferT s m) (Judgment s) where
   thunk = fmap JThunk . thunk
   thunkId (JThunk x) = thunkId x
 
-  query (JThunk x) b f = query x b f
   queryM (JThunk x) b f = queryM x b f
 
+  -- If we have a thunk loop, we just don't know the type.
   force (JThunk t) f = catch (force t f)
     $ \(_ :: ThunkLoop) ->
--- If we have a thunk loop, we just don't know the type.
-                           f =<< Judgment As.empty [] <$> fresh
-  forceEff (JThunk t) f = catch (forceEff t f)
-    $ \(_ :: ThunkLoop) ->
--- If we have a thunk loop, we just don't know the type.
                            f =<< Judgment As.empty [] <$> fresh
 
-  wrapValue = JThunk . wrapValue
-  getValue (JThunk x) = getValue x
+  -- If we have a thunk loop, we just don't know the type.
+  forceEff (JThunk t) f = catch (forceEff t f)
+    $ \(_ :: ThunkLoop) ->
+                           f =<< Judgment As.empty [] <$> fresh
+-}
 
 instance MonadInfer m => MonadEval (Judgment s) (InferT s m) where
   freeVariable var = do
@@ -531,33 +535,33 @@ instance Monad m => FromValue NixString (InferT s m) (Judgment s) where
   fromValue _ = error "Unused"
 
 instance MonadInfer m
-  => FromValue (AttrSet (JThunkT s m), AttrSet SourcePos)
+  => FromValue (AttrSet (Judgment s), AttrSet SourcePos)
               (InferT s m) (Judgment s) where
   fromValueMay (Judgment _ _ (TSet _ xs)) = do
     let sing _ = Judgment As.empty []
-    pure $ Just (M.mapWithKey (\k v -> wrapValue (sing k v)) xs, M.empty)
+    pure $ Just (M.mapWithKey sing xs, M.empty)
   fromValueMay _ = pure Nothing
   fromValue = fromValueMay >=> \case
     Just v  -> pure v
     Nothing -> pure (M.empty, M.empty)
 
 instance MonadInfer m
-  => ToValue (AttrSet (JThunkT s m), AttrSet SourcePos)
+  => ToValue (AttrSet (Judgment s), AttrSet SourcePos)
             (InferT s m) (Judgment s) where
   toValue (xs, _) =
     Judgment
       <$> foldrM go As.empty xs
-      <*> (concat <$> traverse (`force` (pure . typeConstraints)) xs)
-      <*> (TSet True <$> traverse (`force` (pure . inferredType)) xs)
-    where go x rest = force x $ \x' -> pure $ As.merge (assumptions x') rest
+      <*> (concat <$> traverse (`demand` (pure . typeConstraints)) xs)
+      <*> (TSet True <$> traverse (`demand` (pure . inferredType)) xs)
+    where go x rest = demand x $ \x' -> pure $ As.merge (assumptions x') rest
 
-instance MonadInfer m => ToValue [JThunkT s m] (InferT s m) (Judgment s) where
+instance MonadInfer m => ToValue [Judgment s] (InferT s m) (Judgment s) where
   toValue xs =
     Judgment
       <$> foldrM go As.empty xs
-      <*> (concat <$> traverse (`force` (pure . typeConstraints)) xs)
-      <*> (TList <$> traverse (`force` (pure . inferredType)) xs)
-    where go x rest = force x $ \x' -> pure $ As.merge (assumptions x') rest
+      <*> (concat <$> traverse (`demand` (pure . typeConstraints)) xs)
+      <*> (TList <$> traverse (`demand` (pure . inferredType)) xs)
+    where go x rest = demand x $ \x' -> pure $ As.merge (assumptions x') rest
 
 instance MonadInfer m => ToValue Bool (InferT s m) (Judgment s) where
   toValue _ = pure $ Judgment As.empty [] typeBool
@@ -695,8 +699,8 @@ solve cs = solve' (nextSolvable cs)
     s' <- lift $ instantiate s
     solve (EqConst t s' : cs)
 
-instance Monad m => Scoped (JThunkT s m) (InferT s m) where
+instance Monad m => Scoped (Judgment s) (InferT s m) where
   currentScopes = currentScopesReader
-  clearScopes   = clearScopesReader @(InferT s m) @(JThunkT s m)
+  clearScopes   = clearScopesReader @(InferT s m) @(Judgment s)
   pushScopes    = pushScopesReader
   lookupVar     = lookupVarReader

--- a/src/Nix/Type/Infer.hs
+++ b/src/Nix/Type/Infer.hs
@@ -403,10 +403,12 @@ instance Monad m => MonadCatch (InferT s m) where
       (fromException (toException e))
     err -> error $ "Unexpected error: " ++ show err
 
-type MonadInfer m = ({- MonadThunkId m,-} MonadVar m, MonadFix m)
+type MonadInfer m
+  = ({- MonadThunkId m,-}
+     MonadVar m, MonadFix m)
 
 instance MonadValue (Judgment s) (InferT s m) where
-  defer = id
+  defer  = id
   demand = flip ($)
 
 {-

--- a/src/Nix/Utils.hs
+++ b/src/Nix/Utils.hs
@@ -95,23 +95,20 @@ transport :: Functor g => (forall x . f x -> g x) -> Fix f -> Fix g
 transport f (Fix x) = Fix $ fmap (transport f) (f x)
 
 lifted
-    :: ( MonadTransControl u
-      , Monad (u m)
-      , Monad m
-      )
-    => ((a -> m (StT u b)) -> m (StT u b)) -> (a -> u m b) -> u m b
+  :: (MonadTransControl u, Monad (u m), Monad m)
+  => ((a -> m (StT u b)) -> m (StT u b))
+  -> (a -> u m b)
+  -> u m b
 lifted f k = liftWith (\run -> f (run . k)) >>= restoreT . return
 
 freeToFix :: Functor f => (a -> Fix f) -> Free f a -> Fix f
 freeToFix f = go
-  where
-    go (Pure a) = f a
-    go (Free v) = Fix (fmap go v)
+ where
+  go (Pure a) = f a
+  go (Free v) = Fix (fmap go v)
 
 fixToFree :: Functor f => Fix f -> Free f Void
-fixToFree = Free . go
-  where
-    go (Fix f) = fmap (Free . go) f
+fixToFree = Free . go where go (Fix f) = fmap (Free . go) f
 
 -- | adi is Abstracting Definitional Interpreters:
 --

--- a/src/Nix/Utils.hs
+++ b/src/Nix/Utils.hs
@@ -179,11 +179,3 @@ alterF
 alterF f k m = f (M.lookup k m) <&> \case
   Nothing -> M.delete k m
   Just v  -> M.insert k v m
-
-
-
-
-
-
-
-

--- a/src/Nix/Utils.hs
+++ b/src/Nix/Utils.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE FunctionalDependencies #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings #-}

--- a/src/Nix/Value.hs
+++ b/src/Nix/Value.hs
@@ -501,6 +501,12 @@ describeValue = \case
   TPath              -> "a path"
   TBuiltin           -> "a builtin function"
 
+showValueType :: (MonadThunk t m (NValue t f m), Comonad f)
+              => NValue t f m -> m String
+showValueType (Pure t) = force t showValueType
+showValueType (Free (NValue (extract -> v))) =
+  pure $ describeValue $ valueType $ v
+
 data ValueFrame t f m
     = ForcingThunk t
     | ConcerningValue (NValue t f m)

--- a/src/Nix/Value.hs
+++ b/src/Nix/Value.hs
@@ -36,10 +36,12 @@ import           Control.Monad
 import           Control.Monad.Free
 import           Control.Monad.Trans.Class
 import qualified Data.Aeson                    as A
+import           Data.Fix
 import           Data.Functor.Classes
 import           Data.HashMap.Lazy              ( HashMap )
 import           Data.Text                      ( Text )
 import           Data.Typeable                  ( Typeable )
+import           Data.Void
 import           GHC.Generics
 import           Lens.Family2
 import           Lens.Family2.Stock
@@ -62,7 +64,7 @@ data NValueF p m r
     | NVPathF FilePath
     | NVListF [r]
     | NVSetF (AttrSet r) (AttrSet SourcePos)
-    | NVClosureF (Params ()) (m p -> m r)
+    | NVClosureF (Params ()) (p -> m r)
       -- ^ A function is a closed set of parameters representing the "call
       --   signature", used at application time to check the type of arguments
       --   passed to the function. Since it supports default values which may
@@ -74,7 +76,7 @@ data NValueF p m r
       --   Note that 'm r' is being used here because effectively a function
       --   and its set of default arguments is "never fully evaluated". This
       --   enforces in the type that it must be re-evaluated for each call.
-    | NVBuiltinF String (m p -> m r)
+    | NVBuiltinF String (p -> m r)
       -- ^ A builtin function is itself already in normal form. Also, it may
       --   or may not choose to evaluate its argument in the production of a
       --   result.
@@ -92,6 +94,20 @@ instance Foldable (NValueF p m) where
     NVClosureF _ _ -> mempty
     NVBuiltinF _ _ -> mempty
 
+instance Show r => Show (NValueF p m r) where
+  showsPrec = flip go   where
+    go (NVConstantF atom  ) = showsCon1 "NVConstant" atom
+    go (NVStrF      ns    ) = showsCon1 "NVStr" (hackyStringIgnoreContext ns)
+    go (NVListF     lst   ) = showsCon1 "NVList" lst
+    go (NVSetF     attrs _) = showsCon1 "NVSet" attrs
+    go (NVClosureF p     _) = showsCon1 "NVClosure" p
+    go (NVPathF p         ) = showsCon1 "NVPath" p
+    go (NVBuiltinF name _ ) = showsCon1 "NVBuiltin" name
+
+    showsCon1 :: Show a => String -> a -> Int -> String -> String
+    showsCon1 con a d =
+      showParen (d > 10) $ showString (con ++ " ") . showsPrec 11 a
+
 lmapNValueF :: Functor m => (b -> a) -> NValueF a m r -> NValueF b m r
 lmapNValueF f = \case
   NVConstantF a  -> NVConstantF a
@@ -99,22 +115,21 @@ lmapNValueF f = \case
   NVPathF     p  -> NVPathF p
   NVListF     l  -> NVListF l
   NVSetF     s p -> NVSetF s p
-  NVClosureF p g -> NVClosureF p (g . fmap f)
-  NVBuiltinF s g -> NVBuiltinF s (g . fmap f)
+  NVClosureF p g -> NVClosureF p (g . f)
+  NVBuiltinF s g -> NVBuiltinF s (g . f)
 
 hoistNValueF
-  :: (forall x . n x -> m x)
-  -> (forall x . m x -> n x)
+  :: (forall x . m x -> n x)
   -> NValueF p m a
   -> NValueF p n a
-hoistNValueF run lft = \case
+hoistNValueF lft = \case
   NVConstantF a  -> NVConstantF a
   NVStrF      s  -> NVStrF s
   NVPathF     p  -> NVPathF p
   NVListF     l  -> NVListF l
   NVSetF     s p -> NVSetF s p
-  NVClosureF p g -> NVClosureF p (lft . g . run)
-  NVBuiltinF s g -> NVBuiltinF s (lft . g . run)
+  NVClosureF p g -> NVClosureF p (lft . g)
+  NVBuiltinF s g -> NVBuiltinF s (lft . g)
 
 sequenceNValueF
   :: (Functor n, Monad m, Applicative n)
@@ -147,17 +162,16 @@ bindNValueF transform f = \case
 
 liftNValueF
   :: (MonadTrans u, Monad m)
-  => (forall x . u m x -> m x)
-  -> NValueF p m a
+  => NValueF p m a
   -> NValueF p (u m) a
-liftNValueF run = hoistNValueF run lift
+liftNValueF = hoistNValueF lift
 
 unliftNValueF
   :: (MonadTrans u, Monad m)
   => (forall x . u m x -> m x)
   -> NValueF p (u m) a
   -> NValueF p m a
-unliftNValueF run = hoistNValueF lift run
+unliftNValueF = hoistNValueF
 
 type MonadDataContext f (m :: * -> *)
   = (Comonad f, Applicative f, Traversable f, Monad m)
@@ -167,76 +181,69 @@ type MonadDataContext f (m :: * -> *)
 newtype NValue' t f m a = NValue { _nValue :: f (NValueF (NValue t f m) m a) }
     deriving (Generic, Typeable, Functor, Foldable)
 
-instance Show r => Show (NValueF p m r) where
-  showsPrec = flip go   where
-    go (NVConstantF atom  ) = showsCon1 "NVConstant" atom
-    go (NVStrF      ns    ) = showsCon1 "NVStr" (hackyStringIgnoreContext ns)
-    go (NVListF     lst   ) = showsCon1 "NVList" lst
-    go (NVSetF     attrs _) = showsCon1 "NVSet" attrs
-    go (NVClosureF p     _) = showsCon1 "NVClosure" p
-    go (NVPathF p         ) = showsCon1 "NVPath" p
-    go (NVBuiltinF name _ ) = showsCon1 "NVBuiltin" name
-
-    showsCon1 :: Show a => String -> a -> Int -> String -> String
-    showsCon1 con a d =
-      showParen (d > 10) $ showString (con ++ " ") . showsPrec 11 a
-
 instance (Comonad f, Show a) => Show (NValue' t f m a) where
   show (NValue (extract -> v)) = show v
 
 instance Comonad f => Show1 (NValue' t f m) where
   liftShowsPrec sp sl p = \case
-    NVConstant atom -> showsUnaryWith showsPrec "NVConstantF" p atom
-    NVStr ns ->
+    NVConstant' atom  -> showsUnaryWith showsPrec "NVConstantF" p atom
+    NVStr' ns ->
       showsUnaryWith showsPrec "NVStrF" p (hackyStringIgnoreContext ns)
-    NVList lst       -> showsUnaryWith (liftShowsPrec sp sl) "NVListF" p lst
-    NVSet attrs _    -> showsUnaryWith (liftShowsPrec sp sl) "NVSetF" p attrs
-    NVPath path      -> showsUnaryWith showsPrec "NVPathF" p path
-    NVClosure c    _ -> showsUnaryWith showsPrec "NVClosureF" p c
-    NVBuiltin name _ -> showsUnaryWith showsPrec "NVBuiltinF" p name
-    _                -> error "Pattern synonyms mask coverage"
+    NVList' lst       -> showsUnaryWith (liftShowsPrec sp sl) "NVListF" p lst
+    NVSet' attrs _    -> showsUnaryWith (liftShowsPrec sp sl) "NVSetF" p attrs
+    NVPath' path      -> showsUnaryWith showsPrec "NVPathF" p path
+    NVClosure' c    _ -> showsUnaryWith showsPrec "NVClosureF" p c
+    NVBuiltin' name _ -> showsUnaryWith showsPrec "NVBuiltinF" p name
+    _                 -> error "Pattern synonyms mask coverage"
 
-type NValue t f m = NValue' t f m t
-
-sequenceNValue
+sequenceNValue'
   :: (Functor n, Traversable f, Monad m, Applicative n)
   => (forall x . n x -> m x)
   -> NValue' t f m (n a)
   -> n (NValue' t f m a)
-sequenceNValue transform (NValue v) =
+sequenceNValue' transform (NValue v) =
   NValue <$> traverse (sequenceNValueF transform) v
 
-bindNValue
+bindNValue'
   :: (Traversable f, Monad m, Monad n)
   => (forall x . n x -> m x)
   -> (a -> n b)
   -> NValue' t f m a
   -> n (NValue' t f m b)
-bindNValue transform f (NValue v) =
+bindNValue' transform f (NValue v) =
   NValue <$> traverse (bindNValueF transform f) v
 
-hoistNValue
+hoistNValue'
   :: (Functor m, Functor n, Functor f)
   => (forall x . n x -> m x)
   -> (forall x . m x -> n x)
   -> NValue' t f m a
   -> NValue' t f n a
-hoistNValue run lft (NValue v) =
-  NValue (fmap (lmapNValueF (hoistNValue lft run) . hoistNValueF run lft) v)
+hoistNValue' run lft (NValue v) =
+    NValue (fmap (lmapNValueF (hoistNValue lft run) . hoistNValueF lft) v)
 
-liftNValue
+liftNValue'
   :: (MonadTrans u, Monad m, Functor (u m), Functor f)
   => (forall x . u m x -> m x)
   -> NValue' t f m a
   -> NValue' t f (u m) a
-liftNValue run = hoistNValue run lift
+liftNValue' run = hoistNValue' run lift
 
-unliftNValue
+unliftNValue'
   :: (MonadTrans u, Monad m, Functor (u m), Functor f)
   => (forall x . u m x -> m x)
   -> NValue' t f (u m) a
   -> NValue' t f m a
-unliftNValue run = hoistNValue lift run
+unliftNValue' run = hoistNValue' lift run
+
+iterNValue'
+  :: forall t f m a r
+   . MonadDataContext f m
+  => (a -> (NValue' t f m a -> r) -> r)
+  -> (NValue' t f m r -> r)
+  -> NValue' t f m a
+  -> r
+iterNValue' k f = f . fmap (\a -> k a (iterNValue' k f))
 
 -- | An 'NValueNF' is a fully evaluated value in normal form. An 'NValue f t m' is
 --   a value in head normal form, where only the "top layer" has been
@@ -248,64 +255,72 @@ unliftNValue run = hoistNValue lift run
 --   The 'Free' structure is used here to represent the possibility that
 --   cycles may appear during normalization.
 
-type NValueNF t f m = Free (NValue' t f m) t
+type NValue   t f m = Free (NValue' t f m) t
+type NValueNF t f m = Fix  (NValue' t f m)
+
+hoistNValue
+  :: (Functor m, Functor n, Functor f)
+  => (forall x . n x -> m x)
+  -> (forall x . m x -> n x)
+  -> NValue t f m
+  -> NValue t f n
+hoistNValue run lft = hoistFree (hoistNValue' run lft)
+
+liftNValue
+  :: (MonadTrans u, Monad m, Functor (u m), Functor f)
+  => (forall x . u m x -> m x)
+  -> NValue t f m
+  -> NValue t f (u m)
+liftNValue run = hoistNValue run lift
+
+unliftNValue
+  :: (MonadTrans u, Monad m, Functor (u m), Functor f)
+  => (forall x . u m x -> m x)
+  -> NValue t f (u m)
+  -> NValue t f m
+unliftNValue run = hoistNValue lift run
 
 iterNValue
-  :: forall t f m a r
+  :: forall t f m r
    . MonadDataContext f m
-  => (a -> (NValue' t f m a -> r) -> r)
+  => (t -> (NValue t f m -> r) -> r)
   -> (NValue' t f m r -> r)
-  -> NValue' t f m a
+  -> NValue t f m
   -> r
-iterNValue k f = f . fmap (\a -> k a (iterNValue k f))
+iterNValue k f = iter f . fmap (\t -> k t (iterNValue k f))
 
 iterNValueM
   :: (MonadDataContext f m, Monad n)
   => (forall x . n x -> m x)
-  -> (a -> (NValue' t f m a -> n r) -> n r)
-  -> (NValue' t f m r -> n r)
-  -> NValue' t f m a
+  -> (t -> (NValue t f m -> n r) -> n r)
+  -> (NValue' t f m (n r) -> n r)
+  -> NValue t f m
   -> n r
 iterNValueM transform k f =
-  f <=< bindNValue transform (\a -> k a (iterNValueM transform k f))
+    iterM f <=< go . fmap (\t -> k t (iterNValueM transform k f))
+  where
+    go (Pure x) = Pure <$> x
+    go (Free fa) = Free <$> bindNValue' transform go fa
 
 iterNValueNF
   :: MonadDataContext f m
-  => (t -> r)
-  -> (NValue' t f m r -> r)
+  => (NValue' t f m r -> r)
   -> NValueNF t f m
   -> r
-iterNValueNF k f = iter f . fmap k
-
-iterNValueNFM
-  :: forall f m n t r
-   . (MonadDataContext f m, Monad n)
-  => (forall x . n x -> m x)
-  -> (t -> n r)
-  -> (NValue' t f m (n r) -> n r)
-  -> NValueNF t f m
-  -> n r
-iterNValueNFM transform k f v =
-  iterM f =<< go (fmap k v)
-  where
-  go (Pure a ) = Pure <$> a
-  go (Free fa) = Free <$> bindNValue transform go fa
+iterNValueNF = cata
 
 nValueFromNF
   :: (MonadThunk t m (NValue t f m), MonadDataContext f m)
   => NValueNF t f m
   -> NValue t f m
-nValueFromNF = iterNValueNF f (fmap wrapValue)
- where
-  f t = query t cyc id
-  cyc = nvStr (principledMakeNixStringWithoutContext "<CYCLE>")
+nValueFromNF = fmap absurd . fixToFree
 
 nValueToNF
   :: (MonadThunk t m (NValue t f m), MonadDataContext f m)
   => (t -> (NValue t f m -> NValueNF t f m) -> NValueNF t f m)
   -> NValue t f m
   -> NValueNF t f m
-nValueToNF k = iterNValue k Free
+nValueToNF k = iterNValue k Fix
 
 nValueToNFM
   :: (MonadDataContext f m, Monad n)
@@ -313,91 +328,124 @@ nValueToNFM
   -> (t -> (NValue t f m -> n (NValueNF t f m)) -> n (NValueNF t f m))
   -> NValue t f m
   -> n (NValueNF t f m)
-nValueToNFM transform k = iterNValueM transform k $ pure . Free
+nValueToNFM transform k = iterNValueM transform k undefined
 
-pattern NVConstant x <- NValue (extract -> NVConstantF x)
-pattern NVConstantNF x <- Free (NValue (extract -> NVConstantF x))
+pattern NVThunk t <- Pure t
 
+nvThunk :: Applicative f => t -> NValue t f m
+nvThunk = Pure
+
+pattern NVConstant' x <- NValue (extract -> NVConstantF x)
+pattern NVConstant x <- Free (NVConstant' x)
+pattern NVConstantNF x <- Fix (NVConstant' x)
+
+nvConstant' :: Applicative f => NAtom -> NValue' t f m r
+nvConstant' x = NValue (pure (NVConstantF x))
 nvConstant :: Applicative f => NAtom -> NValue t f m
-nvConstant x = NValue (pure (NVConstantF x))
+nvConstant x = Free (NValue (pure (NVConstantF x)))
 nvConstantNF :: Applicative f => NAtom -> NValueNF t f m
-nvConstantNF x = Free (NValue (pure (NVConstantF x)))
+nvConstantNF x = Fix (NValue (pure (NVConstantF x)))
 
-pattern NVStr ns <- NValue (extract -> NVStrF ns)
-pattern NVStrNF ns <- Free (NValue (extract -> NVStrF ns))
+pattern NVStr' ns <- NValue (extract -> NVStrF ns)
+pattern NVStr ns <- Free (NVStr' ns)
+pattern NVStrNF ns <- Fix (NVStr' ns)
 
+nvStr' :: Applicative f => NixString -> NValue' t f m r
+nvStr' ns = NValue (pure (NVStrF ns))
 nvStr :: Applicative f => NixString -> NValue t f m
-nvStr ns = NValue (pure (NVStrF ns))
+nvStr ns = Free (NValue (pure (NVStrF ns)))
 nvStrNF :: Applicative f => NixString -> NValueNF t f m
-nvStrNF ns = Free (NValue (pure (NVStrF ns)))
+nvStrNF ns = Fix (NValue (pure (NVStrF ns)))
 
-pattern NVPath x <- NValue (extract -> NVPathF x)
-pattern NVPathNF x <- Free (NValue (extract -> NVPathF x))
+pattern NVPath' x <- NValue (extract -> NVPathF x)
+pattern NVPath x <- Free (NVPath' x)
+pattern NVPathNF x <- Fix (NVPath' x)
 
+nvPath' :: Applicative f => FilePath -> NValue' t f m r
+nvPath' x = NValue (pure (NVPathF x))
 nvPath :: Applicative f => FilePath -> NValue t f m
-nvPath x = NValue (pure (NVPathF x))
+nvPath x = Free (NValue (pure (NVPathF x)))
 nvPathNF :: Applicative f => FilePath -> NValueNF t f m
-nvPathNF x = Free (NValue (pure (NVPathF x)))
+nvPathNF x = Fix (NValue (pure (NVPathF x)))
 
-pattern NVList l <- NValue (extract -> NVListF l)
-pattern NVListNF l <- Free (NValue (extract -> NVListF l))
+pattern NVList' l <- NValue (extract -> NVListF l)
+pattern NVList l <- Free (NVList' l)
+pattern NVListNF l <- Fix (NVList' l)
 
-nvList :: Applicative f => [t] -> NValue t f m
-nvList l = NValue (pure (NVListF l))
+nvList' :: Applicative f => [r] -> NValue' t f m r
+nvList' l = NValue (pure (NVListF l))
+nvList :: Applicative f => [NValue t f m] -> NValue t f m
+nvList l = Free (NValue (pure (NVListF l)))
 nvListNF :: Applicative f => [NValueNF t f m] -> NValueNF t f m
-nvListNF l = Free (NValue (pure (NVListF l)))
+nvListNF l = Fix (NValue (pure (NVListF l)))
 
-pattern NVSet s x <- NValue (extract -> NVSetF s x)
-pattern NVSetNF s x <- Free (NValue (extract -> NVSetF s x))
+pattern NVSet' s x <- NValue (extract -> NVSetF s x)
+pattern NVSet s x <- Free (NVSet' s x)
+pattern NVSetNF s x <- Fix (NVSet' s x)
 
+nvSet' :: Applicative f
+       => HashMap Text r -> HashMap Text SourcePos -> NValue' t f m r
+nvSet' s x = NValue (pure (NVSetF s x))
 nvSet :: Applicative f
-      => HashMap Text t -> HashMap Text SourcePos -> NValue t f m
-nvSet s x = NValue (pure (NVSetF s x))
+      => HashMap Text (NValue t f m) -> HashMap Text SourcePos -> NValue t f m
+nvSet s x = Free (NValue (pure (NVSetF s x)))
 nvSetNF :: Applicative f
-        => HashMap Text (NValueNF t f m) -> HashMap Text SourcePos -> NValueNF t f m
-nvSetNF s x = Free (NValue (pure (NVSetF s x)))
+        => HashMap Text (NValueNF t f m) -> HashMap Text SourcePos
+        -> NValueNF t f m
+nvSetNF s x = Fix (NValue (pure (NVSetF s x)))
 
-pattern NVClosure x f <- NValue (extract -> NVClosureF x f)
-pattern NVClosureNF x f <- Free (NValue (extract -> NVClosureF x f))
+pattern NVClosure' x f <- NValue (extract -> NVClosureF x f)
+pattern NVClosure x f <- Free (NVClosure' x f)
+pattern NVClosureNF x f <- Fix (NVClosure' x f)
 
-nvClosure :: Applicative f
-          => Params () -> (m (NValue t f m) -> m t) -> NValue t f m
-nvClosure x f = NValue (pure (NVClosureF x f))
+nvClosure' :: (Applicative f, Functor m)
+           => Params () -> (NValue t f m -> m r) -> NValue' t f m r
+nvClosure' x f = NValue (pure (NVClosureF x f))
+nvClosure :: (Applicative f, Functor m)
+          => Params () -> (NValue t f m -> m (NValue t f m)) -> NValue t f m
+nvClosure x f = Free (NValue (pure (NVClosureF x f)))
 nvClosureNF :: Applicative f
-            => Params () -> (m (NValue t f m) -> m (NValueNF t f m)) -> NValueNF t f m
-nvClosureNF x f = Free (NValue (pure (NVClosureF x f)))
+            => Params () -> (NValue t f m -> m (NValueNF t f m))
+            -> NValueNF t f m
+nvClosureNF x f = Fix (NValue (pure (NVClosureF x f)))
 
-pattern NVBuiltin name f <- NValue (extract -> NVBuiltinF name f)
-pattern NVBuiltinNF name f <- Free (NValue (extract -> NVBuiltinF name f))
+pattern NVBuiltin' name f <- NValue (extract -> NVBuiltinF name f)
+pattern NVBuiltin name f <- Free (NVBuiltin' name f)
+pattern NVBuiltinNF name f <- Fix (NVBuiltin' name f)
 
-nvBuiltin :: Applicative f
-          => String -> (m (NValue t f m) -> m t) -> NValue t f m
-nvBuiltin name f = NValue (pure (NVBuiltinF name f))
+nvBuiltin' :: (Applicative f, Functor m)
+           => String -> (NValue t f m -> m r) -> NValue' t f m r
+nvBuiltin' name f = NValue (pure (NVBuiltinF name f))
+nvBuiltin :: (Applicative f, Functor m)
+          => String -> (NValue t f m -> m (NValue t f m)) -> NValue t f m
+nvBuiltin name f =
+  Free (NValue (pure (NVBuiltinF name f)))
 nvBuiltinNF :: Applicative f
-            => String -> (m (NValue t f m) -> m (NValueNF t f m)) -> NValueNF t f m
-nvBuiltinNF name f = Free (NValue (pure (NVBuiltinF name f)))
+            => String -> (NValue t f m -> m (NValueNF t f m))
+            -> NValueNF t f m
+nvBuiltinNF name f = Fix (NValue (pure (NVBuiltinF name f)))
 
 builtin
   :: forall m f t
    . (MonadThunk t m (NValue t f m), MonadDataContext f m)
   => String
-  -> (m (NValue t f m) -> m (NValue t f m))
+  -> (NValue t f m -> m (NValue t f m))
   -> m (NValue t f m)
-builtin name f = return $ nvBuiltin name $ \a -> thunk $ f a
+builtin name f = return $ nvBuiltin name $ \a -> f a
 
 builtin2
   :: (MonadThunk t m (NValue t f m), MonadDataContext f m)
   => String
-  -> (m (NValue t f m) -> m (NValue t f m) -> m (NValue t f m))
+  -> (NValue t f m -> NValue t f m -> m (NValue t f m))
   -> m (NValue t f m)
 builtin2 name f = builtin name $ \a -> builtin name $ \b -> f a b
 
 builtin3
   :: (MonadThunk t m (NValue t f m), MonadDataContext f m)
   => String
-  -> (  m (NValue t f m)
-     -> m (NValue t f m)
-     -> m (NValue t f m)
+  -> (  NValue t f m
+     -> NValue t f m
+     -> NValue t f m
      -> m (NValue t f m)
      )
   -> m (NValue t f m)
@@ -454,7 +502,7 @@ describeValue = \case
   TBuiltin           -> "a builtin function"
 
 data ValueFrame t f m
-    = ForcingThunk
+    = ForcingThunk t
     | ConcerningValue (NValue t f m)
     | Comparison (NValue t f m) (NValue t f m)
     | Addition (NValue t f m) (NValue t f m)
@@ -463,9 +511,10 @@ data ValueFrame t f m
     | Coercion ValueType ValueType
     | CoercionToJson (NValue t f m)
     | CoercionFromJson A.Value
-    | ExpectationNF ValueType (NValueNF t f m)
-    | Expectation ValueType (NValue t f m)
-    deriving (Show, Typeable)
+    | forall r. Show r => Expectation ValueType (NValue' t f m r)
+    deriving Typeable
+
+deriving instance (Comonad f, Show t) => Show (ValueFrame t f m)
 
 type MonadDataErrorContext t f m
   = (Show t, Typeable t, Typeable m, Typeable f, MonadDataContext f m)

--- a/src/Nix/Value.hs
+++ b/src/Nix/Value.hs
@@ -328,7 +328,8 @@ nValueToNFM
   -> (t -> (NValue t f m -> n (NValueNF t f m)) -> n (NValueNF t f m))
   -> NValue t f m
   -> n (NValueNF t f m)
-nValueToNFM transform k = iterNValueM transform k undefined
+nValueToNFM transform k =
+  iterNValueM transform k $ fmap Fix . sequenceNValue' transform
 
 pattern NVThunk t <- Pure t
 

--- a/src/Nix/Value/Equal.hs
+++ b/src/Nix/Value/Equal.hs
@@ -154,16 +154,17 @@ compareAttrSets f eq lm rm = runIdentity
   $ compareAttrSetsM (\t -> Identity (f t)) (\x y -> Identity (eq x y)) lm rm
 
 valueEqM
-  :: forall t f m. (MonadThunk t m (NValue t f m), Comonad f)
+  :: forall t f m
+   . (MonadThunk t m (NValue t f m), Comonad f)
   => NValue t f m
   -> NValue t f m
   -> m Bool
-valueEqM (Pure x) (Pure y) = thunkEqM x y
-valueEqM (Pure x) y@(Free _) = thunkEqM x =<< thunk (pure y)
-valueEqM x@(Free _) (Pure y) = thunkEqM ?? y =<< thunk (pure x)
+valueEqM (  Pure x) (  Pure y) = thunkEqM x y
+valueEqM (  Pure x) y@(Free _) = thunkEqM x =<< thunk (pure y)
+valueEqM x@(Free _) (  Pure y) = thunkEqM ?? y =<< thunk (pure x)
 valueEqM (Free (NValue (extract -> x))) (Free (NValue (extract -> y))) =
   valueFEqM (compareAttrSetsM f valueEqM) valueEqM x y
-  where
+ where
   f (Pure t) = force t $ \case
     NVStr s -> pure $ Just s
     _       -> pure Nothing

--- a/src/Nix/Value/Monad.hs
+++ b/src/Nix/Value/Monad.hs
@@ -9,4 +9,4 @@ class MonadValue v m where
   -- | If 'v' is a thunk, 'train' allows us to modify the action to be
   --   peformed by the thunk, perhaps by enriching it with scpoe info, for
   --   example.
-  train :: v -> (m v -> m v) -> m v
+  -- train :: v -> (m v -> m v) -> m v

--- a/src/Nix/Value/Monad.hs
+++ b/src/Nix/Value/Monad.hs
@@ -6,3 +6,7 @@ module Nix.Value.Monad where
 class MonadValue v m where
   defer :: m v -> m v
   demand :: v -> (v -> m r) -> m r
+  -- | If 'v' is a thunk, 'train' allows us to modify the action to be
+  --   peformed by the thunk, perhaps by enriching it with scpoe info, for
+  --   example.
+  train :: v -> (m v -> m v) -> m v

--- a/src/Nix/Value/Monad.hs
+++ b/src/Nix/Value/Monad.hs
@@ -1,0 +1,8 @@
+{-# LANGUAGE FunctionalDependencies #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+
+module Nix.Value.Monad where
+
+class MonadValue v m where
+  defer :: m v -> m v
+  demand :: v -> (v -> m r) -> m r

--- a/src/Nix/XML.hs
+++ b/src/Nix/XML.hs
@@ -19,7 +19,7 @@ toXML :: forall t f m . MonadDataContext f m => NValueNF t f m -> NixString
 toXML =
   runWithStringContext
     . fmap pp
-    . iterNValueNF (const (pure (mkElem "cycle" "value" ""))) phi
+    . iterNValueNF phi
  where
   pp =
     ("<?xml version='1.0' encoding='utf-8'?>\n" <>)
@@ -30,17 +30,17 @@ toXML =
 
   phi :: NValue' t f m (WithStringContext Element) -> WithStringContext Element
   phi = \case
-    NVConstant a -> case a of
+    NVConstant' a -> case a of
       NInt   n -> return $ mkElem "int" "value" (show n)
       NFloat f -> return $ mkElem "float" "value" (show f)
       NBool  b -> return $ mkElem "bool" "value" (if b then "true" else "false")
       NNull    -> return $ Element (unqual "null") [] [] Nothing
 
-    NVStr  str -> mkElem "string" "value" . Text.unpack <$> extractNixString str
-    NVList l   -> sequence l
+    NVStr'  str -> mkElem "string" "value" . Text.unpack <$> extractNixString str
+    NVList' l   -> sequence l
       >>= \els -> return $ Element (unqual "list") [] (Elem <$> els) Nothing
 
-    NVSet s _ -> sequence s >>= \kvs -> return $ Element
+    NVSet' s _ -> sequence s >>= \kvs -> return $ Element
       (unqual "attrs")
       []
       (map
@@ -55,10 +55,10 @@ toXML =
       )
       Nothing
 
-    NVClosure p _ ->
+    NVClosure' p _ ->
       return $ Element (unqual "function") [] (paramsXML p) Nothing
-    NVPath fp        -> return $ mkElem "path" "value" fp
-    NVBuiltin name _ -> return $ mkElem "function" "name" name
+    NVPath' fp        -> return $ mkElem "path" "value" fp
+    NVBuiltin' name _ -> return $ mkElem "function" "name" name
     _                -> error "Pattern synonyms mask coverage"
 
 mkElem :: String -> String -> String -> Element

--- a/src/Nix/XML.hs
+++ b/src/Nix/XML.hs
@@ -16,10 +16,7 @@ import           Nix.Value
 import           Text.XML.Light
 
 toXML :: forall t f m . MonadDataContext f m => NValueNF t f m -> NixString
-toXML =
-  runWithStringContext
-    . fmap pp
-    . iterNValueNF phi
+toXML = runWithStringContext . fmap pp . iterNValueNF phi
  where
   pp =
     ("<?xml version='1.0' encoding='utf-8'?>\n" <>)
@@ -36,8 +33,9 @@ toXML =
       NBool  b -> return $ mkElem "bool" "value" (if b then "true" else "false")
       NNull    -> return $ Element (unqual "null") [] [] Nothing
 
-    NVStr'  str -> mkElem "string" "value" . Text.unpack <$> extractNixString str
-    NVList' l   -> sequence l
+    NVStr' str ->
+      mkElem "string" "value" . Text.unpack <$> extractNixString str
+    NVList' l -> sequence l
       >>= \els -> return $ Element (unqual "list") [] (Elem <$> els) Nothing
 
     NVSet' s _ -> sequence s >>= \kvs -> return $ Element
@@ -59,7 +57,7 @@ toXML =
       return $ Element (unqual "function") [] (paramsXML p) Nothing
     NVPath' fp        -> return $ mkElem "path" "value" fp
     NVBuiltin' name _ -> return $ mkElem "function" "name" name
-    _                -> error "Pattern synonyms mask coverage"
+    _                 -> error "Pattern synonyms mask coverage"
 
 mkElem :: String -> String -> String -> Element
 mkElem n a v = Element (unqual n) [Attr (unqual a) v] [] Nothing


### PR DESCRIPTION
This will result in simplifications in Value, Convert, Eval, Exec, Normal and many other places. Basically, no one besides the module that chooses the thunk representation should even be aware that thunking conceptually exists.