### PR TITLE
Concat list null fixes

### DIFF
--- a/src/Nix/Exec.hs
+++ b/src/Nix/Exec.hs
@@ -453,15 +453,13 @@ execBinaryOp scope span op lval rarg = do
       _       -> nverr $ ErrorCall $ unsupportedTypes lval rval
 
     (NVList ls, NVConstant NNull) -> case op of
-      NConcat -> pure $ bin nvListP ls
-      NEq     -> toBool =<< valueEqM lval (nvList [])
-      NNEq    -> toBool . not =<< valueEqM lval (nvList [])
+      NEq     -> toBool False
+      NNEq    -> toBool True
       _       -> nverr $ ErrorCall $ unsupportedTypes lval rval
 
     (NVConstant NNull, NVList rs) -> case op of
-      NConcat -> pure $ bin nvListP rs
-      NEq     -> toBool =<< valueEqM (nvList []) rval
-      NNEq    -> toBool . not =<< valueEqM (nvList []) rval
+      NEq     -> toBool False
+      NNEq    -> toBool True
       _       -> nverr $ ErrorCall $ unsupportedTypes lval rval
 
     (NVPath p, NVStr ns) -> case op of

--- a/src/Nix/Type/Infer.hs
+++ b/src/Nix/Type/Infer.hs
@@ -311,16 +311,7 @@ binops u1 = \case
   NOr   -> [EqConst u1 (typeFun [typeBool, typeBool, typeBool])]
   NImpl -> [EqConst u1 (typeFun [typeBool, typeBool, typeBool])]
 
-  NConcat ->
-    [ EqConst
-        u1
-        (TMany
-          [ typeFun [typeList, typeList, typeList]
-          , typeFun [typeList, typeNull, typeList]
-          , typeFun [typeNull, typeList, typeList]
-          ]
-        )
-    ]
+  NConcat -> [EqConst u1 (typeFun [typeList, typeList, typeList])]
 
   NUpdate ->
     [ EqConst


### PR DESCRIPTION
Currently, hnix allows concatenating and comparing lists with null. Nix doesn't, hence I've adjusted the type checker and evaluator to reflect that.