### PR TITLE
.travis.yml: increase depth to have Travis git caching between jobs&commits

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,9 @@ language: nix
 sudo: required
 
 git:
-  depth: 1
+  depth: 4    # NOTE: "The use of clone depth: 1 often results in a git error
+              # when a new commit has been pushed to a branch before the CI
+              # platform started cloning the intended commit."
 
 env:
   global:


### PR DESCRIPTION
Setting of "1" would be problematic, since it disallows internal Travis git caching and also:

"The use of clone depth: 1 often results in a git error when a new commit has been pushed to a branch before the CI platform started cloning the intended commit."