### PR TITLE
Fix nixUri source span

### DIFF
--- a/src/Nix/Parser.hs
+++ b/src/Nix/Parser.hs
@@ -286,7 +286,7 @@ nixString :: Parser NExprLoc
 nixString = nStr <$> annotateLocation nixString'
 
 nixUri :: Parser NExprLoc
-nixUri = annotateLocation1 $ lexeme $ try $ do
+nixUri = lexeme $ annotateLocation1 $ try $ do
   start    <- letterChar
   protocol <- many $ satisfy $ \x ->
     isAlpha x || isDigit x || x `elem` ("+-." :: String)


### PR DESCRIPTION
Previously it would include the spacing after the URI in the source
span.

Fix for https://github.com/Infinisil/nix-quote-urls/issues/1