### PR TITLE
Add conservative dependency bounds to all dependencies

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -46,6 +46,16 @@ let
   overlay = pkgs.lib.foldr pkgs.lib.composeExtensions (_: _: {}) [
     (import "${hnix-store-src}/overlay.nix")
     (self: super: with pkgs.haskell.lib; {
+
+      # Type error in the tests under ghc844 package set
+      Diff = dontCheck super.Diff;
+
+      # These packages only depend on contravariant when ghc >= 8.6.3
+      # Without normalizing the dependencies, our build fails with
+      # aeson and base-compat-batteries unable to find `contravariant`
+      aeson                 = addBuildDepend super.aeson self.contravariant;
+      base-compat-batteries = addBuildDepend super.base-compat-batteries self.contravariant;
+
       mono-traversable = dontCheck super.mono-traversable;
       these = doJailbreak super.these;
       multistate = doJailbreak super.multistate;

--- a/hnix.cabal
+++ b/hnix.cabal
@@ -484,54 +484,54 @@ library
       src
   ghc-options: -Wall -fprint-potential-instances
   build-depends:
-      aeson
+      aeson >= 1.4.2 && < 1.5
     , array >=0.4 && <0.6
     , base >=4.9 && <5
-    , binary
-    , bytestring
-    , comonad
-    , containers
-    , data-fix
+    , binary >= 0.8.5 && < 0.9
+    , bytestring >= 0.10.8 && < 0.11
+    , comonad >= 5.0.4 && < 5.1
+    , containers >= 0.5.11 && < 0.6
+    , data-fix >= 0.2.0 && <  0.3
     , deepseq >=1.4.2 && <1.5
-    , dependent-sum
+    , dependent-sum >= 0.4 && < 0.5
     , deriving-compat >=0.3 && <0.6
-    , directory
-    , exceptions
-    , filepath
-    , free
-    , hashing
-    , hnix-store-core
-    , http-client
-    , http-client-tls
-    , http-types
-    , interpolate
-    , lens-family-th
-    , logict
+    , directory >= 1.3.1 && < 1.4
+    , exceptions >= 0.10.0 && < 0.11
+    , filepath >= 1.4.2 && < 1.5
+    , free >= 5.1 && < 5.2
+    , hashing >= 0.1.0 && < 0.2
+    , hnix-store-core >= 0.1.0 && < 0.2
+    , http-client >= 0.6.2 && < 0.7
+    , http-client-tls >= 0.3.5 && < 0.4
+    , http-types >= 0.12.3 && < 0.13
+    , interpolate >= 0.2.0 && < 0.3
+    , lens-family-th >= 0.5.0 && < 0.6
+    , logict >= 0.6.0 && < 0.7
     , megaparsec >=7.0 && <7.1
-    , monad-control
-    , monadlist
-    , mtl
-    , optparse-applicative
-    , parser-combinators
-    , prettyprinter
-    , process
-    , ref-tf
-    , regex-tdfa
-    , regex-tdfa-text
-    , scientific
+    , monad-control >= 1.0.2 && < 1.1
+    , monadlist >= 0.0.2 && < 0.1
+    , mtl >= 2.2.2 && < 2.3
+    , optparse-applicative >= 0.14.3 && < 0.15
+    , parser-combinators >= 1.0.1 && < 1.1
+    , prettyprinter >= 1.2.1 && < 1.3
+    , process >= 1.6.3 && < 1.7
+    , ref-tf >= 0.4.0 && < 0.5
+    , regex-tdfa >= 1.2.3 && < 1.3
+    , regex-tdfa-text >= 1.0.0 && < 1.1
+    , scientific >= 0.3.6 && < 0.4
     , semigroups >=0.18 && <0.19
-    , split
-    , syb
-    , template-haskell
-    , text
-    , these
-    , time
-    , transformers
-    , transformers-base
-    , unix
-    , unordered-containers >=0.2.9 && <0.3
-    , vector
-    , xml
+    , split >= 0.2.3 && < 0.3
+    , syb >= 0.7 && < 0.8
+    , template-haskell >= 2.13.0 && < 2.14
+    , text >= 1.2.3 && < 1.3
+    , these >= 0.8 && < 0.9
+    , time >= 1.8.0 && < 1.9
+    , transformers >= 0.5.5 && < 0.6
+    , transformers-base >= 0.4.5 && < 0.5
+    , unix >= 2.7.2 && < 2.8
+    , unordered-containers >=0.2.9 && < 0.3
+    , vector >= 0.12.0 && < 0.13
+    , xml >= 1.3.14 && < 1.4
   if flag(optimize)
     ghc-options: -fexpose-all-unfoldings -fspecialise-aggressively -O2
   if os(linux) && impl(ghc >= 8.2) && impl(ghc < 8.3)
@@ -539,12 +539,12 @@ library
         compact
   if !impl(ghcjs)
     build-depends:
-        base16-bytestring
-      , cryptohash-md5
-      , cryptohash-sha1
-      , cryptohash-sha256
-      , cryptohash-sha512
-      , serialise
+        base16-bytestring >= 0.1.1 && < 0.2
+      , cryptohash-md5 >= 0.11.100 && < 0.12
+      , cryptohash-sha1 >= 0.11.100 && < 0.12
+      , cryptohash-sha256 >= 0.11.101 && < 0.12
+      , cryptohash-sha512 >= 0.11.100 && < 0.12
+      , serialise >= 0.2.1 && < 0.3
   if impl(ghc < 8.1)
     build-depends:
         lens-family ==1.2.1
@@ -564,8 +564,8 @@ library
         Nix.Options.Parser
     build-depends:
         hashable >=1.2.5 && <1.3
-      , haskeline
-      , pretty-show
+      , haskeline >= 0.7.5 && < 0.8
+      , pretty-show >= 1.9.5 && < 1.10
   default-language: Haskell2010
 
 executable hnix
@@ -578,12 +578,12 @@ executable hnix
   ghc-options: -Wall -rtsopts
   build-depends:
       aeson
-    , base >=4.9 && <5
+    , base
     , bytestring
     , comonad
     , containers
     , data-fix
-    , deepseq >=1.4.2 && <1.5
+    , deepseq
     , exceptions
     , filepath
     , free
@@ -600,7 +600,7 @@ executable hnix
     , text
     , time
     , transformers
-    , unordered-containers >=0.2.9 && <0.3
+    , unordered-containers
   if flag(optimize)
     ghc-options: -fexpose-all-unfoldings -fspecialise-aggressively -O2
   if os(linux) && impl(ghc >= 8.2) && impl(ghc < 8.3)

--- a/hnix.cabal
+++ b/hnix.cabal
@@ -490,7 +490,8 @@ library
     , binary >= 0.8.5 && < 0.9
     , bytestring >= 0.10.8 && < 0.11
     , comonad >= 5.0.4 && < 5.1
-    , containers >= 0.6.0.1 && < 0.7
+    , containers >= 0.5.11.0 && < 0.7
+    , contravariant >= 1.5 && < 1.6
     , data-fix >= 0.2.0 && <  0.3
     , deepseq >=1.4.2 && <1.5
     , dependent-sum >= 0.4 && < 0.5
@@ -522,7 +523,7 @@ library
     , semigroups >=0.18 && <0.19
     , split >= 0.2.3 && < 0.3
     , syb >= 0.7 && < 0.8
-    , template-haskell >= 2.14.0.0 && < 2.15
+    , template-haskell
     , text >= 1.2.3 && < 1.3
     , these >= 0.7.5 && < 0.8
     , time >= 1.8.0 && < 1.9
@@ -564,7 +565,7 @@ library
         Nix.Options.Parser
     build-depends:
         hashable >=1.2.5 && <1.3
-      , haskeline >= 0.7.4.3 && < 0.8
+      , haskeline >= 0.7.4.2 && < 0.8
       , pretty-show >= 1.9.5 && < 1.10
   default-language: Haskell2010
 

--- a/hnix.cabal
+++ b/hnix.cabal
@@ -490,7 +490,7 @@ library
     , binary >= 0.8.5 && < 0.9
     , bytestring >= 0.10.8 && < 0.11
     , comonad >= 5.0.4 && < 5.1
-    , containers >= 0.5.11 && < 0.6
+    , containers >= 0.6.0.1 && < 0.7
     , data-fix >= 0.2.0 && <  0.3
     , deepseq >=1.4.2 && <1.5
     , dependent-sum >= 0.4 && < 0.5
@@ -501,9 +501,9 @@ library
     , free >= 5.1 && < 5.2
     , hashing >= 0.1.0 && < 0.2
     , hnix-store-core >= 0.1.0 && < 0.2
-    , http-client >= 0.6.2 && < 0.7
+    , http-client >= 0.5.14 && < 0.6
     , http-client-tls >= 0.3.5 && < 0.4
-    , http-types >= 0.12.3 && < 0.13
+    , http-types >= 0.12.2 && < 0.13
     , interpolate >= 0.2.0 && < 0.3
     , lens-family-th >= 0.5.0 && < 0.6
     , logict >= 0.6.0 && < 0.7
@@ -522,9 +522,9 @@ library
     , semigroups >=0.18 && <0.19
     , split >= 0.2.3 && < 0.3
     , syb >= 0.7 && < 0.8
-    , template-haskell >= 2.13.0 && < 2.14
+    , template-haskell >= 2.14.0.0 && < 2.15
     , text >= 1.2.3 && < 1.3
-    , these >= 0.8 && < 0.9
+    , these >= 0.7.5 && < 0.8
     , time >= 1.8.0 && < 1.9
     , transformers >= 0.5.5 && < 0.6
     , transformers-base >= 0.4.5 && < 0.5
@@ -564,7 +564,7 @@ library
         Nix.Options.Parser
     build-depends:
         hashable >=1.2.5 && <1.3
-      , haskeline >= 0.7.5 && < 0.8
+      , haskeline >= 0.7.4.3 && < 0.8
       , pretty-show >= 1.9.5 && < 1.10
   default-language: Haskell2010
 


### PR DESCRIPTION
This is a follow-up to the discussion in #486, where hackage users got an incompatible combination of `hnix` and `hnix-store` due to lack of dependency bounds.

We should probably debate the pros and cons of this a bit, because conservative version bounds will add some maintenance trouble. @mightybyte, @shlevy , @jwiegley is `hnix` ready for its dependency versions to be managed manually? Anyone else have a strong feeling about this?

*Edit*: Note as Shea says, hnix-store-core wasn't on hackage yet and its version number was still at 0.1.0. So, let's just consider this PR in terms of future compatibility tracking.