### PR TITLE
README: Getting Started: upd use new-* cabal options for Nix

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,13 +18,13 @@ $ git clone --recursive https://github.com/haskell-nix/hnix.git
 ...
 $ cd hnix
 $ nix-shell
-$ cabal configure --enable-tests
-$ cabal build
-$ cabal test
+$ cabal new-configure --enable-tests
+$ cabal new-build
+$ cabal new-test
 # To run all of the tests, which takes up to a minute:
-$ env ALL_TESTS=yes cabal test
+$ env ALL_TESTS=yes cabal new-test
 # To run only specific tests (see `tests/Main.hs` for a list)
-$ env NIXPKGS_TESTS=yes PRETTY_TESTS=1 cabal test
+$ env NIXPKGS_TESTS=yes PRETTY_TESTS=1 cabal new-test
 $ ./dist/build/hnix/hnix --help
 ```
 


### PR DESCRIPTION
Otherwise:
```
$ cabal test
Warning: The test command is a part of the legacy v1 style of cabal usage.

Please switch to using either the new project style and the new-test command
or the legacy v1-test alias as new-style projects will become the default in
the next version of cabal-install. Please file a bug if you cannot replicate a
working v1- use case with the new-style commands.

For more information, see: https://wiki.haskell.org/Cabal/NewBuild

/nix/store/iajira937isi5mjnrdcnvazd6p63b31d-ghc-8.6.3-with-packages/bin/ghc-pkg: createProcess: runInteractiveProcess: exec: does not exist (No such file or directory)
```

At the very least `cabal new-test` seems to be required, but also new-* commands seems to use Nix better inside nix-shell.