### PR TITLE
Builtins: add builtins.concatMap

### DIFF
--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -175,6 +175,7 @@ builtinsList = sequence
   , add2 Normal   "catAttrs"         catAttrs
   , add2 Normal   "compareVersions"  compareVersions_
   , add  Normal   "concatLists"      concatLists
+  , add2 Normal   "concatMap"        concatMap_
   , add' Normal   "concatStringsSep" (arity2 principledIntercalateNixString)
   , add0 Normal   "currentSystem"    currentSystem
   , add0 Normal   "currentTime"      currentTime_
@@ -1161,6 +1162,20 @@ concatLists =
     >=> mapM (flip demand $ fromValue @[NValue t f m] >=> pure)
     >=> toValue
     .   concat
+
+concatMap_
+  :: forall e t f m
+   . MonadNix e t f m
+  => NValue t f m
+  -> NValue t f m
+  -> m (NValue t f m)
+concatMap_ f =
+  fromValue @[NValue t f m]
+    >=> traverse applyFunc
+    >=> toValue . concat
+  where
+    applyFunc :: NValue t f m  -> m [NValue t f m]
+    applyFunc =  (f `callFunc`) >=> fromValue
 
 listToAttrs
   :: forall e t f m . MonadNix e t f m => NValue t f m -> m (NValue t f m)

--- a/tests/NixLanguageTests.hs
+++ b/tests/NixLanguageTests.hs
@@ -70,7 +70,6 @@ newFailingTests = Set.fromList
   [ "eval-okay-path"
   , "eval-okay-fromTOML"
   , "eval-okay-context-introspection"
-  , "eval-okay-concatmap"
   ]
 
 genTests :: IO TestTree


### PR DESCRIPTION
Fixes #448

We were missing the new `concatMap` builtin.

I did not find an immediate way to test the evaluation strategy, ie. what thunk to force/defer.

Since this function is quite straightforward and not really documented outside of the nix repository, I guess we can use nix's evaluation strategy as a reference here :-)

See https://github.com/NixOS/nix/blob/master/src/libexpr/primops.cc#L1639