### PR TITLE
Replacing every use of ErrorCall with a custom Exception value

### DIFF
--- a/README-design.md
+++ b/README-design.md
@@ -41,3 +41,7 @@ points in the code are generic over both.
 Having said that, I should mention that there are two different types of
 values: `NValue` and `NValueNF`. The former is created by evaluating an
 `NExpr`, and then latter by calling `normalForm` on an `NValue`.
+
+## Exception types
+
+Exception type and data constructors end with an `E`.

--- a/README-design.md
+++ b/README-design.md
@@ -44,4 +44,5 @@ values: `NValue` and `NValueNF`. The former is created by evaluating an
 
 ## Exception types
 
-Exception type and data constructors end with an `E`.
+Exception type constructors start with `EA` or `ES`, exception data constructors start
+with an `E`, where: `E` - *exception*, `A` - *asynchronous*, `S` - *synchronous*.

--- a/README-design.md
+++ b/README-design.md
@@ -44,5 +44,5 @@ values: `NValue` and `NValueNF`. The former is created by evaluating an
 
 ## Exception types
 
-Exception type constructors start with `EA` or `ES`, exception data constructors start
-with an `E`, where: `E` - *exception*, `A` - *asynchronous*, `S` - *synchronous*.
+*Synchronous* exception type and data constructors start with `E` acronym.
+*Asynchronous* exception constructors start with `EA` acronym.

--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -1117,10 +1117,7 @@ genList
 genList f = fromValue @Integer >=> \n -> if n >= 0
   then toValue =<< forM [0 .. n - 1] (\i -> defer $ (f `callFunc`) =<< toValue i)
   else
-    throwError
-    $  ErrorCall
-    $  displayException
-    $  EGenListNegativeNum n
+    throwError $ EGenListNegativeNum n
 
 -- We wrap values solely to provide an Ord instance for genericClosure
 newtype WValue t f m = WValue (NValue t f m)

--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -1257,8 +1257,7 @@ functionArgs fun = demand fun $ \case
       Param name     -> M.singleton name False
       ParamSet s _ _ -> isJust <$> M.fromList s
   v ->
-    throwError
-      $ ErrorCall $ displayException $ EFunctionArgsArgNotFun v
+    throwError $ EFunctionArgsArgNotFun v
 
 toFile
   :: MonadNix e t f m

--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -768,7 +768,7 @@ head_ = fromValue >=> \case
 
 tail_ :: MonadNix e t f m => NValue t f m -> m (NValue t f m)
 tail_ = fromValue >=> \case
-  []    -> throwError $ ErrorCall $ displayException ETail_EmptyList
+  []    -> throwError ETail_EmptyList
   _ : t -> return $ nvList t
 
 data VersionComponent

