### PR TITLE
Fix eval-okay-builtins-add.

### DIFF
--- a/src/Nix/Atoms.hs
+++ b/src/Nix/Atoms.hs
@@ -11,6 +11,7 @@ import Codec.Serialise
 #endif
 import           Control.DeepSeq
 import           Data.Data
+import           Data.Fixed                     (mod')
 import           Data.Hashable
 import           Data.Text                      ( Text
                                                 , pack
@@ -40,6 +41,10 @@ instance Serialise NAtom
 -- | Translate an atom into its nix representation.
 atomText :: NAtom -> Text
 atomText (NInt   i) = pack (show i)
-atomText (NFloat f) = pack (show f)
+atomText (NFloat f) = pack (showNixFloat f)
+  where
+    showNixFloat x
+      | x `mod'` 1 /= 0 = show x
+      | otherwise       = show (truncate x :: Int)
 atomText (NBool  b) = if b then "true" else "false"
 atomText NNull      = "null"

--- a/tests/NixLanguageTests.hs
+++ b/tests/NixLanguageTests.hs
@@ -71,7 +71,6 @@ newFailingTests = Set.fromList
   , "eval-okay-fromTOML"
   , "eval-okay-context-introspection"
   , "eval-okay-concatmap"
-  , "eval-okay-builtins-add"
   ]
 
 genTests :: IO TestTree


### PR DESCRIPTION
Nix omits the trailing .0 when displaying a Float. Aligning
hnix pretty printer with this behavior.

Fixes #447.