### PR TITLE
Allow most recent versions of dependencies.

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -8,15 +8,14 @@
 
 , withHoogle  ? true
 
-, rev    ? "ed1b59a98e7bd61dd7eac266569c294fb6b16300"
-, sha256 ? "0b2wdbbaqdqccl7q9gskhfjk7xaqvjwcls4b6218anyc247gscnb"
+, rev    ? "c4adeddb5f8e945517068968d06ea838b7c24bd3"
 
 , pkgs   ?
     if builtins.compareVersions builtins.nixVersion "2.0" < 0
     then abort "hnix requires at least nix 2.0"
-    else import (builtins.fetchTarball {
-           url = "https://github.com/NixOS/nixpkgs/archive/${rev}.tar.gz";
-           inherit sha256; }) {
+    else import (builtins.fetchGit {
+           url = "https://github.com/NixOS/nixpkgs/";
+           inherit rev; }) {
            config.allowUnfree = true;
            config.allowBroken = false;
            config.packageOverrides = pkgs: rec {

--- a/hnix.cabal
+++ b/hnix.cabal
@@ -497,7 +497,7 @@ library
     , contravariant >= 1.5 && < 1.6
     , data-fix >= 0.2.0 && <  0.3
     , deepseq >=1.4.2 && <1.5
-    , dependent-sum >= 0.4 && < 0.5
+    , dependent-sum >= 0.4 && < 0.5 || >= 0.6.2.0 && < 0.7
     , deriving-compat >=0.3 && <0.6
     , directory >= 1.3.1 && < 1.4
     , exceptions >= 0.10.0 && < 0.11
@@ -505,31 +505,33 @@ library
     , free >= 5.1 && < 5.2
     , hashing >= 0.1.0 && < 0.2
     , hnix-store-core >= 0.1.0 && < 0.2
-    , http-client >= 0.5.14 && < 0.6
+    , http-client >= 0.5.14 && < 0.6 || >= 0.6.4 && < 0.7
     , http-client-tls >= 0.3.5 && < 0.4
     , http-types >= 0.12.2 && < 0.13
     , interpolate >= 0.2.0 && < 0.3
     , lens-family-th >= 0.5.0 && < 0.6
-    , logict >= 0.6.0 && < 0.7
+    , logict >= 0.6.0 && < 0.7 || >= 0.7.0.2 && < 0.8
     , megaparsec >=7.0 && <7.1
     , monad-control >= 1.0.2 && < 1.1
     , monadlist >= 0.0.2 && < 0.1
     , mtl >= 2.2.2 && < 2.3
-    , optparse-applicative >= 0.14.3 && < 0.15
-    , parser-combinators >= 1.0.1 && < 1.1
-    , prettyprinter >= 1.2.1 && < 1.3
+    , optparse-applicative >= 0.14.3 && < 0.15 || >= 0.15.0.0 && < 0.16
+    , parser-combinators >= 1.0.1 && < 1.1 || >= 1.2.0 && < 1.3
+    , prettyprinter >= 1.2.1 && < 1.3 || >= 1.3.0 && < 1.4
     , process >= 1.6.3 && < 1.7
     , ref-tf >= 0.4.0 && < 0.5
     , regex-tdfa >= 1.2.3 && < 1.3
     , regex-tdfa-text >= 1.0.0 && < 1.1
     , scientific >= 0.3.6 && < 0.4
-    , semigroups >=0.18 && <0.19
+    , semialign >= 1 && < 1.1
+    , semialign-indexed >= 1 && < 1.1
+    , semigroups >=0.18 && <0.19 || >= 0.19.1 && < 0.20
     , split >= 0.2.3 && < 0.3
     , syb >= 0.7 && < 0.8
     , template-haskell
     , text >= 1.2.3 && < 1.3
-    , these >= 0.7.5 && < 0.8
-    , time >= 1.8.0 && < 1.9
+    , these >= 1.0.1 && < 1.1
+    , time >= 1.8.0 && < 1.9 || >= 1.9.3 && < 1.10
     , transformers >= 0.5.5 && < 0.6
     , transformers-base >= 0.4.5 && < 0.5
     , unix >= 2.7.2 && < 2.8
@@ -562,12 +564,12 @@ library
   --       ghc-datasize
   if impl(ghcjs)
     build-depends:
-        hashable >=1.2.4 && <1.3
+        hashable >=1.2.4 && <1.3 || >= 1.3.0.0 && < 1.4
   else
     exposed-modules:
         Nix.Options.Parser
     build-depends:
-        hashable >=1.2.5 && <1.3
+        hashable >=1.2.5 && <1.3 || >= 1.3.0.0 && < 1.4
       , haskeline >= 0.7.4.2 && < 0.8
       , pretty-show >= 1.9.5 && < 1.10
   default-language: Haskell2010

--- a/src/Nix/Eval.hs
+++ b/src/Nix/Eval.hs
@@ -17,7 +17,7 @@ import           Control.Monad
 import           Control.Monad.Fix
 import           Control.Monad.Reader
 import           Control.Monad.State.Strict
-import           Data.Align.Key                 ( alignWithKey )
+import           Data.Semialign.Indexed         ( ialignWith )
 import           Data.Either                    ( isRight )
 import           Data.Fix                       ( Fix(Fix) )
 import           Data.HashMap.Lazy              ( HashMap )
@@ -385,9 +385,9 @@ buildArgument params arg = do
               Nothing -> id
               Just n  -> M.insert n $ const $ defer (withScopes scope arg)
         loebM
-          (inject $ M.mapMaybe id $ alignWithKey (assemble scope isVariadic)
-                                                 args
-                                                 (M.fromList s)
+          (inject $ M.mapMaybe id $ ialignWith (assemble scope isVariadic)
+                                               args
+                                               (M.fromList s)
           )
  where
   assemble


### PR DESCRIPTION
The only actual breaking change affecting `hnix` is `these` splitting
into three packages and renaming some things. Otherwise, as the
package should work fine with either the newer or older versions, I
have left the previous bounds in place and added the new ones
disjunctively.

This will help somewhat with #494.

--

A release with these bounds bumps would also be handy, since GHC 8.8 support probably isn't getting backported to old versions of libraries. `hnix` won't work out of the box with 8.8 yet, but only due to dependencies, and it's quite likely there'll be nothing else to do once they catch up.