--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -106,106 +106,106 @@ import           System.Posix.Files             ( isRegularFile
 import           Text.Read
 import           Text.Regex.TDFA
 
-newtype EAMkThunk a
+newtype EMkThunk a
   = EMkThunkInBuiltin a
   deriving Show
 
-instance Exception (EAMkThunk Text)
+instance Exception (EMkThunk Text)
  where
   displayException (EMkThunkInBuiltin n)
     = "While calling builtin " <> Text.unpack n <> "\n"
 
-newtype EAFoldNixPath a
+newtype EFoldNixPath a
   = EFoldNixPathUnexpectedEntry a
   deriving Show
 
 instance (Show a, Typeable a)
-  => Exception (EAFoldNixPath a)
+  => Exception (EFoldNixPath a)
  where
   displayException (EFoldNixPathUnexpectedEntry x)
     = "Unexpected entry in NIX_PATH: " <> show x
 
-newtype EAAttrsetGet a
+newtype EAttrsetGet a
   = EAttrsetGetAttrRequired a
   deriving Show
 
-instance Exception (EAAttrsetGet Text)
+instance Exception (EAttrsetGet Text)
  where
   displayException (EAttrsetGetAttrRequired k)
     = "Attribute '" <> Text.unpack k <> "' required"
 
-data EAUnsafeGetAttrPos a b
+data EUnsafeGetAttrPos a b
   = EUnsafeGetAttrPosInvalidTypes a b
   deriving Show
 
 instance (Show a, Typeable a, Show b, Typeable b)
-  => Exception (EAUnsafeGetAttrPos a b)
+  => Exception (EUnsafeGetAttrPos a b)
  where
   displayException (EUnsafeGetAttrPosInvalidTypes x y)
     = "Invalid types for builtins.unsafeGetAttrPos: " <> show (x, y)
 
-data EAHead_
+data EHead_
   = EHead_EmptyList
   deriving Show
 
-instance Exception EAHead_
+instance Exception EHead_
  where
   displayException EHead_EmptyList
     = "builtins.head: empty list"
 
-data EATail_
+data ETail_
   = ETail_EmptyList
   deriving Show
 
-instance Exception EATail_
+instance Exception ETail_
  where
   displayException ETail_EmptyList
     = "builtins.tail: empty list"
 
-newtype EASubString a
+newtype ESubString a
   = ESubStringNegativeStartPosition a
   deriving Show
 
 instance (Show a, Typeable a)
-  => Exception (EASubString a)
+  => Exception (ESubString a)
  where
   displayException (ESubStringNegativeStartPosition start)
     = "builtins.substring: negative start position: " <> show start
 
-data EAMap_
+data EMap_
   = EMap_
   deriving Show
 
-instance Exception EAMap_
+instance Exception EMap_
  where
   displayException EMap_
     = "While applying f in map:\n"
 
-data EAMapAttrs_
+data EMapAttrs_
   = EMapAttrs_
   deriving Show
 
-instance Exception EAMapAttrs_
+instance Exception EMapAttrs_
  where
   displayException EMapAttrs_
     = "While applying f in mapAttrs:\n"
 
-newtype EADirOf a
+newtype EDirOf a
   = EDirOfWrongArg a
   deriving Show
 
 instance (Show a, Typeable a)
-  => Exception (EADirOf a)
+  => Exception (EDirOf a)
  where
   displayException (EDirOfWrongArg v)
     = "dirOf: expected string or path, got " ++ show v
 
-data EAElemAt_ a b
+data EElemAt_ a b
   = EElemAt_IndexOutOfBound a b
   deriving Show
 
 instance (Show a, Typeable a, Foldable t, Show (t b), Typeable (t b))
-  => Exception (EAElemAt_ a (t b))
+  => Exception (EElemAt_ a (t b))
  where
   displayException (EElemAt_IndexOutOfBound n' xs')
     = "builtins.elem: Index "
@@ -213,24 +213,24 @@ instance (Show a, Typeable a, Foldable t, Show (t b), Typeable (t b))
     <> " too large for list of length "
     <> show (length xs')
 
-newtype EAGenList a
+newtype EGenList a
   = EGenListNegativeNum a
   deriving Show
 
 instance (Show a, Typeable a)
-  => Exception (EAGenList a)
+  => Exception (EGenList a)
  where
   displayException (EGenListNegativeNum n)
     = "builtins.genList: Expected a non-negative number, got "
     <> show n
 
-data EAGenericClosure
+data EGenericClosure
  = EGenericClosureNoAttrsStartSetNOperator
  | EGenericClosureNoAttrStartSet
  | EGenericClosureNoAttrOperator
  deriving Show
 
-instance Exception EAGenericClosure
+instance Exception EGenericClosure
  where
   displayException EGenericClosureNoAttrsStartSetNOperator
     = "builtins.genericClosure: Attributes 'startSet' and 'operator' required"
@@ -239,41 +239,41 @@ instance Exception EAGenericClosure
   displayException EGenericClosureNoAttrOperator
     = "builtins.genericClosure: Attribute 'operator' required"
 
-data EAReplaceStrings
+data EReplaceStrings
   = EReplaceStringsDiffLenArgs
   deriving Show
 
-instance Exception EAReplaceStrings
+instance Exception EReplaceStrings
  where
   displayException EReplaceStringsDiffLenArgs
     = "'from' and 'to' arguments to 'replaceStrings'have different lengths"
 
-newtype EAPathExists_ a
+newtype EPathExists_ a
   = EPathExists_NotPath a
   deriving Show
 
 instance (Show a, Typeable a)
-  => Exception (EAPathExists_ a)
+  => Exception (EPathExists_ a)
  where
   displayException (EPathExists_NotPath v)
     = "builtins.pathExists: expected path, got " <> show v
 
-newtype EAFunctionArgs a
+newtype EFunctionArgs a
  = EFunctionArgsArgNotFun a
  deriving Show
 
 instance (Show a, Typeable a)
-  => Exception (EAFunctionArgs a)
+  => Exception (EFunctionArgs a)
  where
   displayException (EFunctionArgsArgNotFun v)
     = "builtins.functionArgs: expected function, got " <> show v
 
-data EALessThan a b
+data ELessThan a b
   = ELessThanUnsupportedArgs a b
   deriving Show
 
 instance (Show a, Typeable a, Show b, Typeable b)
-  => Exception (EALessThan a b)
+  => Exception (ELessThan a b)
  where
   displayException (ELessThanUnsupportedArgs va vb)
     = "builtins.lessThan: expected two numbers or two strings, got '"
@@ -282,25 +282,25 @@ instance (Show a, Typeable a, Show b, Typeable b)
     <> show vb
     <> "'"
 
-newtype EAHashString a
+newtype EHashString a
   = EHashStringUnsupportedValue a
   deriving Show
 
 instance (Show a, Typeable a)
-  => Exception (EAHashString a)
+  => Exception (EHashString a)
  where
   displayException (EHashStringUnsupportedValue algo)
     = "builtins.hashString: "
     <> "expected \"md5\", \"sha1\", \"sha256\", or \"sha512\", got "
     <> show algo
 
-data EAAbsolutePathFromValue a
+data EAbsolutePathFromValue a
   = EAbsolutePathFromValueNotAbsPath a
   | EAbsolutePathFromValueNotPath a
   deriving Show
 
 instance (Show a, Typeable a)
-  => Exception (EAAbsolutePathFromValue a)
+  => Exception (EAbsolutePathFromValue a)
  where
    displayException (EAbsolutePathFromValueNotAbsPath path)
      = "string "
@@ -310,14 +310,14 @@ instance (Show a, Typeable a)
    displayException (EAbsolutePathFromValueNotPath v)
      = "expected a path, got " <> show v
 
-data EAFindFile_ a
+data EFindFile_ a
   = EFindFile_NotString a
   | EFindFile_NotList a
   | EFindFile_InvalidTypes a
   deriving Show
 
 instance (Show a, Typeable a)
-  => Exception (EAFindFile_ a)
+  => Exception (EFindFile_ a)
  where
   displayException (EFindFile_NotString y)
     = "expected a string, got " <> show y
@@ -326,24 +326,24 @@ instance (Show a, Typeable a)
   displayException (EFindFile_InvalidTypes xy)
     = "Invalid types for builtins.findFile: " <> show xy
 
-newtype EAFromJSON a
+newtype EFromJSON a
   = EFromJSON a
   deriving Show
 
 instance (Show a, Typeable a)
-  => Exception (EAFromJSON a)
+  => Exception (EFromJSON a)
  where
   displayException (EFromJSON jsonError)
     = "builtins.fromJSON: " <> show jsonError
 
-data EAFetchurl a
+data EFetchurl a
   = EFetchrulNotURIOrSet a
   | EFetchrulNotURIOrString a
   | EFetchrulUnsupportedArg a
   deriving Show
 
 instance (Show a, Typeable a)
-  => Exception (EAFetchurl a)
+  => Exception (EFetchurl a)
  where
   displayException (EFetchrulNotURIOrSet v)
     = "builtins.fetchurl: Expected URI or set, got "
@@ -354,24 +354,24 @@ instance (Show a, Typeable a)
   displayException (EFetchrulUnsupportedArg _)
     = "builtins.fetchurl: unsupported arguments to url"
 
-newtype EAGetContext a
+newtype EGetContext a
   = EGetContextUnsupportedType a
   deriving Show
 
 instance (Show a, Typeable a)
-  => Exception (EAGetContext a)
+  => Exception (EGetContext a)
  where
   displayException (EGetContextUnsupportedType x)
     = "Invalid type for builtins.getContext: " <> show x
 
-data EAAppendContext a
+data EAppendContext a
   = EAppendContextInvalidContextOutTypes a
   | EAppendContextInvalidContextValTypes a
   | EAppendContextInvalidTypes a
   deriving Show
 
 instance (Show a, Typeable a)
-  => Exception (EAAppendContext a)
+  => Exception (EAppendContext a)
  where
   displayException (EAppendContextInvalidContextOutTypes x)
     = "Invalid types for context value outputs in builtins.appendContext: "

--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -1474,9 +1474,7 @@ hashString nsAlgo ns = Prim $ do
 #else
           decodeUtf8 $ Base16.encode $ SHA512.hash $ encodeUtf8 s
 #endif
-    _ ->
-      throwError
-        $ ErrorCall $ displayException $ EHashStringUnsupportedValue algo
+    _ -> throwError $ EHashStringUnsupportedValue algo
 
 placeHolder :: MonadNix e t f m => NValue t f m -> m (NValue t f m)
 placeHolder = fromValue >=> fromStringNoContext >=> \t -> do

--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -1389,9 +1389,7 @@ lessThan
   -> NValue t f m
   -> m (NValue t f m)
 lessThan ta tb = demand ta $ \va -> demand tb $ \vb -> do
-  let badType =
-        throwError
-          $ ErrorCall $ displayException $ ELessThanUnsupportedArgs va vb
+  let badType = throwError $ ELessThanUnsupportedArgs va vb
   nvConstant . NBool <$> case (va, vb) of
     (NVConstant ca, NVConstant cb) -> case (ca, cb) of
       (NInt   a, NInt b  ) -> pure $ a < b

--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -1153,9 +1153,7 @@ genericClosure = fromValue @(AttrSet (NValue t f m)) >=> \s ->
     (Nothing, Nothing) ->
       throwError EGenericClosureNoAttrsStartSetNOperator
     (Nothing, Just _) ->
-      throwError
-        $ ErrorCall
-        $ displayException EGenericClosureNoAttrStartSet
+      throwError EGenericClosureNoAttrStartSet
     (Just _, Nothing) ->
       throwError
         $ ErrorCall

--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -763,7 +763,7 @@ foldl'_ f z xs = fromValue @[NValue t f m] xs >>= foldM go z
 
 head_ :: MonadNix e t f m => NValue t f m -> m (NValue t f m)
 head_ = fromValue >=> \case
-  []    -> throwError $ ErrorCall $ displayException EHead_EmptyList
+  []    -> throwError EHead_EmptyList
   h : _ -> pure h
 
 tail_ :: MonadNix e t f m => NValue t f m -> m (NValue t f m)

--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -153,6 +153,15 @@ instance Exception EAHead_
   displayException EHead_EmptyList
     = "builtins.head: empty list"
 
+data EATail_
+  = ETail_EmptyList
+  deriving Show
+
+instance Exception EATail_
+ where
+  displayException ETail_EmptyList
+    = "builtins.tail: empty list"
+
 -- | Evaluate a nix expression in the default context
 withNixContext
   :: forall e t f m r
@@ -542,7 +551,7 @@ head_ = fromValue >=> \case
 
 tail_ :: MonadNix e t f m => NValue t f m -> m (NValue t f m)
 tail_ = fromValue >=> \case
-  []    -> throwError $ ErrorCall "builtins.tail: empty list"
+  []    -> throwError $ ErrorCall $ displayException ETail_EmptyList
   _ : t -> return $ nvList t
 
 data VersionComponent

--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -354,6 +354,16 @@ instance (Show a, Typeable a)
   displayException (EFetchrulUnsupportedArg _)
     = "builtins.fetchurl: unsupported arguments to url"
 
+newtype EAGetContext a
+  = EGetContextUnsupportedType a
+  deriving Show
+
+instance (Show a, Typeable a)
+  => Exception (EAGetContext a)
+ where
+  displayException (EGetContextUnsupportedType x)
+    = "Invalid type for builtins.getContext: " <> show x
+
 -- | Evaluate a nix expression in the default context
 withNixContext
   :: forall e t f m r
@@ -1698,7 +1708,7 @@ getContext x = demand x $ \case
     valued :: M.HashMap Text (NValue t f m) <- sequenceA $ M.map toValue context
     pure $ flip nvSet M.empty $ valued
   x ->
-    throwError $ ErrorCall $ "Invalid type for builtins.getContext: " ++ show x
+    throwError $ ErrorCall $ displayException $ EGetContextUnsupportedType x
 
 appendContext
   :: forall e t f m

--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -1059,7 +1059,7 @@ dirOf x = demand x $ \case
     (principledModifyNixContents (Text.pack . takeDirectory . Text.unpack) ns)
   NVPath path -> pure $ nvPath $ takeDirectory path
   v ->
-    throwError $ ErrorCall $ displayException $ EDirOfWrongArg v
+    throwError $ EDirOfWrongArg v
 
 -- jww (2018-04-28): This should only be a string argument, and not coerced?
 unsafeDiscardStringContext

--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -106,6 +106,15 @@ import           System.Posix.Files             ( isRegularFile
 import           Text.Read
 import           Text.Regex.TDFA
 
+newtype EAMkThunk a
+  = EMkThunkInBuiltin a
+  deriving Show
+
+instance Exception (EAMkThunk Text)
+ where
+  displayException (EMkThunkInBuiltin n)
+    = "While calling builtin " <> Text.unpack n <> "\n"
+
 -- | Evaluate a nix expression in the default context
 withNixContext
   :: forall e t f m r
@@ -298,7 +307,7 @@ builtinsList = sequence
 
   mkThunk n = defer . withFrame
     Info
-    (ErrorCall $ "While calling builtin " ++ Text.unpack n ++ "\n")
+    (ErrorCall $ displayException $ EMkThunkInBuiltin n)
 
   add0 t n v = wrap t n <$> mkThunk n v
   add  t n v = wrap t n <$> mkThunk n (builtin (Text.unpack n) v)

--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -134,6 +134,16 @@ instance Exception (EAAttrsetGet Text)
   displayException (EAttrsetGetAttrRequired k)
     = "Attribute '" <> Text.unpack k <> "' required"
 
+data EAUnsafeGetAttrPos a b
+  = EUnsafeGetAttrPosInvalidTypes a b
+  deriving Show
+
+instance (Show a, Typeable a, Show b, Typeable b)
+  => Exception (EAUnsafeGetAttrPos a b)
+ where
+  displayException (EUnsafeGetAttrPosInvalidTypes x y)
+    = "Invalid types for builtins.unsafeGetAttrPos: " <> show (x, y)
+
 -- | Evaluate a nix expression in the default context
 withNixContext
   :: forall e t f m r
@@ -433,9 +443,7 @@ unsafeGetAttrPos x y = demand x $ \x' -> demand y $ \y' -> case (x', y') of
       Just delta -> toValue delta
   (x, y) ->
     throwError
-      $  ErrorCall
-      $  "Invalid types for builtins.unsafeGetAttrPos: "
-      ++ show (x, y)
+      $  ErrorCall $ displayException $ EUnsafeGetAttrPosInvalidTypes x y
 
 -- This function is a bit special in that it doesn't care about the contents
 -- of the list.

--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -125,6 +125,15 @@ instance (Show a, Typeable a)
   displayException (EFoldNixPathUnexpectedEntry x)
     = "Unexpected entry in NIX_PATH: " <> show x
 
+newtype EAAttrsetGet a
+  = EAttrsetGetAttrRequired a
+  deriving Show
+
+instance Exception (EAAttrsetGet Text)
+ where
+  displayException (EAttrsetGetAttrRequired k)
+    = "Attribute '" <> Text.unpack k <> "' required"
+
 -- | Evaluate a nix expression in the default context
 withNixContext
   :: forall e t f m r
@@ -396,7 +405,7 @@ attrsetGet :: MonadNix e t f m => Text -> AttrSet (NValue t f m) -> m (NValue t 
 attrsetGet k s = case M.lookup k s of
   Just v -> pure v
   Nothing ->
-    throwError $ ErrorCall $ "Attribute '" ++ Text.unpack k ++ "' required"
+    throwError $ ErrorCall $ displayException $ EAttrsetGetAttrRequired k
 
 hasContext :: MonadNix e t f m => NValue t f m -> m (NValue t f m)
 hasContext = toValue . stringHasContext <=< fromValue

--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -1106,10 +1106,7 @@ elemAt_ xs n = fromValue n >>= \n' -> fromValue xs >>= \xs' ->
   case elemAt xs' n' of
     Just a -> pure a
     Nothing ->
-      throwError
-        $ ErrorCall
-        $ displayException
-        $ EElemAt_IndexOutOfBound n' xs'
+      throwError $ EElemAt_IndexOutOfBound n' xs'
 
 genList
   :: forall e t f m

--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -1646,8 +1646,7 @@ fetchurl v = demand v $ \case
       Left  e -> throwError e
       Right p -> toValue p
     v ->
-      throwError
-      $ ErrorCall $ displayException $ EFetchrulNotURIOrString v
+      throwError $ EFetchrulNotURIOrString v
 
   noContextAttrs ns = case principledGetStringNoContext ns of
     Nothing ->

--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -1520,8 +1520,7 @@ findFile_ aset filePath = demand aset $ \aset' -> demand filePath $ \filePath' -
       $ ErrorCall $ displayException $ EFindFile_NotString y
     (x, NVStr _)  -> throwError
       $ ErrorCall $ displayException $ EFindFile_NotList x
-    (x, y)        -> throwError
-      $ ErrorCall $ displayException $ EFindFile_InvalidTypes (x, y)
+    (x, y)        -> throwError $ EFindFile_InvalidTypes (x, y)
 
 data FileType
    = FileTypeRegular

--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -1638,8 +1638,7 @@ fetchurl v = demand v $ \case
   NVSet s _ -> attrsetGet "url" s >>= demand ?? (go (M.lookup "sha256" s))
   v@NVStr{} -> go Nothing v
   v ->
-    throwError
-    $ ErrorCall $ displayException $ EFetchrulNotURIOrSet v
+    throwError $ EFetchrulNotURIOrSet v
  where
   go :: Maybe (NValue t f m) -> NValue t f m -> m (NValue t f m)
   go _msha = \case

--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -651,7 +651,7 @@ attrsetGet :: MonadNix e t f m => Text -> AttrSet (NValue t f m) -> m (NValue t 
 attrsetGet k s = case M.lookup k s of
   Just v -> pure v
   Nothing ->
-    throwError $ ErrorCall $ displayException $ EAttrsetGetAttrRequired k
+    throwError $ EAttrsetGetAttrRequired k
 
 hasContext :: MonadNix e t f m => NValue t f m -> m (NValue t f m)
 hasContext = toValue . stringHasContext <=< fromValue

--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -1553,9 +1553,7 @@ fromJSON
   :: forall e t f m . MonadNix e t f m => NValue t f m -> m (NValue t f m)
 fromJSON arg = demand arg $ fromValue >=> fromStringNoContext >=> \encoded ->
   case A.eitherDecodeStrict' @A.Value $ encodeUtf8 encoded of
-    Left jsonError ->
-      throwError
-      $ ErrorCall $ displayException $ EFromJSON jsonError
+    Left jsonError -> throwError $ EFromJSON jsonError
     Right v -> jsonToNValue v
  where
   jsonToNValue = \case

--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -1729,8 +1729,7 @@ appendContext x y = demand x $ \x' -> demand y $ \y' -> case (x', y') of
       $ toNixLikeContext
       $ principledGetContext ns
   (x, y) ->
-    throwError
-      $ ErrorCall $ displayException $ EAppendContextInvalidTypes (x, y)
+    throwError $ EAppendContextInvalidTypes (x, y)
 
 newtype Prim m a = Prim { runPrim :: m a }
 

--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -190,6 +190,16 @@ instance Exception EAMapAttrs_
   displayException EMapAttrs_
     = "While applying f in mapAttrs:\n"
 
+newtype EADirOf a
+  = EDirOfWrongArg a
+  deriving Show
+
+instance (Show a, Typeable a)
+  => Exception (EADirOf a)
+ where
+  displayException (EDirOfWrongArg v)
+    = "dirOf: expected string or path, got " ++ show v
+
 -- | Evaluate a nix expression in the default context
 withNixContext
   :: forall e t f m r
@@ -870,7 +880,7 @@ dirOf x = demand x $ \case
     (principledModifyNixContents (Text.pack . takeDirectory . Text.unpack) ns)
   NVPath path -> pure $ nvPath $ takeDirectory path
   v ->
-    throwError $ ErrorCall $ "dirOf: expected string or path, got " ++ show v
+    throwError $ ErrorCall $ displayException $ EDirOfWrongArg v
 
 -- jww (2018-04-28): This should only be a string argument, and not coerced?
 unsafeDiscardStringContext

--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -1516,8 +1516,7 @@ findFile_ aset filePath = demand aset $ \aset' -> demand filePath $ \filePath' -
     (NVList x, NVStr ns) -> do
       mres <- findPath @t @f @m x (Text.unpack (hackyStringIgnoreContext ns))
       pure $ nvPath mres
-    (NVList _, y) -> throwError
-      $ ErrorCall $ displayException $ EFindFile_NotString y
+    (NVList _, y) -> throwError $ EFindFile_NotString y
     (x, NVStr _)  -> throwError $ EFindFile_NotList x
     (x, y)        -> throwError $ EFindFile_InvalidTypes (x, y)
 

--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -258,6 +258,16 @@ instance (Show a, Typeable a)
   displayException (EPathExists_NotPath v)
     = "builtins.pathExists: expected path, got " <> show v
 
+newtype EAFunctionArgs a
+ = EFunctionArgsArgNotFun a
+ deriving Show
+
+instance (Show a, Typeable a)
+  => Exception (EAFunctionArgs a)
+ where
+  displayException (EFunctionArgsArgNotFun v)
+    = "builtins.functionArgs: expected function, got " <> show v
+
 -- | Evaluate a nix expression in the default context
 withNixContext
   :: forall e t f m r
@@ -1151,9 +1161,7 @@ functionArgs fun = demand fun $ \case
       ParamSet s _ _ -> isJust <$> M.fromList s
   v ->
     throwError
-      $  ErrorCall
-      $  "builtins.functionArgs: expected function, got "
-      ++ show v
+      $ ErrorCall $ displayException $ EFunctionArgsArgNotFun v
 
 toFile
   :: MonadNix e t f m

--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -239,6 +239,15 @@ instance Exception EAGenericClosure
   displayException EGenericClosureNoAttrOperator
     = "builtins.genericClosure: Attribute 'operator' required"
 
+data EAReplaceStrings
+  = EReplaceStringsDiffLenArgs
+  deriving Show
+
+instance Exception EAReplaceStrings
+ where
+  displayException EReplaceStringsDiffLenArgs
+    = "'from' and 'to' arguments to 'replaceStrings'have different lengths"
+
 -- | Evaluate a nix expression in the default context
 withNixContext
   :: forall e t f m r
@@ -1061,10 +1070,9 @@ replaceStrings tfrom tto ts = fromValue (Deeper tfrom) >>= \(nsFrom :: [NixStrin
     fromValue ts >>= \(ns :: NixString) -> do
       let from = map principledStringIgnoreContext nsFrom
       when (length nsFrom /= length nsTo)
-        $  throwError
-        $  ErrorCall
-        $  "'from' and 'to' arguments to 'replaceStrings'"
-        ++ " have different lengths"
+        $ throwError
+        $ ErrorCall
+        $ displayException EReplaceStringsDiffLenArgs
       let
         lookupPrefix s = do
           (prefix, replacement) <- find ((`Text.isPrefixOf` s) . fst)

--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -144,6 +144,15 @@ instance (Show a, Typeable a, Show b, Typeable b)
   displayException (EUnsafeGetAttrPosInvalidTypes x y)
     = "Invalid types for builtins.unsafeGetAttrPos: " <> show (x, y)
 
+data EAHead_
+  = EHead_EmptyList
+  deriving Show
+
+instance Exception EAHead_
+ where
+  displayException EHead_EmptyList
+    = "builtins.head: empty list"
+
 -- | Evaluate a nix expression in the default context
 withNixContext
   :: forall e t f m r
@@ -528,7 +537,7 @@ foldl'_ f z xs = fromValue @[NValue t f m] xs >>= foldM go z
 
 head_ :: MonadNix e t f m => NValue t f m -> m (NValue t f m)
 head_ = fromValue >=> \case
-  []    -> throwError $ ErrorCall "builtins.head: empty list"
+  []    -> throwError $ ErrorCall $ displayException EHead_EmptyList
   h : _ -> pure h
 
 tail_ :: MonadNix e t f m => NValue t f m -> m (NValue t f m)

--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -1496,8 +1496,7 @@ absolutePathFromValue = \case
   NVStr ns -> do
     let path = Text.unpack $ hackyStringIgnoreContext ns
     unless (isAbsolute path)
-      $ throwError
-      $ ErrorCall $ displayException $ EAbsolutePathFromValueNotAbsPath path
+      $ throwError $ EAbsolutePathFromValueNotAbsPath path
     pure path
   NVPath path -> pure path
   v           -> throwError

--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -1155,9 +1155,7 @@ genericClosure = fromValue @(AttrSet (NValue t f m)) >=> \s ->
     (Nothing, Just _) ->
       throwError EGenericClosureNoAttrStartSet
     (Just _, Nothing) ->
-      throwError
-        $ ErrorCall
-        $ displayException EGenericClosureNoAttrOperator
+      throwError EGenericClosureNoAttrOperator
     (Just startSet, Just operator) ->
       demand startSet $ fromValue @[NValue t f m] >=> \ss ->
         demand operator $ \op -> toValue @[NValue t f m] =<< snd <$> go op ss S.empty

--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -678,8 +678,7 @@ unsafeGetAttrPos x y = demand x $ \x' -> demand y $ \y' -> case (x', y') of
       Nothing    -> pure $ nvConstant NNull
       Just delta -> toValue delta
   (x, y) ->
-    throwError
-      $  ErrorCall $ displayException $ EUnsafeGetAttrPosInvalidTypes x y
+    throwError $ EUnsafeGetAttrPosInvalidTypes x y
 
 -- This function is a bit special in that it doesn't care about the contents
 -- of the list.

--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -248,6 +248,16 @@ instance Exception EAReplaceStrings
   displayException EReplaceStringsDiffLenArgs
     = "'from' and 'to' arguments to 'replaceStrings'have different lengths"
 
+newtype EAPathExists_ a
+  = EPathExists_NotPath a
+  deriving Show
+
+instance (Show a, Typeable a)
+  => Exception (EAPathExists_ a)
+ where
+  displayException (EPathExists_NotPath v)
+    = "builtins.pathExists: expected path, got " <> show v
+
 -- | Evaluate a nix expression in the default context
 withNixContext
   :: forall e t f m r
@@ -1171,9 +1181,7 @@ pathExists_ path = demand path $ \case
   NVStr  ns -> toValue =<< pathExists (Text.unpack (hackyStringIgnoreContext ns))
   v ->
     throwError
-      $  ErrorCall
-      $  "builtins.pathExists: expected path, got "
-      ++ show v
+      $ ErrorCall $ displayException $ EPathExists_NotPath v
 
 hasKind
   :: forall a e t f m

--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -172,6 +172,15 @@ instance (Show a, Typeable a)
   displayException (ESubStringNegativeStartPosition start)
     = "builtins.substring: negative start position: " <> show start
 
+data EAMap_
+  = EMap_
+  deriving Show
+
+instance Exception EAMap_
+ where
+  displayException EMap_
+    = "While applying f in map:\n"
+
 -- | Evaluate a nix expression in the default context
 withNixContext
   :: forall e t f m r
@@ -769,7 +778,7 @@ map_ f =
   toValue
     <=< traverse
           ( defer @(NValue t f m)
-          . withFrame Debug (ErrorCall "While applying f in map:\n")
+          . withFrame Debug (ErrorCall $ displayException EMap_)
           . (f `callFunc`)
           )
     <=< fromValue @[NValue t f m]

--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -573,9 +573,7 @@ builtinsList = sequence
   arity2 :: forall a b c. (a -> b -> c) -> (a -> b -> Prim m c)
   arity2 f = ((Prim . pure) .) . f
 
-  mkThunk n = defer . withFrame
-    Info
-    (ErrorCall $ displayException $ EMkThunkInBuiltin n)
+  mkThunk n = defer . withFrame Info (EMkThunkInBuiltin n)
 
   add0 t n v = wrap t n <$> mkThunk n v
   add  t n v = wrap t n <$> mkThunk n (builtin (Text.unpack n) v)

--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -991,7 +991,7 @@ mapAttrs_ f xs = fromValue @(AttrSet (NValue t f m)) xs >>= \aset -> do
   let pairs = M.toList aset
   values <- for pairs $ \(key, value) ->
     defer @(NValue t f m)
-      $   withFrame Debug (ErrorCall $ displayException EMapAttrs_)
+      $   withFrame Debug EMapAttrs_
       $   callFunc ?? value
       =<< callFunc f (nvStr (principledMakeNixStringWithoutContext key))
   toValue . M.fromList . zip (map fst pairs) $ values

--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -721,8 +721,10 @@ splitMatches numDropped (((_, (start, len)) : captures) : mts) haystack =
 
 thunkStr s = nvStr (hackyMakeNixStringWithoutContext (decodeUtf8 s))
 
-substring :: forall e t f m. MonadNix e t f m => Int -> Int -> NixString -> Prim m NixString
-substring start len str = Prim $ if start < 0 --NOTE: negative values of 'len' are OK
+substring :: forall e t f m. MonadNix e t f m
+  => Int -> Int -> NixString -> Prim m NixString
+-- 2019-03-17: NOTE: negative values of 'len' are OK
+substring start len str = Prim $ if start < 0
   then
     throwError
     $  ErrorCall

--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -1716,9 +1716,7 @@ appendContext x y = demand x $ \x' -> demand y $ \y' -> case (x', y') of
             NVList vs ->
               forM vs $ fmap principledStringIgnoreContext . fromValue
             x ->
-              throwError
-                $ ErrorCall
-                $ displayException $ EAppendContextInvalidContextOutTypes x
+              throwError $ EAppendContextInvalidContextOutTypes x
         return $ NixLikeContextValue path allOutputs outputs
       x ->
         throwError

--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -1151,9 +1151,7 @@ genericClosure
 genericClosure = fromValue @(AttrSet (NValue t f m)) >=> \s ->
   case (M.lookup "startSet" s, M.lookup "operator" s) of
     (Nothing, Nothing) ->
-      throwError
-        $ ErrorCall
-        $ displayException EGenericClosureNoAttrsStartSetNOperator
+      throwError EGenericClosureNoAttrsStartSetNOperator
     (Nothing, Just _) ->
       throwError
         $ ErrorCall

--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -1650,8 +1650,7 @@ fetchurl v = demand v $ \case
 
   noContextAttrs ns = case principledGetStringNoContext ns of
     Nothing ->
-      throwError
-      $ ErrorCall $ displayException $ EFetchrulUnsupportedArg ()
+      throwError $ EFetchrulUnsupportedArg ()
     Just t -> pure t
 
 partition_

--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -326,6 +326,16 @@ instance (Show a, Typeable a)
   displayException (EFindFile_InvalidTypes xy)
     = "Invalid types for builtins.findFile: " <> show xy
 
+newtype EAFromJSON a
+  = EFromJSON a
+  deriving Show
+
+instance (Show a, Typeable a)
+  => Exception (EAFromJSON a)
+ where
+  displayException (EFromJSON jsonError)
+    = "builtins.fromJSON: " <> show jsonError
+
 -- | Evaluate a nix expression in the default context
 withNixContext
   :: forall e t f m r
@@ -1526,7 +1536,8 @@ fromJSON
 fromJSON arg = demand arg $ fromValue >=> fromStringNoContext >=> \encoded ->
   case A.eitherDecodeStrict' @A.Value $ encodeUtf8 encoded of
     Left jsonError ->
-      throwError $ ErrorCall $ "builtins.fromJSON: " ++ jsonError
+      throwError
+      $ ErrorCall $ displayException $ EFromJSON jsonError
     Right v -> jsonToNValue v
  where
   jsonToNValue = \case

--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -213,6 +213,17 @@ instance (Show a, Typeable a, Foldable t, Show (t b), Typeable (t b))
     <> " too large for list of length "
     <> show (length xs')
 
+newtype EAGenList a
+  = EGenListNegativeNum a
+  deriving Show
+
+instance (Show a, Typeable a)
+  => Exception (EAGenList a)
+ where
+  displayException (EGenListNegativeNum n)
+    = "builtins.genList: Expected a non-negative number, got "
+    <> show n
+
 -- | Evaluate a nix expression in the default context
 withNixContext
   :: forall e t f m r
@@ -956,8 +967,8 @@ genList f = fromValue @Integer >=> \n -> if n >= 0
   else
     throwError
     $  ErrorCall
-    $  "builtins.genList: Expected a non-negative number, got "
-    ++ show n
+    $  displayException
+    $  EGenListNegativeNum n
 
 -- We wrap values solely to provide an Ord instance for genericClosure
 newtype WValue t f m = WValue (NValue t f m)

--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -282,6 +282,17 @@ instance (Show a, Typeable a, Show b, Typeable b)
     <> show vb
     <> "'"
 
+newtype EAHashString a
+  = EHashStringUnsupportedValue a
+  deriving Show
+
+instance (Show a, Typeable a)
+  => Exception (EAHashString a)
+ where
+  displayException (EHashStringUnsupportedValue algo)
+    = "builtins.hashString: "
+    <> "expected \"md5\", \"sha1\", \"sha256\", or \"sha512\", got "
+    <> show algo
 
 -- | Evaluate a nix expression in the default context
 withNixContext
@@ -1398,10 +1409,7 @@ hashString nsAlgo ns = Prim $ do
 #endif
     _ ->
       throwError
-        $  ErrorCall
-        $  "builtins.hashString: "
-        ++ "expected \"md5\", \"sha1\", \"sha256\", or \"sha512\", got "
-        ++ show algo
+        $ ErrorCall $ displayException $ EHashStringUnsupportedValue algo
 
 placeHolder :: MonadNix e t f m => NValue t f m -> m (NValue t f m)
 placeHolder = fromValue >=> fromStringNoContext >=> \t -> do

--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -181,6 +181,15 @@ instance Exception EAMap_
   displayException EMap_
     = "While applying f in map:\n"
 
+data EAMapAttrs_
+  = EMapAttrs_
+  deriving Show
+
+instance Exception EAMapAttrs_
+ where
+  displayException EMapAttrs_
+    = "While applying f in mapAttrs:\n"
+
 -- | Evaluate a nix expression in the default context
 withNixContext
   :: forall e t f m r
@@ -793,7 +802,7 @@ mapAttrs_ f xs = fromValue @(AttrSet (NValue t f m)) xs >>= \aset -> do
   let pairs = M.toList aset
   values <- for pairs $ \(key, value) ->
     defer @(NValue t f m)
-      $   withFrame Debug (ErrorCall "While applying f in mapAttrs:\n")
+      $   withFrame Debug (ErrorCall $ displayException EMapAttrs_)
       $   callFunc ?? value
       =<< callFunc f (nvStr (principledMakeNixStringWithoutContext key))
   toValue . M.fromList . zip (map fst pairs) $ values

--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -162,6 +162,16 @@ instance Exception EATail_
   displayException ETail_EmptyList
     = "builtins.tail: empty list"
 
+newtype EASubString a
+  = ESubStringNegativeStartPosition a
+  deriving Show
+
+instance (Show a, Typeable a)
+  => Exception (EASubString a)
+ where
+  displayException (ESubStringNegativeStartPosition start)
+    = "builtins.substring: negative start position: " <> show start
+
 -- | Evaluate a nix expression in the default context
 withNixContext
   :: forall e t f m r
@@ -727,9 +737,7 @@ substring :: forall e t f m. MonadNix e t f m
 substring start len str = Prim $ if start < 0
   then
     throwError
-    $  ErrorCall
-    $  "builtins.substring: negative start position: "
-    ++ show start
+    $  ErrorCall $ displayException $ ESubStringNegativeStartPosition start
   else pure $ principledModifyNixContents (Text.take len . Text.drop start) str
 
 attrNames

--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -941,11 +941,11 @@ thunkStr s = nvStr (hackyMakeNixStringWithoutContext (decodeUtf8 s))
 substring :: forall e t f m. MonadNix e t f m
   => Int -> Int -> NixString -> Prim m NixString
 -- 2019-03-17: NOTE: negative values of 'len' are OK
-substring start len str = Prim $ if start < 0
-  then
-    throwError
-    $  ErrorCall $ displayException $ ESubStringNegativeStartPosition start
-  else pure $ principledModifyNixContents (Text.take len . Text.drop start) str
+substring start len str = Prim
+  $ if start < 0
+    then
+      throwError $ ESubStringNegativeStartPosition start
+    else pure $ principledModifyNixContents (Text.take len . Text.drop start) str
 
 attrNames
   :: forall e t f m . MonadNix e t f m => NValue t f m -> m (NValue t f m)

--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -1693,7 +1693,7 @@ getContext x = demand x $ \case
     valued :: M.HashMap Text (NValue t f m) <- sequenceA $ M.map toValue context
     pure $ flip nvSet M.empty $ valued
   x ->
-    throwError $ ErrorCall $ displayException $ EGetContextUnsupportedType x
+    throwError $ EGetContextUnsupportedType x
 
 appendContext
   :: forall e t f m

--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -1284,8 +1284,7 @@ pathExists_ path = demand path $ \case
   NVPath p  -> toValue =<< pathExists p
   NVStr  ns -> toValue =<< pathExists (Text.unpack (hackyStringIgnoreContext ns))
   v ->
-    throwError
-      $ ErrorCall $ displayException $ EPathExists_NotPath v
+    throwError $ EPathExists_NotPath v
 
 hasKind
   :: forall a e t f m

--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -1719,9 +1719,7 @@ appendContext x y = demand x $ \x' -> demand y $ \y' -> case (x', y') of
               throwError $ EAppendContextInvalidContextOutTypes x
         return $ NixLikeContextValue path allOutputs outputs
       x ->
-        throwError
-          $ ErrorCall
-          $ displayException $ EAppendContextInvalidContextValTypes x
+        throwError $ EAppendContextInvalidContextValTypes x
     toValue
       $ principledMakeNixString (principledStringIgnoreContext ns)
       $ fromNixLikeContext

--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -614,8 +614,7 @@ foldNixPath f z = do
   go (x, ty) rest = case Text.splitOn "=" x of
     [p] -> f (Text.unpack p) Nothing ty rest
     [n, p] -> f (Text.unpack p) (Just (Text.unpack n)) ty rest
-    _ -> throwError
-      $ ErrorCall $ displayException $ EFoldNixPathUnexpectedEntry x
+    _ -> throwError $ EFoldNixPathUnexpectedEntry x
 
 nixPath :: MonadNix e t f m => m (NValue t f m)
 nixPath = fmap nvList $ flip foldNixPath [] $ \p mn ty rest ->

--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -200,6 +200,19 @@ instance (Show a, Typeable a)
   displayException (EDirOfWrongArg v)
     = "dirOf: expected string or path, got " ++ show v
 
+data EAElemAt_ a b
+  = EElemAt_IndexOutOfBound a b
+  deriving Show
+
+instance (Show a, Typeable a, Foldable t, Show (t b), Typeable (t b))
+  => Exception (EAElemAt_ a (t b))
+ where
+  displayException (EElemAt_IndexOutOfBound n' xs')
+    = "builtins.elem: Index "
+    <> show n'
+    <> " too large for list of length "
+    <> show (length xs')
+
 -- | Evaluate a nix expression in the default context
 withNixContext
   :: forall e t f m r
@@ -928,11 +941,9 @@ elemAt_ xs n = fromValue n >>= \n' -> fromValue xs >>= \xs' ->
     Just a -> pure a
     Nothing ->
       throwError
-        $  ErrorCall
-        $  "builtins.elem: Index "
-        ++ show n'
-        ++ " too large for list of length "
-        ++ show (length xs')
+        $ ErrorCall
+        $ displayException
+        $ EElemAt_IndexOutOfBound n' xs'
 
 genList
   :: forall e t f m

--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -1499,8 +1499,7 @@ absolutePathFromValue = \case
       $ throwError $ EAbsolutePathFromValueNotAbsPath path
     pure path
   NVPath path -> pure path
-  v           -> throwError
-    $ ErrorCall $ displayException $ EAbsolutePathFromValueNotPath v
+  v           -> throwError $ EAbsolutePathFromValueNotPath v
 
 readFile_ :: MonadNix e t f m => NValue t f m -> m (NValue t f m)
 readFile_ path = demand path $

--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -1518,8 +1518,7 @@ findFile_ aset filePath = demand aset $ \aset' -> demand filePath $ \filePath' -
       pure $ nvPath mres
     (NVList _, y) -> throwError
       $ ErrorCall $ displayException $ EFindFile_NotString y
-    (x, NVStr _)  -> throwError
-      $ ErrorCall $ displayException $ EFindFile_NotList x
+    (x, NVStr _)  -> throwError $ EFindFile_NotList x
     (x, y)        -> throwError $ EFindFile_InvalidTypes (x, y)
 
 data FileType

--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -976,7 +976,7 @@ map_ f =
   toValue
     <=< traverse
           ( defer @(NValue t f m)
-          . withFrame Debug (ErrorCall $ displayException EMap_)
+          . withFrame Debug EMap_
           . (f `callFunc`)
           )
     <=< fromValue @[NValue t f m]

--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -1189,9 +1189,7 @@ replaceStrings tfrom tto ts = fromValue (Deeper tfrom) >>= \(nsFrom :: [NixStrin
     fromValue ts >>= \(ns :: NixString) -> do
       let from = map principledStringIgnoreContext nsFrom
       when (length nsFrom /= length nsTo)
-        $ throwError
-        $ ErrorCall
-        $ displayException EReplaceStringsDiffLenArgs
+        $ throwError EReplaceStringsDiffLenArgs
       let
         lookupPrefix s = do
           (prefix, replacement) <- find ((`Text.isPrefixOf` s) . fst)

--- a/src/Nix/Effects.hs
+++ b/src/Nix/Effects.hs
@@ -166,6 +166,18 @@ instance (Show a, Typeable a) => Exception (MonadInstantiateAsyncE a String)
     <> ": "
     <> err
 
+data MonadHttpAsyncE a b
+  = MonadHttpFetchFailE a b
+  deriving Show
+
+instance (Show a, Typeable a) => Exception (MonadHttpAsyncE String a)
+ where
+  displayException (MonadHttpFetchFailE urlstr status)
+    = "fail, got "
+    <> show status
+    <> " when fetching url:"
+    <> urlstr
+
 pathExists :: MonadFile m => FilePath -> m Bool
 pathExists = doesFileExist
 
@@ -216,13 +228,8 @@ instance MonadHttp IO where
     let status = statusCode (responseStatus response)
     if status /= 200
       then
-        return
-        $  Left
-        $  ErrorCall
-        $  "fail, got "
-        ++ show status
-        ++ " when fetching url:"
-        ++ urlstr
+        return $ Left
+        $ ErrorCall $ displayException $ MonadHttpFetchFailE urlstr status
       else -- do
         -- let bstr = responseBody response
         return

--- a/src/Nix/Effects.hs
+++ b/src/Nix/Effects.hs
@@ -108,7 +108,9 @@ instance MonadExec IO where
 
 class Monad m => MonadInstantiate m where
     instantiateExpr :: String -> m (Either ErrorCall NExprLoc)
-    default instantiateExpr :: (MonadTrans t, MonadInstantiate m', m ~ t m') => String -> m (Either ErrorCall NExprLoc)
+    default instantiateExpr
+      :: (MonadTrans t, MonadInstantiate m', m ~ t m')
+      => String -> m (Either ErrorCall NExprLoc)
     instantiateExpr = lift . instantiateExpr
 
 instance MonadInstantiate IO where

--- a/src/Nix/Effects.hs
+++ b/src/Nix/Effects.hs
@@ -98,14 +98,8 @@ instance MonadExec IO where
           then return $ Left
             $ ErrorCall $ displayException $ MonadExecNoOutputE u emsg
           else case parseNixTextLoc t of
-            Failure err ->
-              return
-                $  Left
-                $  ErrorCall
-                $  "Error parsing output of exec: "
-                ++ show err
-                ++ " "
-                ++ emsg
+            Failure err -> return $ Left
+              $ ErrorCall $ displayException $ MonadExecParsingOutputE err emsg
             Success v -> return $ Right v
         err ->
           return
@@ -151,6 +145,7 @@ instance MonadInstantiate IO where
 data MonadExecAsyncE a b
   = MonadExecMissingProgramE a b
   | MonadExecNoOutputE a b
+  | MonadExecParsingOutputE a b
   deriving Show
 
 instance (Show a, Typeable a) => Exception (MonadExecAsyncE a String)
@@ -159,6 +154,9 @@ instance (Show a, Typeable a) => Exception (MonadExecAsyncE a String)
     = "exec: missing program"
   displayException (MonadExecNoOutputE _ emsg)
     = "exec has no output:" <> emsg
+  displayException (MonadExecParsingOutputE err emsg)
+    = "Error parsing output of exec: "
+    <> show err <> ", " <> emsg
 
 pathExists :: MonadFile m => FilePath -> m Bool
 pathExists = doesFileExist

--- a/src/Nix/Effects.hs
+++ b/src/Nix/Effects.hs
@@ -125,13 +125,10 @@ instance MonadInstantiate IO where
           $ ErrorCall $ displayException $ MonadInstantiateParsingOutputE e u
         Success v -> return $ Right v
       status ->
-        return
-          $  Left
-          $  ErrorCall
-          $  "nix-instantiate failed: "
-          ++ show status
-          ++ ": "
-          ++ err
+        return $ Left
+          $ ErrorCall $ displayException $ MonadInstantiateFailE status err
+   where
+     u = undefined :: String
 
 data MonadExecAsyncE a b
   = MonadExecMissingProgramE a b
@@ -155,6 +152,7 @@ instance (Show a, Typeable a) => Exception (MonadExecAsyncE a String)
 
 data MonadInstantiateAsyncE a b
   = MonadInstantiateParsingOutputE a b
+  | MonadInstantiateFailE a b
   deriving Show
 
 instance (Show a, Typeable a) => Exception (MonadInstantiateAsyncE a String)
@@ -162,6 +160,11 @@ instance (Show a, Typeable a) => Exception (MonadInstantiateAsyncE a String)
   displayException (MonadInstantiateParsingOutputE e _)
     = "Error parsing output of nix-instantiate: "
     <> show e
+  displayException (MonadInstantiateFailE status err)
+    = "nix-instantiate failed: "
+    <> show status
+    <> ": "
+    <> err
 
 pathExists :: MonadFile m => FilePath -> m Bool
 pathExists = doesFileExist

--- a/src/Nix/Effects.hs
+++ b/src/Nix/Effects.hs
@@ -101,14 +101,8 @@ instance MonadExec IO where
             Failure err -> return $ Left
               $ ErrorCall $ displayException $ MonadExecParsingOutputE err emsg
             Success v -> return $ Right v
-        err ->
-          return
-            $  Left
-            $  ErrorCall
-            $  "exec  failed: "
-            ++ show err
-            ++ " "
-            ++ emsg
+        err -> return $ Left
+           $ ErrorCall $ displayException $ MonadExecFailE err emsg
    where
      u = undefined :: String
 
@@ -146,6 +140,7 @@ data MonadExecAsyncE a b
   = MonadExecMissingProgramE a b
   | MonadExecNoOutputE a b
   | MonadExecParsingOutputE a b
+  | MonadExecFailE a b
   deriving Show
 
 instance (Show a, Typeable a) => Exception (MonadExecAsyncE a String)
@@ -156,6 +151,9 @@ instance (Show a, Typeable a) => Exception (MonadExecAsyncE a String)
     = "exec has no output:" <> emsg
   displayException (MonadExecParsingOutputE err emsg)
     = "Error parsing output of exec: "
+    <> show err <> ", " <> emsg
+  displayException (MonadExecFailE err emsg)
+    = "exec  failed: "
     <> show err <> ", " <> emsg
 
 pathExists :: MonadFile m => FilePath -> m Bool

--- a/src/Nix/Effects.hs
+++ b/src/Nix/Effects.hs
@@ -121,11 +121,8 @@ instance MonadInstantiate IO where
     case exitCode of
       ExitSuccess -> case parseNixTextLoc (T.pack out) of
         Failure e ->
-          return
-            $  Left
-            $  ErrorCall
-            $  "Error parsing output of nix-instantiate: "
-            ++ show e
+          return $ Left
+          $ ErrorCall $ displayException $ MonadInstantiateParsingOutputE e u
         Success v -> return $ Right v
       status ->
         return
@@ -155,6 +152,16 @@ instance (Show a, Typeable a) => Exception (MonadExecAsyncE a String)
   displayException (MonadExecFailE err emsg)
     = "exec  failed: "
     <> show err <> ", " <> emsg
+
+data MonadInstantiateAsyncE a b
+  = MonadInstantiateParsingOutputE a b
+  deriving Show
+
+instance (Show a, Typeable a) => Exception (MonadInstantiateAsyncE a String)
+ where
+  displayException (MonadInstantiateParsingOutputE e _)
+    = "Error parsing output of nix-instantiate: "
+    <> show e
 
 pathExists :: MonadFile m => FilePath -> m Bool
 pathExists = doesFileExist

--- a/src/Nix/Effects.hs
+++ b/src/Nix/Effects.hs
@@ -132,14 +132,14 @@ instance MonadInstantiate IO where
    where
      u = undefined :: String
 
-data EAMonadExec a b
+data EMonadExec a b
   = EMonadExecMissingProgram a b
   | EMonadExecNoOutput a b
   | EMonadExecParsingOutput a b
   | EMonadExecFail a b
   deriving Show
 
-instance (Show a, Typeable a) => Exception (EAMonadExec a String)
+instance (Show a, Typeable a) => Exception (EMonadExec a String)
  where
   displayException (EMonadExecMissingProgram _ _)
     = "exec: missing program"
@@ -152,12 +152,12 @@ instance (Show a, Typeable a) => Exception (EAMonadExec a String)
     = "exec  failed: "
     <> show err <> ", " <> emsg
 
-data EAMonadInstantiate a b
+data EMonadInstantiate a b
   = EMonadInstantiateParsingOutput a b
   | EMonadInstantiateFail a b
   deriving Show
 
-instance (Show a, Typeable a) => Exception (EAMonadInstantiate a String)
+instance (Show a, Typeable a) => Exception (EMonadInstantiate a String)
  where
   displayException (EMonadInstantiateParsingOutput e _)
     = "Error parsing output of nix-instantiate: "
@@ -168,12 +168,12 @@ instance (Show a, Typeable a) => Exception (EAMonadInstantiate a String)
     <> ": "
     <> err
 
-data EAMonadHttp a b
+data EMonadHttp a b
   = EMonadHttpFetchFail a b
   | EMonadHttpStoreNotReady a b
   deriving Show
 
-instance (Show a, Typeable a) => Exception (EAMonadHttp String a)
+instance (Show a, Typeable a) => Exception (EMonadHttp String a)
  where
   displayException (EMonadHttpFetchFail urlstr status)
     = "fail, got "
@@ -184,11 +184,11 @@ instance (Show a, Typeable a) => Exception (EAMonadHttp String a)
     = "successful download, but hnix-store is not yet ready; url = "
     <> urlstr
 
-newtype EAMonadStore a
+newtype EMonadStore a
   = EMonadStoreAddPathFail a
   deriving Show
 
-instance (Show a, Typeable a) => Exception (EAMonadStore a)
+instance (Show a, Typeable a) => Exception (EMonadStore a)
  where
   displayException (EMonadStoreAddPathFail path)
     = "addPath: failed: nix-store --add "

--- a/src/Nix/Effects.hs
+++ b/src/Nix/Effects.hs
@@ -95,7 +95,8 @@ instance MonadExec IO where
       let emsg = "program[" ++ prog ++ "] args=" ++ show args
       case exitCode of
         ExitSuccess -> if T.null t
-          then return $ Left $ ErrorCall $ "exec has no output :" ++ emsg
+          then return $ Left
+            $ ErrorCall $ displayException $ MonadExecNoOutputE u emsg
           else case parseNixTextLoc t of
             Failure err ->
               return
@@ -149,12 +150,15 @@ instance MonadInstantiate IO where
 
 data MonadExecAsyncE a b
   = MonadExecMissingProgramE a b
+  | MonadExecNoOutputE a b
   deriving Show
 
 instance (Show a, Typeable a) => Exception (MonadExecAsyncE a String)
  where
   displayException (MonadExecMissingProgramE _ _)
     = "exec: missing program"
+  displayException (MonadExecNoOutputE _ emsg)
+    = "exec has no output:" <> emsg
 
 pathExists :: MonadFile m => FilePath -> m Bool
 pathExists = doesFileExist

--- a/src/Nix/Effects/Basic.hs
+++ b/src/Nix/Effects/Basic.hs
@@ -105,6 +105,9 @@ defaultMakeAbsolutePath origPath = do
           Nothing -> getCurrentDirectory
           Just v  -> demand v $ \case
             NVPath s -> return $ takeDirectory s
+            -- TODO: 2019-08-12: John Ericson (Ericson2314):
+            -- You don't want to call displayException here, but where the m is
+            -- eliminated.
             v -> throwError $ ErrorCall $ displayException $ CurFileIsntPath v
       pure $ cwd <///> origPathExpanded
   removeDotDotIndirections <$> canonicalizePath absPath

--- a/src/Nix/Effects/Basic.hs
+++ b/src/Nix/Effects/Basic.hs
@@ -52,12 +52,12 @@ import           GHC.DataSize
 #endif
 #endif
 
-data FileError a
+data FileAsyncException a
   = CurFileIsntPath a
   | FileNotInNixPath a
   deriving Show
 
-instance (Show v, Typeable v) => Exception (FileError v)
+instance (Show v, Typeable v) => Exception (FileAsyncException v)
  where
   displayException (CurFileIsntPath v)
     =  "When resolving relative path, __cur_file is in scope, "
@@ -66,23 +66,23 @@ instance (Show v, Typeable v) => Exception (FileError v)
     =  "File '" <> show name <> "' was not found in the Nix search path "
     <> "(add it using $NIX_PATH or -I)."
 
-data NixPathError a
+data NixPathAsyncException a
   = WrongNixPathFormat a
   deriving Show
 
-instance (Show v, Typeable v) => Exception (NixPathError v)
+instance (Show v, Typeable v) => Exception (NixPathAsyncException v)
  where
   displayException (WrongNixPathFormat s)
     =  "__nixPath must be a list of attr sets with 'path' elements, "
     <> "but received: '" <> show s <> "'."
 
-data FetchTarballError a
+data FetchTarballAsyncException a
   = NoUrlAttr
   | NorUriNorSet a
   | NorUriNorString a
   deriving Show
 
-instance (Show v, Typeable v) => Exception (FetchTarballError v)
+instance (Show v, Typeable v) => Exception (FetchTarballAsyncException v)
  where
   displayException NoUrlAttr
     = "builtins.fetchTarball: Missing url attribute."
@@ -199,7 +199,7 @@ fetchTarball
 fetchTarball = flip demand $ \case
   NVSet s _ -> case M.lookup "url" s of
     Nothing ->
-      throwError $ ErrorCall $ displayException (NoUrlAttr :: FetchTarballError String)
+      throwError $ ErrorCall $ displayException (NoUrlAttr :: FetchTarballAsyncException String)
     Just url -> demand url $ go (M.lookup "sha256" s)
   v@NVStr{} -> go Nothing v
   v ->

--- a/src/Nix/Effects/Basic.hs
+++ b/src/Nix/Effects/Basic.hs
@@ -283,10 +283,7 @@ defaultImportPath path = do
         eres <- parseNixFileLoc path
         case eres of
           Failure err ->
-            throwError
-              $ ErrorCall
-              . displayException
-              $ EDefaultImportPathParse
+            throwError $ EDefaultImportPathParse
               $ fillSep ["Parse during import failed:", err]
           Success expr -> do
             modify (M.insert path expr)

--- a/src/Nix/Effects/Basic.hs
+++ b/src/Nix/Effects/Basic.hs
@@ -95,6 +95,7 @@ instance (Show v, Typeable v) => Exception (EAFetchTarball v)
 
 data EADefaultImportPath a
   = EDefaultImportPathParse a
+  | EDefaultImportPath a
   deriving Show
 
 instance (Show a, Typeable a) => Exception (EADefaultImportPath a)
@@ -102,6 +103,8 @@ instance (Show a, Typeable a) => Exception (EADefaultImportPath a)
   -- displayException :: EADefaultImportPath a -> String
   displayException (EDefaultImportPathParse a)
     = show a
+  displayException (EDefaultImportPath a)
+    = "While importing file " <> show a
 
 defaultMakeAbsolutePath :: MonadNix e t f m => FilePath -> m FilePath
 defaultMakeAbsolutePath origPath = do
@@ -272,8 +275,7 @@ defaultImportPath
   -> m (NValue t f m)
 defaultImportPath path = do
   traceM $ "Importing file " ++ path
-  -- TODO: 2019-08-13: Incorporate into exceptions structure
-  withFrame Info (ErrorCall $ "While importing file " ++ show path) $ do
+  withFrame Info (ErrorCall $ displayException $ EDefaultImportPath path) $ do
     imports <- get
     evalExprLoc =<< case M.lookup path imports of
       Just expr -> pure expr

--- a/src/Nix/Effects/Basic.hs
+++ b/src/Nix/Effects/Basic.hs
@@ -93,6 +93,16 @@ instance (Show v, Typeable v) => Exception (EAFetchTarball v)
     = "builtins.fetchTarball: Expected URI or string, received: '"
     <> show v <> "'."
 
+data EADefaultImportPath a
+  = EDefaultImportPathParse a
+  deriving Show
+
+instance (Show a, Typeable a) => Exception (EADefaultImportPath a)
+ where
+  -- displayException :: EADefaultImportPath a -> String
+  displayException (EDefaultImportPathParse a)
+    = show a
+
 defaultMakeAbsolutePath :: MonadNix e t f m => FilePath -> m FilePath
 defaultMakeAbsolutePath origPath = do
   origPathExpanded <- expandHomePath origPath
@@ -272,9 +282,10 @@ defaultImportPath path = do
         case eres of
           Failure err ->
             throwError
-              -- TODO: 2019-08-13: Incorporate into exceptions structure
               $ ErrorCall
-              . show $ fillSep ["Parse during import failed:", err]
+              . displayException
+              $ EDefaultImportPathParse
+              $ fillSep ["Parse during import failed:", err]
           Success expr -> do
             modify (M.insert path expr)
             pure expr

--- a/src/Nix/Effects/Basic.hs
+++ b/src/Nix/Effects/Basic.hs
@@ -181,7 +181,7 @@ findPathBy finder l name = do
   mpath <- foldM go Nothing l
   case mpath of
     Nothing ->
-      throwError $ ErrorCall $ displayException $ EFileNotInNixPath name
+      throwError $ EFileNotInNixPath name
     Just path -> return path
  where
   go :: Maybe FilePath -> NValue t f m -> m (Maybe FilePath)

--- a/src/Nix/Effects/Basic.hs
+++ b/src/Nix/Effects/Basic.hs
@@ -262,6 +262,7 @@ defaultImportPath
   -> m (NValue t f m)
 defaultImportPath path = do
   traceM $ "Importing file " ++ path
+  -- TODO: 2019-08-13: Incorporate into exceptions structure
   withFrame Info (ErrorCall $ "While importing file " ++ show path) $ do
     imports <- get
     evalExprLoc =<< case M.lookup path imports of
@@ -271,6 +272,7 @@ defaultImportPath path = do
         case eres of
           Failure err ->
             throwError
+              -- TODO: 2019-08-13: Incorporate into exceptions structure
               $ ErrorCall
               . show $ fillSep ["Parse during import failed:", err]
           Success expr -> do

--- a/src/Nix/Effects/Basic.hs
+++ b/src/Nix/Effects/Basic.hs
@@ -215,7 +215,7 @@ fetchTarball
 fetchTarball = flip demand $ \case
   NVSet s _ -> case M.lookup "url" s of
     Nothing ->
-      throwError $ ErrorCall $ displayException (ENoUrlAttr :: EAFetchTarball String)
+      throwError (ENoUrlAttr :: EAFetchTarball String)
     Just url -> demand url $ go (M.lookup "sha256" s)
   v@NVStr{} -> go Nothing v
   v ->

--- a/src/Nix/Effects/Basic.hs
+++ b/src/Nix/Effects/Basic.hs
@@ -275,7 +275,7 @@ defaultImportPath
   -> m (NValue t f m)
 defaultImportPath path = do
   traceM $ "Importing file " ++ path
-  withFrame Info (ErrorCall $ displayException $ EDefaultImportPath path) $ do
+  withFrame Info (EDefaultImportPath path) $ do
     imports <- get
     evalExprLoc =<< case M.lookup path imports of
       Just expr -> pure expr

--- a/src/Nix/Effects/Basic.hs
+++ b/src/Nix/Effects/Basic.hs
@@ -52,12 +52,12 @@ import           GHC.DataSize
 #endif
 #endif
 
-data FileAsyncException a
+data FileAsyncE a
   = CurFileIsntPath a
   | FileNotInNixPath a
   deriving Show
 
-instance (Show v, Typeable v) => Exception (FileAsyncException v)
+instance (Show v, Typeable v) => Exception (FileAsyncE v)
  where
   displayException (CurFileIsntPath v)
     =  "When resolving relative path, __cur_file is in scope, "
@@ -66,23 +66,23 @@ instance (Show v, Typeable v) => Exception (FileAsyncException v)
     =  "File '" <> show name <> "' was not found in the Nix search path "
     <> "(add it using $NIX_PATH or -I)."
 
-data NixPathAsyncException a
+data NixPathAsyncE a
   = WrongNixPathFormat a
   deriving Show
 
-instance (Show v, Typeable v) => Exception (NixPathAsyncException v)
+instance (Show v, Typeable v) => Exception (NixPathAsyncE v)
  where
   displayException (WrongNixPathFormat s)
     =  "__nixPath must be a list of attr sets with 'path' elements, "
     <> "but received: '" <> show s <> "'."
 
-data FetchTarballAsyncException a
+data FetchTarballAsyncE a
   = NoUrlAttr
   | NorUriNorSet a
   | NorUriNorString a
   deriving Show
 
-instance (Show v, Typeable v) => Exception (FetchTarballAsyncException v)
+instance (Show v, Typeable v) => Exception (FetchTarballAsyncE v)
  where
   displayException NoUrlAttr
     = "builtins.fetchTarball: Missing url attribute."
@@ -202,7 +202,7 @@ fetchTarball
 fetchTarball = flip demand $ \case
   NVSet s _ -> case M.lookup "url" s of
     Nothing ->
-      throwError $ ErrorCall $ displayException (NoUrlAttr :: FetchTarballAsyncException String)
+      throwError $ ErrorCall $ displayException (NoUrlAttr :: FetchTarballAsyncE String)
     Just url -> demand url $ go (M.lookup "sha256" s)
   v@NVStr{} -> go Nothing v
   v ->

--- a/src/Nix/Effects/Basic.hs
+++ b/src/Nix/Effects/Basic.hs
@@ -76,6 +76,15 @@ instance (Show v, Typeable v) => Exception (NixPathError v)
     =  "__nixPath must be a list of attr sets with 'path' elements, "
     <> "but received: '" <> show s <> "'."
 
+data FetchTarballError
+  = NoUrlAttr
+  deriving Show
+
+instance Exception (FetchTarballError)
+ where
+  displayException NoUrlAttr
+    = "builtins.fetchTarball: Missing url attribute."
+
 defaultMakeAbsolutePath :: MonadNix e t f m => FilePath -> m FilePath
 defaultMakeAbsolutePath origPath = do
   origPathExpanded <- expandHomePath origPath
@@ -182,7 +191,7 @@ fetchTarball
 fetchTarball = flip demand $ \case
   NVSet s _ -> case M.lookup "url" s of
     Nothing ->
-      throwError $ ErrorCall "builtins.fetchTarball: Missing url attribute"
+      throwError $ ErrorCall $ displayException NoUrlAttr
     Just url -> demand url $ go (M.lookup "sha256" s)
   v@NVStr{} -> go Nothing v
   v ->

--- a/src/Nix/Effects/Basic.hs
+++ b/src/Nix/Effects/Basic.hs
@@ -52,22 +52,22 @@ import           GHC.DataSize
 #endif
 #endif
 
-newtype EADefaultMakeAbsolutePath a
+newtype EDefaultMakeAbsolutePath a
   = EDefaultMakeAbsolutePathCurFileIsntPath a
   deriving Show
 
-instance (Show v, Typeable v) => Exception (EADefaultMakeAbsolutePath v)
+instance (Show v, Typeable v) => Exception (EDefaultMakeAbsolutePath v)
  where
   displayException (EDefaultMakeAbsolutePathCurFileIsntPath v)
     =  "When resolving relative path, __cur_file is in scope, "
     <> "but is not a path; it is: '" <> show v <>"'."
 
-data EAFindPathByFile a
+data EFindPathByFile a
   = EFindPathByFileNotInNixPath a
   | EFindPathByWrongNixPathFormat a
   deriving Show
 
-instance (Show v, Typeable v) => Exception (EAFindPathByFile v)
+instance (Show v, Typeable v) => Exception (EFindPathByFile v)
  where
   displayException (EFindPathByFileNotInNixPath name)
     =  "File '" <> show name <> "' was not found in the Nix search path "
@@ -76,13 +76,13 @@ instance (Show v, Typeable v) => Exception (EAFindPathByFile v)
     =  "__nixPath must be a list of attr sets with 'path' elements, "
     <> "but received: '" <> show s <> "'."
 
-data EAFetchTarball a
+data EFetchTarball a
   = EFetchTarballNoUrlAttr
   | EFetchTarballNorUriNorSet a
   | EFetchTarballNorUriNorString a
   deriving Show
 
-instance (Show v, Typeable v) => Exception (EAFetchTarball v)
+instance (Show v, Typeable v) => Exception (EFetchTarball v)
  where
   displayException EFetchTarballNoUrlAttr
     = "builtins.fetchTarball: Missing url attribute."
@@ -93,12 +93,12 @@ instance (Show v, Typeable v) => Exception (EAFetchTarball v)
     = "builtins.fetchTarball: Expected URI or string, received: '"
     <> show v <> "'."
 
-data EADefaultImportPath a
+data EDefaultImportPath a
   = EDefaultImportPathParse a
   | EDefaultImportPath a
   deriving Show
 
-instance (Show a, Typeable a) => Exception (EADefaultImportPath a)
+instance (Show a, Typeable a) => Exception (EDefaultImportPath a)
  where
   -- displayException :: EADefaultImportPath a -> String
   displayException (EDefaultImportPathParse a)
@@ -215,7 +215,7 @@ fetchTarball
 fetchTarball = flip demand $ \case
   NVSet s _ -> case M.lookup "url" s of
     Nothing ->
-      throwError (EFetchTarballNoUrlAttr :: EAFetchTarball String)
+      throwError (EFetchTarballNoUrlAttr :: EFetchTarball String)
     Just url -> demand url $ go (M.lookup "sha256" s)
   v@NVStr{} -> go Nothing v
   v ->

--- a/src/Nix/Effects/Basic.hs
+++ b/src/Nix/Effects/Basic.hs
@@ -121,7 +121,7 @@ defaultMakeAbsolutePath origPath = do
             -- TODO: 2019-08-12: John Ericson (Ericson2314):
             -- You don't want to call displayException here, but where the m is
             -- eliminated.
-            v -> throwError $ ErrorCall $ displayException $ ECurFileIsntPath v
+            v -> throwError $ ECurFileIsntPath v
       pure $ cwd <///> origPathExpanded
   removeDotDotIndirections <$> canonicalizePath absPath
 

--- a/src/Nix/Eval.hs
+++ b/src/Nix/Eval.hs
@@ -113,7 +113,7 @@ data EAAttrSetAlter
 instance Exception EAAttrSetAlter
  where
   displayException EAttrSetAlterInvalidSelector
-    = "invalid selector with no components"
+    = "Invalid selector (no components)."
 
 data EAEvalGetterKeyName
   = EComponentValueIsNullExpectedString

--- a/src/Nix/Eval.hs
+++ b/src/Nix/Eval.hs
@@ -219,7 +219,7 @@ attrSetAlter
   -> m v
   -> m (AttrSet (m v), AttrSet SourcePos)
 attrSetAlter [] _ _ _ _ =
-  evalError @v $ ErrorCall $ displayException EAttrSetAlterInvalidSelector
+  evalError @v $ EAttrSetAlterInvalidSelector
 
 attrSetAlter (k : ks) pos m p val = case M.lookup k m of
   Nothing | null ks   -> go

--- a/src/Nix/Eval.hs
+++ b/src/Nix/Eval.hs
@@ -106,30 +106,30 @@ data SynHoleInfo m v = SynHoleInfo
 
 instance (Typeable m, Typeable v) => Exception (SynHoleInfo m v)
 
-data AttrSetAlterAsyncException
+data AttrSetAlterAsyncE
   = AttrSetAlterInvalidSelector
   deriving Show
 
-instance Exception AttrSetAlterAsyncException
+instance Exception AttrSetAlterAsyncE
  where
   displayException AttrSetAlterInvalidSelector
     = "invalid selector with no components"
 
-data EvalGetterKeyNameAsyncException
+data EvalGetterKeyNameAsyncE
   = ComponentValueIsNullExpectedString
   deriving Show
 
-instance Exception EvalGetterKeyNameAsyncException
+instance Exception EvalGetterKeyNameAsyncE
  where
   displayException ComponentValueIsNullExpectedString
     = "value is null while a string was expected"
 
-data BuildArgumentAsyncException a
+data BuildArgumentAsyncE a
   = BuildArgumentMissingValue a
   | BuildArgumentUnexpectedParameter a
   deriving Show
 
-instance (Show a, Typeable a) => Exception (BuildArgumentAsyncException a)
+instance (Show a, Typeable a) => Exception (BuildArgumentAsyncE a)
  where
   displayException (BuildArgumentMissingValue k)
     = "Missing value for parameter '" <> show k <> "'."

--- a/src/Nix/Eval.hs
+++ b/src/Nix/Eval.hs
@@ -106,30 +106,30 @@ data SynHoleInfo m v = SynHoleInfo
 
 instance (Typeable m, Typeable v) => Exception (SynHoleInfo m v)
 
-data EAAttrSetAlter
+data EAttrSetAlter
   = EAttrSetAlterInvalidSelector
   deriving Show
 
-instance Exception EAAttrSetAlter
+instance Exception EAttrSetAlter
  where
   displayException EAttrSetAlterInvalidSelector
     = "Invalid selector (no components)."
 
-data EAEvalGetterKeyName
+data EEvalGetterKeyName
   = EComponentValueIsNullExpectedString
   deriving Show
 
-instance Exception EAEvalGetterKeyName
+instance Exception EEvalGetterKeyName
  where
   displayException EComponentValueIsNullExpectedString
     = "value is null while a string was expected"
 
-data EABuildArgument a
+data EBuildArgument a
   = EBuildArgumentMissingValue a
   | EBuildArgumentUnexpectedParameter a
   deriving Show
 
-instance (Show a, Typeable a) => Exception (EABuildArgument a)
+instance (Show a, Typeable a) => Exception (EBuildArgument a)
  where
   displayException (EBuildArgumentMissingValue k)
     = "Missing value for parameter '" <> show k <> "'."

--- a/src/Nix/Eval.hs
+++ b/src/Nix/Eval.hs
@@ -106,6 +106,15 @@ data SynHoleInfo m v = SynHoleInfo
 
 instance (Typeable m, Typeable v) => Exception (SynHoleInfo m v)
 
+data AttrSetAlterAsyncException
+  = AttrSetAlterInvalidSelector
+  deriving Show
+
+instance Exception AttrSetAlterAsyncException
+ where
+  displayException AttrSetAlterInvalidSelector
+    = "invalid selector with no components"
+
 -- jww (2019-03-18): By deferring only those things which must wait until
 -- context of us, this can be written as:
 -- eval :: forall v m . MonadNixEval v m => NExprF v -> m v
@@ -189,7 +198,7 @@ attrSetAlter
   -> m v
   -> m (AttrSet (m v), AttrSet SourcePos)
 attrSetAlter [] _ _ _ _ =
-  evalError @v $ ErrorCall "invalid selector with no components"
+  evalError @v $ ErrorCall $ displayException AttrSetAlterInvalidSelector
 
 attrSetAlter (k : ks) pos m p val = case M.lookup k m of
   Nothing | null ks   -> go

--- a/src/Nix/Eval.hs
+++ b/src/Nix/Eval.hs
@@ -223,7 +223,7 @@ attrSetAlter [] _ _ _ _ =
 
 attrSetAlter (k : ks) pos m p val = case M.lookup k m of
   Nothing | null ks   -> go
-          | otherwise -> recurse M.empty M.empty
+    | otherwise -> recurse M.empty M.empty
   Just x
     | null ks
     -> go

--- a/src/Nix/Eval.hs
+++ b/src/Nix/Eval.hs
@@ -373,8 +373,7 @@ evalGetterKeyName
 evalGetterKeyName = evalSetterKeyName >=> \case
   Just k -> pure k
   Nothing ->
-    evalError @v $ ErrorCall
-      $ displayException EComponentValueIsNullExpectedString
+    evalError @v EComponentValueIsNullExpectedString
 
 -- | Evaluate a component of an attribute path in a context where we are
 -- *binding* a value

--- a/src/Nix/Eval.hs
+++ b/src/Nix/Eval.hs
@@ -126,12 +126,15 @@ instance Exception EvalGetterKeyNameAsyncException
 
 data BuildArgumentAsyncException a
   = BuildArgumentMissingValue a
+  | BuildArgumentUnexpectedParameter a
   deriving Show
 
 instance (Show a, Typeable a) => Exception (BuildArgumentAsyncException a)
  where
   displayException (BuildArgumentMissingValue k)
     = "Missing value for parameter '" <> show k <> "'."
+  displayException (BuildArgumentUnexpectedParameter k)
+    = "Unexpected parameter '" <> show k <> "'."
 
 -- jww (2019-03-18): By deferring only those things which must wait until
 -- context of us, this can be written as:
@@ -434,12 +437,8 @@ buildArgument params arg = do
       | isVariadic
       -> Nothing
       | otherwise
-      -> Just
-        $  const
-        $  evalError @v
-        $  ErrorCall
-        $  "Unexpected parameter: "
-        ++ show k
+      -> Just $ const $ evalError @v $ ErrorCall
+        $ displayException $ BuildArgumentUnexpectedParameter k
     These x _ -> Just (const (pure x))
 
 addSourcePositions

--- a/src/Nix/Eval.hs
+++ b/src/Nix/Eval.hs
@@ -428,8 +428,7 @@ buildArgument params arg = do
     -> Maybe (AttrSet v -> m v)
   assemble scope isVariadic k = \case
     That Nothing ->
-      Just $ const $ evalError @v $ ErrorCall
-        $ displayException $ EBuildArgumentMissingValue k
+      Just $ const $ evalError @v $ EBuildArgumentMissingValue k
     That (Just f) ->
       Just $ \args -> defer $ withScopes scope $ pushScope args f
     This _

--- a/src/Nix/Eval.hs
+++ b/src/Nix/Eval.hs
@@ -435,8 +435,7 @@ buildArgument params arg = do
       | isVariadic
       -> Nothing
       | otherwise
-      -> Just $ const $ evalError @v $ ErrorCall
-        $ displayException $ EBuildArgumentUnexpectedParameter k
+      -> Just $ const $ evalError @v $ EBuildArgumentUnexpectedParameter k
     These x _ -> Just (const (pure x))
 
 addSourcePositions

--- a/src/Nix/Eval.hs
+++ b/src/Nix/Eval.hs
@@ -115,6 +115,15 @@ instance Exception AttrSetAlterAsyncException
   displayException AttrSetAlterInvalidSelector
     = "invalid selector with no components"
 
+data EvalGetterKeyNameAsyncException
+  = ComponentValueIsNullExpectedString
+  deriving Show
+
+instance Exception EvalGetterKeyNameAsyncException
+ where
+  displayException ComponentValueIsNullExpectedString
+    = "value is null while a string was expected"
+
 -- jww (2019-03-18): By deferring only those things which must wait until
 -- context of us, this can be written as:
 -- eval :: forall v m . MonadNixEval v m => NExprF v -> m v
@@ -352,7 +361,8 @@ evalGetterKeyName
 evalGetterKeyName = evalSetterKeyName >=> \case
   Just k -> pure k
   Nothing ->
-    evalError @v $ ErrorCall "value is null while a string was expected"
+    evalError @v $ ErrorCall
+      $ displayException ComponentValueIsNullExpectedString
 
 -- | Evaluate a component of an attribute path in a context where we are
 -- *binding* a value

--- a/src/Nix/Exec.hs
+++ b/src/Nix/Exec.hs
@@ -215,6 +215,17 @@ instance (Show op, Typeable op, Show lval, Typeable lval, Show rval, Typeable rv
     <> show rval
     <> "'."
 
+data EAAlreadyHandled a
+  = EAlreadyHandled a
+  deriving Show
+
+instance (Show a, Typeable a) => Exception (EAAlreadyHandled a)
+ where
+  displayException (EAlreadyHandled op)
+    = "This cannot happen: operator '"
+      <> show op
+      <> "' should have been handled in execBinaryOp."
+
 data EAFromStringNoContext
   = EAFromStringNoContext
   deriving Show
@@ -543,10 +554,7 @@ execBinaryOpForced scope span op lval rval = case op of
   hackyUnsupportedTypesForCompare = throwError $ ErrorCall
     $ displayException $ EUnsupportedTypes op lval rval
 
-  alreadyHandled = throwError $ ErrorCall $
-    "This cannot happen: operator "
-      ++ show op
-      ++ " should have been handled in execBinaryOp."
+  alreadyHandled = throwError $ ErrorCall $ displayException $ EAlreadyHandled op
 
 -- This function is here, rather than in 'Nix.String', because of the need to
 -- use 'throwError'.

--- a/src/Nix/Exec.hs
+++ b/src/Nix/Exec.hs
@@ -389,8 +389,7 @@ callFunc fun arg = demand fun $ \fun' -> do
     s@(NVSet m _) | Just f <- M.lookup "__functor" m -> do
       traceM "callFunc:__functor"
       demand f $ (`callFunc` s) >=> (`callFunc` arg)
-    x -> throwError $ ErrorCall
-      $ displayException $ ECallFuncCalledNotFunction x
+    x -> throwError $ ECallFuncCalledNotFunction x
 
 execUnaryOp
   :: (Framed e m, MonadCited t f m, Show t)

--- a/src/Nix/Exec.hs
+++ b/src/Nix/Exec.hs
@@ -406,8 +406,7 @@ execUnaryOp scope span op arg = do
       (NNeg, NFloat f) -> unaryOp $ NFloat (-f)
       (NNot, NBool b ) -> unaryOp $ NBool (not b)
       _ ->
-        throwError $ ErrorCall
-          $ displayException $ EExecUnaryOpUnsupportedType op
+        throwError $ EExecUnaryOpUnsupportedType op
     x ->
       throwError $ ErrorCall
         $ displayException $ EExecUnaryOpEvaluatedToNotAtomicType $ show x

--- a/src/Nix/Exec.hs
+++ b/src/Nix/Exec.hs
@@ -297,9 +297,7 @@ instance MonadNix e t f m => MonadEval (NValue t f m) m where
           (NStr_ span (DoubleQuoted [Plain (hackyStringIgnoreContext ns)]))
         )
         ns
-    Nothing -> nverr
-      $ ErrorCall
-      $ displayException (EMonadEvalStringAssembleFail :: EAMonadEval () ())
+    Nothing -> nverr (EMonadEvalStringAssembleFail :: EAMonadEval () ())
 
   evalLiteralPath p = do
     scope <- currentScopes

--- a/src/Nix/Exec.hs
+++ b/src/Nix/Exec.hs
@@ -184,6 +184,15 @@ instance (Show a, Typeable a) => Exception (EACallFunc a)
   displayException (ECallFuncCalledNotFunction x)
     = "Attempt to call non-function: " <> show x
 
+data EAExecUnaryOp a
+  = EExecUnaryOpUnsupportedType a
+  deriving Show
+
+instance Exception (EAExecUnaryOp String)
+ where
+  displayException (EExecUnaryOpUnsupportedType op)
+    = "unsupported argument type for unary operator "
+    <> op
 
 nverr :: forall e t f s m a . (MonadNix e t f m, Exception s) => s -> m a
 nverr = evalError @(NValue t f m)
@@ -367,10 +376,8 @@ execUnaryOp scope span op arg = do
       (NNeg, NFloat f) -> unaryOp $ NFloat (-f)
       (NNot, NBool b ) -> unaryOp $ NBool (not b)
       _ ->
-        throwError
-          $  ErrorCall
-          $  "unsupported argument type for unary operator "
-          ++ show op
+        throwError $ ErrorCall
+          $ displayException $ EExecUnaryOpUnsupportedType $ show op
     x ->
       throwError
         $  ErrorCall

--- a/src/Nix/Exec.hs
+++ b/src/Nix/Exec.hs
@@ -211,6 +211,14 @@ instance (Show op, Typeable op, Show lval, Typeable lval, Show rval, Typeable rv
     <> show lval
     <> show rval
 
+data EAFromStringNoContext
+  = EAFromStringNoContext
+  deriving Show
+
+instance Exception EAFromStringNoContext
+ where
+  displayException EAFromStringNoContext = "expected string with no context"
+
 nverr :: forall e t f s m a . (MonadNix e t f m, Exception s) => s -> m a
 nverr = evalError @(NValue t f m)
 
@@ -543,7 +551,7 @@ execBinaryOpForced scope span op lval rval = case op of
 fromStringNoContext :: Framed e m => NixString -> m Text
 fromStringNoContext ns = case principledGetStringNoContext ns of
   Just str -> return str
-  Nothing  -> throwError $ ErrorCall "expected string with no context"
+  Nothing  -> throwError $ ErrorCall $ displayException EAFromStringNoContext
 
 addTracing
   :: (MonadNix e t f m, Has e Options, MonadReader Int n, Alternative n)

--- a/src/Nix/Exec.hs
+++ b/src/Nix/Exec.hs
@@ -502,9 +502,7 @@ execBinaryOpForced scope span op lval rval = case op of
   NAnd  -> alreadyHandled
   NOr   -> alreadyHandled
   NImpl -> alreadyHandled
-  NApp  -> throwError $ ErrorCall
-          $ displayException
-          (EExecBinaryOpForcedNApp :: EAExecBinaryOpForced () () ())
+  NApp  -> throwError (EExecBinaryOpForcedNApp :: EAExecBinaryOpForced () () ())
 
  where
   prov :: Provenance m (NValue t f m)

--- a/src/Nix/Exec.hs
+++ b/src/Nix/Exec.hs
@@ -265,8 +265,6 @@ instance MonadNix e t f m => MonadEval (NValue t f m) m where
 
   attrMissing ks (Just s) =
     evalError @(NValue t f m)
-      $ ErrorCall
-      $ displayException
       $ EMonadEvalAttrNotFound
       (intercalate "." (map Text.unpack (NE.toList ks))) $ show $ prettyNValue s
 

--- a/src/Nix/Exec.hs
+++ b/src/Nix/Exec.hs
@@ -190,14 +190,14 @@ data EAExecUnaryOp a
   | EExecUnaryOpEvaluatedToNotAtomicType a
   deriving Show
 
-instance Exception (EAExecUnaryOp String)
+instance (Show a, Typeable a) => Exception (EAExecUnaryOp a)
  where
   displayException (EExecUnaryOpUnsupportedType op)
     = "unsupported argument type for unary operator "
-    <> op
+    <> show op
   displayException (EExecUnaryOpEvaluatedToNotAtomicType x)
     = "argument to unary operator must evaluate to an atomic type: "
-    <> x
+    <> show x
 
 data EAUnsupportedTypes o l r
   = EUnsupportedTypes o l r
@@ -400,7 +400,7 @@ execUnaryOp scope span op arg = do
       (NNot, NBool b ) -> unaryOp $ NBool (not b)
       _ ->
         throwError $ ErrorCall
-          $ displayException $ EExecUnaryOpUnsupportedType $ show op
+          $ displayException $ EExecUnaryOpUnsupportedType op
     x ->
       throwError $ ErrorCall
         $ displayException $ EExecUnaryOpEvaluatedToNotAtomicType $ show x

--- a/src/Nix/Exec.hs
+++ b/src/Nix/Exec.hs
@@ -211,6 +211,7 @@ data EAExecBinaryOpForced o l r
   = EExecBinaryOpForcedNPlusStringToPath
   | EExecBinaryOpForcedUnsupportedTypes o l r
   | EExecBinaryOpForcedAlreadyHandled o
+  | EExecBinaryOpForcedNApp
   deriving Show
 
 instance (Show op, Typeable op, Show lval, Typeable lval, Show rval, Typeable rval)
@@ -232,7 +233,8 @@ instance (Show op, Typeable op, Show lval, Typeable lval, Show rval, Typeable rv
     = "This cannot happen: operator '"
       <> show op
       <> "' should have been handled in 'execBinaryOp'."
-
+  displayException EExecBinaryOpForcedNApp
+    = "NApp should be handled by 'evalApp' function."
 
 nverr :: forall e t f s m a . (MonadNix e t f m, Exception s) => s -> m a
 nverr = evalError @(NValue t f m)
@@ -512,7 +514,9 @@ execBinaryOpForced scope span op lval rval = case op of
   NAnd  -> alreadyHandled
   NOr   -> alreadyHandled
   NImpl -> alreadyHandled
-  NApp  -> throwError $ ErrorCall $ "NApp should be handled by evalApp"
+  NApp  -> throwError $ ErrorCall
+          $ displayException
+          (EExecBinaryOpForcedNApp :: EAExecBinaryOpForced () () ())
 
  where
   prov :: Provenance m (NValue t f m)

--- a/src/Nix/Exec.hs
+++ b/src/Nix/Exec.hs
@@ -378,8 +378,7 @@ callFunc
   -> m (NValue t f m)
 callFunc fun arg = demand fun $ \fun' -> do
   frames :: Frames <- asks (view hasLens)
-  when (length frames > 2000) $ throwError $ ErrorCall
-    $ displayException $ ECallFuncCallStackExausted (undefined :: String)
+  when (length frames > 2000) $ throwError $ ECallFuncCallStackExausted (undefined :: String)
   case fun' of
     NVClosure params f -> do
       traceM $ "callFunc:NVFunction taking " ++ show params

--- a/src/Nix/Exec.hs
+++ b/src/Nix/Exec.hs
@@ -485,8 +485,7 @@ execBinaryOpForced scope span op lval rval = case op of
         <$> coerceToString callFunc CopyToStore CoerceStringy rs
     (NVPath ls, NVStr rs) -> case principledGetStringNoContext rs of
       Just rs2 -> nvPathP prov <$> makeAbsolutePath @t @f (ls `mappend` (Text.unpack rs2))
-      Nothing -> throwError $ ErrorCall
-        $ displayException
+      Nothing -> throwError
         (EExecBinaryOpForcedNPlusStringToPath :: EAExecBinaryOpForced () () ())
     (NVPath ls, NVPath rs) -> nvPathP prov <$> makeAbsolutePath @t @f (ls ++ rs)
 

--- a/src/Nix/Exec.hs
+++ b/src/Nix/Exec.hs
@@ -553,7 +553,7 @@ execBinaryOpForced scope span op lval rval = case op of
 fromStringNoContext :: Framed e m => NixString -> m Text
 fromStringNoContext ns = case principledGetStringNoContext ns of
   Just str -> return str
-  Nothing  -> throwError $ ErrorCall $ displayException EAFromStringNoContext
+  Nothing  -> throwError EAFromStringNoContext
 
 addTracing
   :: (MonadNix e t f m, Has e Options, MonadReader Int n, Alternative n)

--- a/src/Nix/Exec.hs
+++ b/src/Nix/Exec.hs
@@ -506,7 +506,7 @@ execBinaryOpForced scope span op lval rval = case op of
 
  where
   prov :: Provenance m (NValue t f m)
-  prov = (Provenance scope (NBinary_ span op (Just lval) (Just rval)))
+  prov = Provenance scope $ NBinary_ span op (Just lval) (Just rval)
 
   toBool = pure . nvConstantP prov . NBool
 

--- a/src/Nix/Exec.hs
+++ b/src/Nix/Exec.hs
@@ -538,8 +538,6 @@ execBinaryOpForced scope span op lval rval = case op of
 
   unsupportedTypes op lval rval
     = throwError
-    $ ErrorCall
-    $ displayException
     $ EExecBinaryOpForcedUnsupportedTypes op lval rval
 
   -- FIXME: Special function for `compare`,

--- a/src/Nix/Exec.hs
+++ b/src/Nix/Exec.hs
@@ -542,8 +542,8 @@ execBinaryOpForced scope span op lval rval = case op of
 
   -- FIXME: Special function for `compare`,
   -- because can not typecheck the rank-2 existential type of it properly
-  hackyUnsupportedTypesForCompare = throwError $ ErrorCall
-    $ displayException $ EExecBinaryOpForcedUnsupportedTypes op lval rval
+  hackyUnsupportedTypesForCompare = throwError
+    $ EExecBinaryOpForcedUnsupportedTypes op lval rval
 
   alreadyHandled = throwError $ ErrorCall
     $ displayException

--- a/src/Nix/Exec.hs
+++ b/src/Nix/Exec.hs
@@ -408,8 +408,7 @@ execUnaryOp scope span op arg = do
       _ ->
         throwError $ EExecUnaryOpUnsupportedType op
     x ->
-      throwError $ ErrorCall
-        $ displayException $ EExecUnaryOpEvaluatedToNotAtomicType $ show x
+      throwError $ EExecUnaryOpEvaluatedToNotAtomicType $ show x
  where
   unaryOp = pure . nvConstantP (Provenance scope (NUnary_ span op (Just arg)))
 

--- a/src/Nix/Exec.hs
+++ b/src/Nix/Exec.hs
@@ -247,8 +247,7 @@ wrapExprLoc span x = Fix (Fix (NSym_ span "<?>") <$ x)
 
 instance MonadNix e t f m => MonadEval (NValue t f m) m where
   freeVariable var =
-    nverr @e @t @f $ ErrorCall
-      $ displayException
+    nverr @e @t @f
       (EMonadEvalUndefinedVar (Text.unpack var) :: EAMonadEval String ())
 
   synHole name = do

--- a/src/Nix/Exec.hs
+++ b/src/Nix/Exec.hs
@@ -242,7 +242,8 @@ instance (Show op, Typeable op, Show lval, Typeable lval, Show rval, Typeable rv
   => Exception (EAExecBinaryOpForced op lval rval)
  where
   displayException EExecBinaryOpForcedNPlusStringToPath
-    -- data/nix/src/libexpr/eval.cc:1412
+    -- Upstream case:
+    -- https://github.com/haskell-nix/nix/blob/b18a4898ff990c0b8ec1d3571d23a054a7d4c5cd/src/libexpr/eval.cc#L1412
     = "A string that refers to a store path cannot be appended to a path."
 
 nverr :: forall e t f s m a . (MonadNix e t f m, Exception s) => s -> m a

--- a/src/Nix/Exec.hs
+++ b/src/Nix/Exec.hs
@@ -260,8 +260,6 @@ instance MonadNix e t f m => MonadEval (NValue t f m) m where
 
   attrMissing ks Nothing =
     evalError @(NValue t f m)
-      $ ErrorCall
-      $ displayException
       (EMonadEvalUnknownAttrInherit
         (intercalate "." (map Text.unpack (NE.toList ks))) :: EAMonadEval String ())
 

--- a/src/Nix/Exec.hs
+++ b/src/Nix/Exec.hs
@@ -545,8 +545,7 @@ execBinaryOpForced scope span op lval rval = case op of
   hackyUnsupportedTypesForCompare = throwError
     $ EExecBinaryOpForcedUnsupportedTypes op lval rval
 
-  alreadyHandled = throwError $ ErrorCall
-    $ displayException
+  alreadyHandled = throwError
     (EExecBinaryOpForcedAlreadyHandled op :: EAExecBinaryOpForced NBinaryOp () ())
 
 -- This function is here, rather than in 'Nix.String', because of the need to

--- a/src/Nix/Exec.hs
+++ b/src/Nix/Exec.hs
@@ -198,6 +198,19 @@ instance Exception (EAExecUnaryOp String)
     = "argument to unary operator must evaluate to an atomic type: "
     <> x
 
+data EAUnsupportedTypes o l r
+  = EUnsupportedTypes o l r
+  deriving Show
+
+instance (Show op, Typeable op, Show lval, Typeable lval, Show rval, Typeable rval)
+  => Exception (EAUnsupportedTypes op lval rval)
+ where
+  displayException (EUnsupportedTypes op lval rval)
+    = "Unsupported argument types for binary operator "
+    <> show op
+    <> show lval
+    <> show rval
+
 nverr :: forall e t f s m a . (MonadNix e t f m, Exception s) => s -> m a
 nverr = evalError @(NValue t f m)
 

--- a/src/Nix/Json.hs
+++ b/src/Nix/Json.hs
@@ -38,7 +38,7 @@ nvalueToJSON = \case
   NVConstant (NInt   n) -> pure $ A.toJSON n
   NVConstant (NFloat n) -> pure $ A.toJSON n
   NVConstant (NBool  b) -> pure $ A.toJSON b
-  NVConstant NNull      -> pure $ A.Null
+  NVConstant NNull      -> pure   A.Null
   NVStr      ns         -> A.toJSON <$> extractNixString ns
   NVList l ->
     A.Array

--- a/src/Nix/Lint.hs
+++ b/src/Nix/Lint.hs
@@ -189,6 +189,7 @@ data LintAppAsyncException
   | LintAppNotImplementedNManyNotSetException
   | LintAppNotImplementedBuiltinException
   | LintAppNotImplementedSetException
+  | LintAppCallNonFunctionException
   deriving Show
 
 instance Exception LintAppAsyncException
@@ -203,6 +204,8 @@ instance Exception LintAppAsyncException
     = "Not yet implemented: lintApp builtin."
   displayException LintAppNotImplementedSetException
     = "Not yet implemented: lintApp Set."
+  displayException LintAppCallNonFunctionException
+    = "Attempt to call non-function."
 
 
 symerr :: forall e m a . MonadLint e m => String -> m a
@@ -485,13 +488,14 @@ lintApp context fun arg = unpackSymbolic fun >>= \case
         NMany [TSet (Just _)] ->
           error $ displayException LintAppNotImplementedException
 
-      _x            -> throwError $ ErrorCall "Attempt to call non-function"
         NMany _ -> throwError $ ErrorCall
           $ displayException LintAppNotImplementedNManyNotSetException
       TBuiltin _ _f -> throwError $ ErrorCall
         $ displayException LintAppNotImplementedBuiltinException
       TSet _m       -> throwError $ ErrorCall
         $ displayException LintAppNotImplementedSetException
+      _x            -> throwError $ ErrorCall
+        $ displayException LintAppCallNonFunctionException
 
     y <- everyPossible
     (head args, ) <$> foldM (unify context) y ys

--- a/src/Nix/Lint.hs
+++ b/src/Nix/Lint.hs
@@ -145,6 +145,19 @@ instance Exception MergeAsyncException
     = "Got into the merge case that is in the code considered impossible "
     <> "to solve (which is most probably is)."
 
+data UnifyAsyncException
+  = UnifyNotDoneException
+  deriving Show
+
+instance Exception UnifyAsyncException
+ where
+  displayException UnifyNotDoneException
+    = "Could not unify arguments."
+    -- x' <- renderSymbolic (Symbolic x)
+    -- y' <- renderSymbolic (Symbolic y)
+    -- ++ show x' ++ " with " ++ show y'
+    --  ++ " in context: " ++ show context
+
 symerr :: forall e m a . MonadLint e m => String -> m a
 symerr = evalError @(Symbolic m) . ErrorCall
 
@@ -260,12 +273,8 @@ unify context (SV x) (SV y) = do
     (NMany xs, NMany ys) -> do
       m <- merge context xs ys
       if null m
-        then do
-              -- x' <- renderSymbolic (Symbolic x)
-              -- y' <- renderSymbolic (Symbolic y)
-          throwError $ ErrorCall "Cannot unify "
-                  -- ++ show x' ++ " with " ++ show y'
-                  --  ++ " in context: " ++ show context
+        then
+          throwError $ ErrorCall $ displayException UnifyNotDoneException
         else do
           writeVar x (NMany m)
           writeVar y (NMany m)

--- a/src/Nix/Lint.hs
+++ b/src/Nix/Lint.hs
@@ -233,8 +233,8 @@ merge context = go
       throwError $ ErrorCall $ displayException MergeBuiltinsException
     _ | compareTypes x y == LT -> go xs (y : ys)
       | compareTypes x y == GT -> go (x : xs) ys
-      | otherwise              -> error
-        $ displayException MergeImpossibleException
+      | otherwise              ->
+        error $ displayException MergeImpossibleException
 
 {-
     mergeFunctions pl nl fl pr fr xs ys = do
@@ -255,7 +255,7 @@ merge context = go
                     <$> go xs ys
 -}
 
--- | unify raises an error if the result is would be 'NMany []'.
+-- | unify raises an error if the result would be 'NMany []'.
 unify
   :: forall e m
    . MonadLint e m

--- a/src/Nix/Lint.hs
+++ b/src/Nix/Lint.hs
@@ -187,6 +187,7 @@ data LintAppAsyncException
   = LintAppNotFuncException
   | LintAppNotImplementedException
   | LintAppNotImplementedNManyNotSetException
+  | LintAppNotImplementedBuiltinException
   deriving Show
 
 instance Exception LintAppAsyncException
@@ -197,6 +198,8 @@ instance Exception LintAppAsyncException
     = "Not yet implemented."
   displayException LintAppNotImplementedNManyNotSetException
     = "Not yet implemented: lintApp NMany is not a set."
+  displayException LintAppNotImplementedBuiltinException
+    = "Not yet implemented: lintApp builtin."
 
 
 symerr :: forall e m a . MonadLint e m => String -> m a
@@ -479,11 +482,12 @@ lintApp context fun arg = unpackSymbolic fun >>= \case
         NMany [TSet (Just _)] ->
           error $ displayException LintAppNotImplementedException
 
-      TBuiltin _ _f -> throwError $ ErrorCall "NYI: lintApp builtin"
       TSet _m       -> throwError $ ErrorCall "NYI: lintApp Set"
       _x            -> throwError $ ErrorCall "Attempt to call non-function"
         NMany _ -> throwError $ ErrorCall
           $ displayException LintAppNotImplementedNManyNotSetException
+      TBuiltin _ _f -> throwError $ ErrorCall
+        $ displayException LintAppNotImplementedBuiltinException
 
     y <- everyPossible
     (head args, ) <$> foldM (unify context) y ys

--- a/src/Nix/Lint.hs
+++ b/src/Nix/Lint.hs
@@ -131,12 +131,15 @@ type MonadLint e m
 
 data MergeAsyncException
   = MergeClosuresException
+  | MergeBuiltinsException
   deriving Show
 
 instance Exception MergeAsyncException
  where
   displayException MergeClosuresException
     = "Do not know how to merge functions (closures)."
+  displayException MergeBuiltinsException
+    = "Do not know how to merge built-in functions."
 symerr :: forall e m a . MonadLint e m => String -> m a
 symerr = evalError @(Symbolic m) . ErrorCall
 
@@ -206,7 +209,7 @@ merge context = go
     (TClosure{}, TClosure{}) ->
       throwError $ ErrorCall $ displayException MergeClosuresException
     (TBuiltin _ _, TBuiltin _ _) ->
-      throwError $ ErrorCall "Cannot unify builtin functions"
+      throwError $ ErrorCall $ displayException MergeBuiltinsException
     _ | compareTypes x y == LT -> go xs (y : ys)
       | compareTypes x y == GT -> go (x : xs) ys
       | otherwise              -> error "impossible"

--- a/src/Nix/Lint.hs
+++ b/src/Nix/Lint.hs
@@ -186,6 +186,7 @@ instance Exception (MonadEvalAsyncException (NE.NonEmpty Text))
 data LintAppAsyncException
   = LintAppNotFuncException
   | LintAppNotImplementedException
+  | LintAppNotImplementedNManyNotSetException
   deriving Show
 
 instance Exception LintAppAsyncException
@@ -194,6 +195,8 @@ instance Exception LintAppAsyncException
     = "Cannot apply something that is not known to be a function."
   displayException LintAppNotImplementedException
     = "Not yet implemented."
+  displayException LintAppNotImplementedNManyNotSetException
+    = "Not yet implemented: lintApp NMany is not a set."
 
 
 symerr :: forall e m a . MonadLint e m => String -> m a
@@ -476,10 +479,11 @@ lintApp context fun arg = unpackSymbolic fun >>= \case
         NMany [TSet (Just _)] ->
           error $ displayException LintAppNotImplementedException
 
-        NMany _ -> throwError $ ErrorCall "NYI: lintApp NMany not set"
       TBuiltin _ _f -> throwError $ ErrorCall "NYI: lintApp builtin"
       TSet _m       -> throwError $ ErrorCall "NYI: lintApp Set"
       _x            -> throwError $ ErrorCall "Attempt to call non-function"
+        NMany _ -> throwError $ ErrorCall
+          $ displayException LintAppNotImplementedNManyNotSetException
 
     y <- everyPossible
     (head args, ) <$> foldM (unify context) y ys

--- a/src/Nix/Lint.hs
+++ b/src/Nix/Lint.hs
@@ -183,6 +183,15 @@ instance Exception (MonadEvalAsyncException (NE.NonEmpty Text))
   displayException (MonadEvalScopeNotASetWithStatementException _)
     = "scope must be a set in with statement"
 
+data LintAppAsyncException
+  = LintAppNotFuncException
+  deriving Show
+
+instance Exception LintAppAsyncException
+ where
+  displayException LintAppNotFuncException
+    = "Cannot apply something that is not known to be a function."
+
 
 symerr :: forall e m a . MonadLint e m => String -> m a
 symerr = evalError @(Symbolic m) . ErrorCall
@@ -454,7 +463,7 @@ lintApp
   -> m (HashMap VarName (Symbolic m), Symbolic m)
 lintApp context fun arg = unpackSymbolic fun >>= \case
   NAny ->
-    throwError $ ErrorCall "Cannot apply something not known to be a function"
+    throwError $ ErrorCall $ displayException LintAppNotFuncException
   NMany xs -> do
     (args, ys) <- fmap unzip $ forM xs $ \case
       TClosure _params -> arg >>= unpackSymbolic >>= \case

--- a/src/Nix/Lint.hs
+++ b/src/Nix/Lint.hs
@@ -332,7 +332,7 @@ unify context (SV x) (SV y) = do
       m <- merge context xs ys
       if null m
         then
-          throwError $ ErrorCall $ displayException EUnifyNotDone
+          throwError EUnifyNotDone
         else do
           writeVar x (NMany m)
           writeVar y (NMany m)

--- a/src/Nix/Lint.hs
+++ b/src/Nix/Lint.hs
@@ -484,7 +484,7 @@ lintApp
   -> m (HashMap VarName (Symbolic m), Symbolic m)
 lintApp context fun arg = unpackSymbolic fun >>= \case
   NAny ->
-    throwError $ ErrorCall $ displayException ELintAppNotFunc
+    throwError ELintAppNotFunc
   NMany xs -> do
     (args, ys) <- fmap unzip $ forM xs $ \case
       TClosure _params -> arg >>= unpackSymbolic >>= \case

--- a/src/Nix/Lint.hs
+++ b/src/Nix/Lint.hs
@@ -362,8 +362,7 @@ instance MonadLint e m => MonadEval (Symbolic m) m where
   freeVariable var = symerr $ "Undefined variable '" ++ Text.unpack var ++ "'"
 
   attrMissing ks Nothing =
-    evalError @(Symbolic m)
-      $  ErrorCall $ displayException $ EMonadEvalAttrUnknownInherit ks
+    evalError @(Symbolic m) $ EMonadEvalAttrUnknownInherit ks
 
   attrMissing ks (Just s) =
     evalError @(Symbolic m)

--- a/src/Nix/Lint.hs
+++ b/src/Nix/Lint.hs
@@ -188,6 +188,7 @@ data LintAppAsyncException
   | LintAppNotImplementedException
   | LintAppNotImplementedNManyNotSetException
   | LintAppNotImplementedBuiltinException
+  | LintAppNotImplementedSetException
   deriving Show
 
 instance Exception LintAppAsyncException
@@ -200,6 +201,8 @@ instance Exception LintAppAsyncException
     = "Not yet implemented: lintApp NMany is not a set."
   displayException LintAppNotImplementedBuiltinException
     = "Not yet implemented: lintApp builtin."
+  displayException LintAppNotImplementedSetException
+    = "Not yet implemented: lintApp Set."
 
 
 symerr :: forall e m a . MonadLint e m => String -> m a
@@ -482,12 +485,13 @@ lintApp context fun arg = unpackSymbolic fun >>= \case
         NMany [TSet (Just _)] ->
           error $ displayException LintAppNotImplementedException
 
-      TSet _m       -> throwError $ ErrorCall "NYI: lintApp Set"
       _x            -> throwError $ ErrorCall "Attempt to call non-function"
         NMany _ -> throwError $ ErrorCall
           $ displayException LintAppNotImplementedNManyNotSetException
       TBuiltin _ _f -> throwError $ ErrorCall
         $ displayException LintAppNotImplementedBuiltinException
+      TSet _m       -> throwError $ ErrorCall
+        $ displayException LintAppNotImplementedSetException
 
     y <- everyPossible
     (head args, ) <$> foldM (unify context) y ys

--- a/src/Nix/Lint.hs
+++ b/src/Nix/Lint.hs
@@ -129,13 +129,13 @@ type MonadLint e m
   , MonadThunkId m
   )
 
-data EAMerge
+data EMerge
   = EMergeClosures
   | EMergeBuiltins
   | EMergeImpossible
   deriving Show
 
-instance Exception EAMerge
+instance Exception EMerge
  where
   displayException EMergeClosures
     = "Do not know how to merge functions (closures)."
@@ -145,12 +145,12 @@ instance Exception EAMerge
     = "Got into the merge case that is in the code considered impossible "
     <> "to solve (which is most probably is)."
 
-data EAUnify
+data EUnify
   = EUnifyNotDone
   | EUnifyUnexpectedCase
   deriving Show
 
-instance Exception EAUnify
+instance Exception EUnify
  where
   displayException EUnifyNotDone
     = "Could not unify arguments."
@@ -161,14 +161,14 @@ instance Exception EAUnify
   displayException EUnifyUnexpectedCase
     = "The unexpected hath transpired! (No case for recieved arguments)"
 
-data EAMonadEval a
+data EMonadEval a
   = EMonadEvalAttrUnknownInherit a
   -- | MonadEvalAttrNotFound a b
   | EMonadEvalNotImplemented a
   | EMonadEvalScopeNotASetWithStatement a
   deriving Show
 
-instance Exception (EAMonadEval (NE.NonEmpty Text))
+instance Exception (EMonadEval (NE.NonEmpty Text))
  where
   displayException (EMonadEvalAttrUnknownInherit ks)
     = "Inheriting unknown attribute: "
@@ -183,7 +183,7 @@ instance Exception (EAMonadEval (NE.NonEmpty Text))
   displayException (EMonadEvalScopeNotASetWithStatement _)
     = "scope must be a set in with statement"
 
-data EALintApp
+data ELintApp
   = ELintAppNotFunc
   | ELintAppNotImplemented
   | ELintAppNotImplementedNManyNotSet
@@ -192,7 +192,7 @@ data EALintApp
   | ELintAppCallNonFunction
   deriving Show
 
-instance Exception EALintApp
+instance Exception ELintApp
  where
   displayException ELintAppNotFunc
     = "Cannot apply something that is not known to be a function."
@@ -207,11 +207,11 @@ instance Exception EALintApp
   displayException ELintAppCallNonFunction
     = "Attempt to call non-function."
 
-data EAMonadCatch
+data EMonadCatch
   = EMonadCatchCanNotCatchInLint
   deriving Show
 
-instance Exception EAMonadCatch
+instance Exception EMonadCatch
  where
   displayException EMonadCatchCanNotCatchInLint
     = "Cannot catch in 'Lint s'."

--- a/src/Nix/Lint.hs
+++ b/src/Nix/Lint.hs
@@ -129,6 +129,14 @@ type MonadLint e m
   , MonadThunkId m
   )
 
+data MergeAsyncException
+  = MergeClosuresException
+  deriving Show
+
+instance Exception MergeAsyncException
+ where
+  displayException MergeClosuresException
+    = "Do not know how to merge functions (closures)."
 symerr :: forall e m a . MonadLint e m => String -> m a
 symerr = evalError @(Symbolic m) . ErrorCall
 
@@ -196,7 +204,7 @@ merge context = go
         (return <$> r)
       if M.null m then go xs ys else (TSet (Just m) :) <$> go xs ys
     (TClosure{}, TClosure{}) ->
-      throwError $ ErrorCall "Cannot unify functions"
+      throwError $ ErrorCall $ displayException MergeClosuresException
     (TBuiltin _ _, TBuiltin _ _) ->
       throwError $ ErrorCall "Cannot unify builtin functions"
     _ | compareTypes x y == LT -> go xs (y : ys)

--- a/src/Nix/Lint.hs
+++ b/src/Nix/Lint.hs
@@ -132,6 +132,7 @@ type MonadLint e m
 data MergeAsyncException
   = MergeClosuresException
   | MergeBuiltinsException
+  | MergeImpossibleException
   deriving Show
 
 instance Exception MergeAsyncException
@@ -140,6 +141,10 @@ instance Exception MergeAsyncException
     = "Do not know how to merge functions (closures)."
   displayException MergeBuiltinsException
     = "Do not know how to merge built-in functions."
+  displayException MergeImpossibleException
+    = "Got into the merge case that is in the code considered impossible "
+    <> "to solve (which is most probably is)."
+
 symerr :: forall e m a . MonadLint e m => String -> m a
 symerr = evalError @(Symbolic m) . ErrorCall
 
@@ -212,7 +217,8 @@ merge context = go
       throwError $ ErrorCall $ displayException MergeBuiltinsException
     _ | compareTypes x y == LT -> go xs (y : ys)
       | compareTypes x y == GT -> go (x : xs) ys
-      | otherwise              -> error "impossible"
+      | otherwise              -> error
+        $ displayException MergeImpossibleException
 
 {-
     mergeFunctions pl nl fl pr fr xs ys = do

--- a/src/Nix/Lint.hs
+++ b/src/Nix/Lint.hs
@@ -500,8 +500,7 @@ lintApp context fun arg = unpackSymbolic fun >>= \case
         $ displayException ELintAppNotImplementedBuiltin
       TSet _m       -> throwError $ ErrorCall
         $ displayException ELintAppNotImplementedSet
-      _x            -> throwError $ ErrorCall
-        $ displayException ELintAppCallNonFunction
+      _x            -> throwError ELintAppCallNonFunction
 
     y <- everyPossible
     (head args, ) <$> foldM (unify context) y ys

--- a/src/Nix/Lint.hs
+++ b/src/Nix/Lint.hs
@@ -129,13 +129,13 @@ type MonadLint e m
   , MonadThunkId m
   )
 
-data MergeAsyncException
+data MergeAsyncE
   = MergeClosuresException
   | MergeBuiltinsException
   | MergeImpossibleException
   deriving Show
 
-instance Exception MergeAsyncException
+instance Exception MergeAsyncE
  where
   displayException MergeClosuresException
     = "Do not know how to merge functions (closures)."
@@ -145,12 +145,12 @@ instance Exception MergeAsyncException
     = "Got into the merge case that is in the code considered impossible "
     <> "to solve (which is most probably is)."
 
-data UnifyAsyncException
+data UnifyAsyncE
   = UnifyNotDoneException
   | UnifyUnexpectedCaseException
   deriving Show
 
-instance Exception UnifyAsyncException
+instance Exception UnifyAsyncE
  where
   displayException UnifyNotDoneException
     = "Could not unify arguments."
@@ -161,14 +161,14 @@ instance Exception UnifyAsyncException
   displayException UnifyUnexpectedCaseException
     = "The unexpected hath transpired! (No case for recieved arguments)"
 
-data MonadEvalAsyncException a
+data MonadEvalAsyncE a
   = MonadEvalAttrUnknownInheritException a
   -- | MonadEvalAttrNotFound a b
   | MonadEvalNotImplementedException a
   | MonadEvalScopeNotASetWithStatementException a
   deriving Show
 
-instance Exception (MonadEvalAsyncException (NE.NonEmpty Text))
+instance Exception (MonadEvalAsyncE (NE.NonEmpty Text))
  where
   displayException (MonadEvalAttrUnknownInheritException ks)
     = "Inheriting unknown attribute: "
@@ -183,7 +183,7 @@ instance Exception (MonadEvalAsyncException (NE.NonEmpty Text))
   displayException (MonadEvalScopeNotASetWithStatementException _)
     = "scope must be a set in with statement"
 
-data LintAppAsyncException
+data LintAppAsyncE
   = LintAppNotFuncException
   | LintAppNotImplementedException
   | LintAppNotImplementedNManyNotSetException
@@ -192,7 +192,7 @@ data LintAppAsyncException
   | LintAppCallNonFunctionException
   deriving Show
 
-instance Exception LintAppAsyncException
+instance Exception LintAppAsyncE
  where
   displayException LintAppNotFuncException
     = "Cannot apply something that is not known to be a function."
@@ -207,11 +207,11 @@ instance Exception LintAppAsyncException
   displayException LintAppCallNonFunctionException
     = "Attempt to call non-function."
 
-data MonadCatchAsyncException
+data MonadCatchAsyncE
   = MonadCatchCanNotCatchInLintException
   deriving Show
 
-instance Exception MonadCatchAsyncException
+instance Exception MonadCatchAsyncE
  where
   displayException MonadCatchCanNotCatchInLintException
     = "Cannot catch in 'Lint s'."
@@ -368,7 +368,7 @@ instance MonadLint e m => MonadEval (Symbolic m) m where
   attrMissing ks (Just s) =
     evalError @(Symbolic m)
       $  ErrorCall
-      -- TODO: 2019-08-19: Abstracting this into MonadEvalAsyncException
+      -- TODO: 2019-08-19: Abstracting this into MonadEvalAsyncE
       -- required propagation of the Typeable of s everywhere
       $  "Could not look up attribute "
       ++ intercalate "." (map Text.unpack (NE.toList ks))

--- a/src/Nix/Lint.hs
+++ b/src/Nix/Lint.hs
@@ -147,6 +147,7 @@ instance Exception MergeAsyncException
 
 data UnifyAsyncException
   = UnifyNotDoneException
+  | UnifyUnexpectedCaseException
   deriving Show
 
 instance Exception UnifyAsyncException
@@ -157,6 +158,8 @@ instance Exception UnifyAsyncException
     -- y' <- renderSymbolic (Symbolic y)
     -- ++ show x' ++ " with " ++ show y'
     --  ++ " in context: " ++ show context
+  displayException UnifyUnexpectedCaseException
+    = "The unexpected hath transpired! (No case for recieved arguments)"
 
 symerr :: forall e m a . MonadLint e m => String -> m a
 symerr = evalError @(Symbolic m) . ErrorCall
@@ -279,7 +282,7 @@ unify context (SV x) (SV y) = do
           writeVar x (NMany m)
           writeVar y (NMany m)
           packSymbolic (NMany m)
-unify _ _ _ = error "The unexpected hath transpired!"
+unify _ _ _ = error $ displayException UnifyUnexpectedCaseException
 
 -- These aren't worth defining yet, because once we move to Hindley-Milner,
 -- we're not going to be managing Symbolic values this way anymore.

--- a/src/Nix/Lint.hs
+++ b/src/Nix/Lint.hs
@@ -207,6 +207,14 @@ instance Exception LintAppAsyncException
   displayException LintAppCallNonFunctionException
     = "Attempt to call non-function."
 
+data MonadCatchAsyncException
+  = MonadCatchCanNotCatchInLintException
+  deriving Show
+
+instance Exception MonadCatchAsyncException
+ where
+  displayException MonadCatchCanNotCatchInLintException
+    = "Cannot catch in 'Lint s'."
 
 symerr :: forall e m a . MonadLint e m => String -> m a
 symerr = evalError @(Symbolic m) . ErrorCall
@@ -517,7 +525,8 @@ instance MonadThrow (Lint s) where
   throwM e = Lint $ ReaderT $ \_ -> throw e
 
 instance MonadCatch (Lint s) where
-  catch _m _h = Lint $ ReaderT $ \_ -> error "Cannot catch in 'Lint s'"
+  catch _m _h = Lint $ ReaderT
+    $ \_ -> error $ displayException MonadCatchCanNotCatchInLintException
 
 runLintM :: Options -> Lint s a -> ST s a
 runLintM opts action = do

--- a/src/Nix/Lint.hs
+++ b/src/Nix/Lint.hs
@@ -411,8 +411,7 @@ instance MonadLint e m => MonadEval (Symbolic m) m where
       NMany [TSet Nothing] ->
         error $ displayException
         $ EMonadEvalNotImplemented u
-      _ -> throwError $ ErrorCall $ displayException
-        $ EMonadEvalScopeNotASetWithStatement u
+      _ -> throwError $ EMonadEvalScopeNotASetWithStatement u
    where
     u = undefined :: NE.NonEmpty Text -- Stub parameter for exception constructor
 

--- a/src/Nix/Lint.hs
+++ b/src/Nix/Lint.hs
@@ -496,8 +496,7 @@ lintApp context fun arg = unpackSymbolic fun >>= \case
 
         NMany _ -> throwError $ ErrorCall
           $ displayException ELintAppNotImplementedNManyNotSet
-      TBuiltin _ _f -> throwError $ ErrorCall
-        $ displayException ELintAppNotImplementedBuiltin
+      TBuiltin _ _f -> throwError ELintAppNotImplementedBuiltin
       TSet _m       -> throwError ELintAppNotImplementedSet
       _x            -> throwError ELintAppCallNonFunction
 

--- a/src/Nix/Lint.hs
+++ b/src/Nix/Lint.hs
@@ -494,8 +494,7 @@ lintApp context fun arg = unpackSymbolic fun >>= \case
         NMany [TSet (Just _)] ->
           error $ displayException ELintAppNotImplemented
 
-        NMany _ -> throwError $ ErrorCall
-          $ displayException ELintAppNotImplementedNManyNotSet
+        NMany _ -> throwError ELintAppNotImplementedNManyNotSet
       TBuiltin _ _f -> throwError ELintAppNotImplementedBuiltin
       TSet _m       -> throwError ELintAppNotImplementedSet
       _x            -> throwError ELintAppCallNonFunction

--- a/src/Nix/Lint.hs
+++ b/src/Nix/Lint.hs
@@ -283,7 +283,7 @@ merge context = go
         (return <$> r)
       if M.null m then go xs ys else (TSet (Just m) :) <$> go xs ys
     (TClosure{}, TClosure{}) ->
-      throwError $ ErrorCall $ displayException EMergeClosures
+      throwError EMergeClosures
     (TBuiltin _ _, TBuiltin _ _) ->
       throwError $ ErrorCall $ displayException EMergeBuiltins
     _ | compareTypes x y == LT -> go xs (y : ys)

--- a/src/Nix/Lint.hs
+++ b/src/Nix/Lint.hs
@@ -285,7 +285,7 @@ merge context = go
     (TClosure{}, TClosure{}) ->
       throwError EMergeClosures
     (TBuiltin _ _, TBuiltin _ _) ->
-      throwError $ ErrorCall $ displayException EMergeBuiltins
+      throwError EMergeBuiltins
     _ | compareTypes x y == LT -> go xs (y : ys)
       | compareTypes x y == GT -> go (x : xs) ys
       | otherwise              ->

--- a/src/Nix/Lint.hs
+++ b/src/Nix/Lint.hs
@@ -498,8 +498,7 @@ lintApp context fun arg = unpackSymbolic fun >>= \case
           $ displayException ELintAppNotImplementedNManyNotSet
       TBuiltin _ _f -> throwError $ ErrorCall
         $ displayException ELintAppNotImplementedBuiltin
-      TSet _m       -> throwError $ ErrorCall
-        $ displayException ELintAppNotImplementedSet
+      TSet _m       -> throwError ELintAppNotImplementedSet
       _x            -> throwError ELintAppCallNonFunction
 
     y <- everyPossible

--- a/src/Nix/Lint.hs
+++ b/src/Nix/Lint.hs
@@ -185,12 +185,15 @@ instance Exception (MonadEvalAsyncException (NE.NonEmpty Text))
 
 data LintAppAsyncException
   = LintAppNotFuncException
+  | LintAppNotImplementedException
   deriving Show
 
 instance Exception LintAppAsyncException
  where
   displayException LintAppNotFuncException
     = "Cannot apply something that is not known to be a function."
+  displayException LintAppNotImplementedException
+    = "Not yet implemented."
 
 
 symerr :: forall e m a . MonadLint e m => String -> m a
@@ -467,11 +470,11 @@ lintApp context fun arg = unpackSymbolic fun >>= \case
   NMany xs -> do
     (args, ys) <- fmap unzip $ forM xs $ \case
       TClosure _params -> arg >>= unpackSymbolic >>= \case
-        NAny -> do
-          error "NYI"
+        NAny ->
+          error $ displayException LintAppNotImplementedException
 
-        NMany [TSet (Just _)] -> do
-          error "NYI"
+        NMany [TSet (Just _)] ->
+          error $ displayException LintAppNotImplementedException
 
         NMany _ -> throwError $ ErrorCall "NYI: lintApp NMany not set"
       TBuiltin _ _f -> throwError $ ErrorCall "NYI: lintApp builtin"

--- a/src/Nix/Lint.hs
+++ b/src/Nix/Lint.hs
@@ -163,6 +163,7 @@ instance Exception UnifyAsyncException
 
 data MonadEvalAsyncException a
   = MonadEvalAttrUnknownInheritException a
+  -- | MonadEvalAttrNotFound a b
   deriving Show
 
 instance Exception (MonadEvalAsyncException (NE.NonEmpty Text))
@@ -170,6 +171,11 @@ instance Exception (MonadEvalAsyncException (NE.NonEmpty Text))
   displayException (MonadEvalAttrUnknownInheritException ks)
     = "Inheriting unknown attribute: "
     <> intercalate "." (map Text.unpack (NE.toList ks))
+  -- displayException (MonadEvalAttrNotFound ks s)
+  --   = "Could not look up attribute "
+  --     ++ intercalate "." (map Text.unpack (NE.toList ks))
+  --     ++ " in "
+  --     ++ show s
 
 symerr :: forall e m a . MonadLint e m => String -> m a
 symerr = evalError @(Symbolic m) . ErrorCall
@@ -323,6 +329,8 @@ instance MonadLint e m => MonadEval (Symbolic m) m where
   attrMissing ks (Just s) =
     evalError @(Symbolic m)
       $  ErrorCall
+      -- TODO: 2019-08-19: Abstracting this into MonadEvalAsyncException
+      -- required propagation of the Typeable of s everywhere
       $  "Could not look up attribute "
       ++ intercalate "." (map Text.unpack (NE.toList ks))
       ++ " in "

--- a/src/Nix/Render/Frame.hs
+++ b/src/Nix/Render/Frame.hs
@@ -33,11 +33,11 @@ import           Text.Megaparsec.Pos
 import qualified Text.Show.Pretty as PS
 #endif
 
-newtype EAFrame a
+newtype EFrame a
   = EUnrecognizedFrame a
   deriving Show
 
-instance (Show a, Typeable a) => Exception (EAFrame a)
+instance (Show a, Typeable a) => Exception (EFrame a)
  where
   displayException (EUnrecognizedFrame f) = "Unrecognized frame: '" <> show f <> "'."
 

--- a/src/Nix/Render/Frame.hs
+++ b/src/Nix/Render/Frame.hs
@@ -33,13 +33,13 @@ import           Text.Megaparsec.Pos
 import qualified Text.Show.Pretty as PS
 #endif
 
-newtype FrameAsyncE a
-  = UnrecognizedFrameE a
+newtype EAFrame a
+  = EUnrecognizedFrame a
   deriving Show
 
-instance (Show a, Typeable a) => Exception (FrameAsyncE a)
+instance (Show a, Typeable a) => Exception (EAFrame a)
  where
-  displayException (UnrecognizedFrameE f) = "Unrecognized frame: '" <> show f <> "'."
+  displayException (EUnrecognizedFrame f) = "Unrecognized frame: '" <> show f <> "'."
 
 renderFrames
   :: forall v t f e m ann
@@ -99,7 +99,7 @@ renderFrame (NixFrame level f)
   | Just (e :: ExecFrame t f m) <- fromException f = renderExecFrame level e
   | Just (e :: ErrorCall) <- fromException f = pure [pretty (show e)]
   | Just (e :: SynHoleInfo m v) <- fromException f = pure [pretty (show e)]
-  | otherwise = error $ displayException $ UnrecognizedFrameE f
+  | otherwise = error $ displayException $ EUnrecognizedFrame f
 
 wrapExpr :: NExprF r -> NExpr
 wrapExpr x = Fix (Fix (NSym "<?>") <$ x)

--- a/src/Nix/Render/Frame.hs
+++ b/src/Nix/Render/Frame.hs
@@ -33,13 +33,13 @@ import           Text.Megaparsec.Pos
 import qualified Text.Show.Pretty as PS
 #endif
 
-newtype FrameAsyncException a
-  = UnrecognizedFrame a
+newtype FrameAsyncE a
+  = UnrecognizedFrameE a
   deriving Show
 
-instance (Show a, Typeable a) => Exception (FrameAsyncException a)
+instance (Show a, Typeable a) => Exception (FrameAsyncE a)
  where
-  displayException (UnrecognizedFrame f) = "Unrecognized frame: '" <> show f <> "'."
+  displayException (UnrecognizedFrameE f) = "Unrecognized frame: '" <> show f <> "'."
 
 renderFrames
   :: forall v t f e m ann
@@ -99,7 +99,7 @@ renderFrame (NixFrame level f)
   | Just (e :: ExecFrame t f m) <- fromException f = renderExecFrame level e
   | Just (e :: ErrorCall) <- fromException f = pure [pretty (show e)]
   | Just (e :: SynHoleInfo m v) <- fromException f = pure [pretty (show e)]
-  | otherwise = error $ displayException $ UnrecognizedFrame f
+  | otherwise = error $ displayException $ UnrecognizedFrameE f
 
 wrapExpr :: NExprF r -> NExpr
 wrapExpr x = Fix (Fix (NSym "<?>") <$ x)

--- a/src/Nix/String.hs
+++ b/src/Nix/String.hs
@@ -205,7 +205,7 @@ principledMakeNixStringWithSingletonContext s c = NixString s (S.singleton c)
 
 -- | Create a NixString from a Text and context
 principledMakeNixString :: Text -> S.HashSet StringContext -> NixString
-principledMakeNixString s c = NixString s c
+principledMakeNixString = NixString
 
 -- | A monad for accumulating string context while producing a result string.
 newtype WithStringContextT m a = WithStringContextT (WriterT (S.HashSet StringContext) m a)

--- a/src/Nix/String/Coerce.hs
+++ b/src/Nix/String/Coerce.hs
@@ -86,7 +86,7 @@ coerceToString call ctsm clevel = go
 
     NVSet s _ | Just p <- M.lookup "outPath" s -> demand p go
 
-    v -> throwError $ ErrorCall $ displayException $ ECoerceUnexpectedArgument v
+    v -> throwError $ ECoerceUnexpectedArgument v
 
   nixStringUnwords =
     principledIntercalateNixString (principledMakeNixStringWithoutContext " ")

--- a/src/Nix/String/Coerce.hs
+++ b/src/Nix/String/Coerce.hs
@@ -38,13 +38,13 @@ data CopyToStoreMode
   -- ^ Add paths to the store as they are encountered
   deriving (Eq,Ord,Enum,Bounded)
 
-newtype EACoerce a
-  = ECoerceUnexpectedArgument a
+newtype EACoerceToString a
+  = ECoerceToStringUnexpectedArgument a
   deriving Show
 
-instance (Show a, Typeable a) => Exception (EACoerce a)
+instance (Show a, Typeable a) => Exception (EACoerceToString a)
  where
-  displayException (ECoerceUnexpectedArgument v)
+  displayException (ECoerceToStringUnexpectedArgument v)
     = "Expected a string, but received: '" <> show v <> "'."
 
 coerceToString
@@ -86,7 +86,7 @@ coerceToString call ctsm clevel = go
 
     NVSet s _ | Just p <- M.lookup "outPath" s -> demand p go
 
-    v -> throwError $ ECoerceUnexpectedArgument v
+    v -> throwError $ ECoerceToStringUnexpectedArgument v
 
   nixStringUnwords =
     principledIntercalateNixString (principledMakeNixStringWithoutContext " ")

--- a/src/Nix/String/Coerce.hs
+++ b/src/Nix/String/Coerce.hs
@@ -38,13 +38,13 @@ data CopyToStoreMode
   -- ^ Add paths to the store as they are encountered
   deriving (Eq,Ord,Enum,Bounded)
 
-newtype CoerceAsyncE a
-  = CoerceUnexpectedArgumentE a
+newtype EACoerce a
+  = ECoerceUnexpectedArgument a
   deriving Show
 
-instance (Show a, Typeable a) => Exception (CoerceAsyncE a)
+instance (Show a, Typeable a) => Exception (EACoerce a)
  where
-  displayException (CoerceUnexpectedArgumentE v)
+  displayException (ECoerceUnexpectedArgument v)
     = "Expected a string, but received: '" <> show v <> "'."
 
 coerceToString
@@ -86,7 +86,7 @@ coerceToString call ctsm clevel = go
 
     NVSet s _ | Just p <- M.lookup "outPath" s -> demand p go
 
-    v -> throwError $ ErrorCall $ displayException $ CoerceUnexpectedArgumentE v
+    v -> throwError $ ErrorCall $ displayException $ ECoerceUnexpectedArgument v
 
   nixStringUnwords =
     principledIntercalateNixString (principledMakeNixStringWithoutContext " ")

--- a/src/Nix/String/Coerce.hs
+++ b/src/Nix/String/Coerce.hs
@@ -38,13 +38,13 @@ data CopyToStoreMode
   -- ^ Add paths to the store as they are encountered
   deriving (Eq,Ord,Enum,Bounded)
 
-newtype CoerceAsyncException a
-  = CoerceUnexpectedArgument a
+newtype CoerceAsyncE a
+  = CoerceUnexpectedArgumentE a
   deriving Show
 
-instance (Show a, Typeable a) => Exception (CoerceAsyncException a)
+instance (Show a, Typeable a) => Exception (CoerceAsyncE a)
  where
-  displayException (CoerceUnexpectedArgument v)
+  displayException (CoerceUnexpectedArgumentE v)
     = "Expected a string, but received: '" <> show v <> "'."
 
 coerceToString
@@ -86,7 +86,7 @@ coerceToString call ctsm clevel = go
 
     NVSet s _ | Just p <- M.lookup "outPath" s -> demand p go
 
-    v -> throwError $ ErrorCall $ displayException $ CoerceUnexpectedArgument v
+    v -> throwError $ ErrorCall $ displayException $ CoerceUnexpectedArgumentE v
 
   nixStringUnwords =
     principledIntercalateNixString (principledMakeNixStringWithoutContext " ")

--- a/src/Nix/String/Coerce.hs
+++ b/src/Nix/String/Coerce.hs
@@ -38,6 +38,15 @@ data CopyToStoreMode
   -- ^ Add paths to the store as they are encountered
   deriving (Eq,Ord,Enum,Bounded)
 
+newtype CoerceAsyncException a
+  = CoerceUnexpectedArgument a
+  deriving Show
+
+instance (Show a, Typeable a) => Exception (CoerceAsyncException a)
+ where
+  displayException (CoerceUnexpectedArgument v)
+    = "Expected a string, but received: '" <> show v <> "'."
+
 coerceToString
   :: ( Framed e m
      , MonadStore m
@@ -77,7 +86,7 @@ coerceToString call ctsm clevel = go
 
     NVSet s _ | Just p <- M.lookup "outPath" s -> demand p go
 
-    v -> throwError $ ErrorCall $ "Expected a string, but saw: " ++ show v
+    v -> throwError $ ErrorCall $ displayException $ CoerceUnexpectedArgument v
 
   nixStringUnwords =
     principledIntercalateNixString (principledMakeNixStringWithoutContext " ")

--- a/src/Nix/String/Coerce.hs
+++ b/src/Nix/String/Coerce.hs
@@ -38,11 +38,11 @@ data CopyToStoreMode
   -- ^ Add paths to the store as they are encountered
   deriving (Eq,Ord,Enum,Bounded)
 
-newtype EACoerceToString a
+newtype ECoerceToString a
   = ECoerceToStringUnexpectedArgument a
   deriving Show
 
-instance (Show a, Typeable a) => Exception (EACoerceToString a)
+instance (Show a, Typeable a) => Exception (ECoerceToString a)
  where
   displayException (ECoerceToStringUnexpectedArgument v)
     = "Expected a string, but received: '" <> show v <> "'."


### PR DESCRIPTION
*(Status: 2020-04-18: finished agenda, awaiting reviews & merge)*

Exceptions for HNix: https://github.com/haskell-nix/hnix/issues/309 "_Replace every use of ErrorCall with a custom Exception value_".

Completed exception values coverage.

For this PR:
1) Keeping current PR as close to `master` implementation as possible.
2) Doing only what was asked in the request, placing groundwork by providing data constructors for exceptions.
3) Decided to keep constructors in groups by the function that exception occurs in. I weighted-in the code structure and what is needed and decided to use this middle way approach.
4) For constructors, the Exception type instances are to process data constructors and it's data into a printable message. With `throwError $ EFunctionNameExceptionName a b c`
5) This is a beauty that exception types are not represented in the signatures, so their data constructors can be rearranged & renamed at any moment into any structure, allowing further evolving the handling.
6) Because the exceptions are grouped by function (3) - they are occurred in, naming convention naturally occurred, you can guess the name of the type that gathers together exceptions you are interested in with, prefix `E*` is for *exception* (*synchronous*), `EA*` for *exception asynchronous*. So it guesses aka `EA` + `FunctionName` (abiding the *camelCalse* rules).