### PR TITLE
Adapt to MonadFail changes in GHC 8.8.

### DIFF
--- a/src/Nix/Eval.hs
+++ b/src/Nix/Eval.hs
@@ -234,7 +234,7 @@ desugarBinds embed binds = evalState (mapM (go <=< collect) binds) M.empty
   go (Left  x) = do
     maybeValue <- gets (M.lookup x)
     case maybeValue of
-      Nothing     -> fail ("No binding " ++ show x)
+      Nothing     -> error ("No binding " ++ show x)
       Just (p, v) -> pure $ NamedVar (StaticKey x :| []) (embed v) p
 
 evalBinds

--- a/src/Nix/Fresh.hs
+++ b/src/Nix/Fresh.hs
@@ -16,6 +16,7 @@ import           Control.Applicative
 import           Control.Monad.Base
 import           Control.Monad.Catch
 import           Control.Monad.Except
+import           Control.Monad.Fail
 import           Control.Monad.Reader
 import           Control.Monad.Ref
 import           Control.Monad.ST
@@ -33,6 +34,7 @@ newtype FreshIdT i m a = FreshIdT { unFreshIdT :: ReaderT (Var m i) m a }
     , Applicative
     , Alternative
     , Monad
+    , MonadFail
     , MonadPlus
     , MonadFix
     , MonadRef

--- a/src/Nix/Fresh/Basic.hs
+++ b/src/Nix/Fresh/Basic.hs
@@ -8,6 +8,7 @@
 
 module Nix.Fresh.Basic where
 
+import           Control.Monad.Fail ( MonadFail )
 import           Control.Monad.Reader
 import           Nix.Effects
 import           Nix.Render
@@ -16,7 +17,7 @@ import           Nix.Value
 
 type StdIdT = FreshIdT Int
 
-instance MonadFile m => MonadFile (StdIdT m)
+instance (MonadFail m, MonadFile m) => MonadFile (StdIdT m)
 instance MonadIntrospect m => MonadIntrospect (StdIdT m)
 instance MonadStore m => MonadStore (StdIdT m) where
   addPath' = lift . addPath'

--- a/src/Nix/Render.hs
+++ b/src/Nix/Render.hs
@@ -12,6 +12,7 @@ module Nix.Render where
 
 import           Prelude                 hiding ( readFile )
 
+import           Control.Monad.Fail             ( MonadFail )
 import           Control.Monad.Trans
 import           Data.ByteString                ( ByteString )
 import qualified Data.ByteString               as BS
@@ -26,7 +27,7 @@ import qualified System.Posix.Files            as S
 import           Text.Megaparsec.Error
 import           Text.Megaparsec.Pos
 
-class Monad m => MonadFile m where
+class MonadFail m => MonadFile m where
     readFile :: FilePath -> m ByteString
     default readFile :: (MonadTrans t, MonadFile m', m ~ t m') => FilePath -> m ByteString
     readFile = lift . readFile

--- a/src/Nix/Standard.hs
+++ b/src/Nix/Standard.hs
@@ -22,6 +22,7 @@ import           Control.Applicative
 import           Control.Comonad                ( Comonad )
 import           Control.Comonad.Env            ( ComonadEnv )
 import           Control.Monad.Catch     hiding ( catchJust )
+import           Control.Monad.Fail             ( MonadFail )
 import           Control.Monad.Free
 import           Control.Monad.Reader
 import           Control.Monad.Ref
@@ -92,7 +93,7 @@ instance (MonadFix1T t m, MonadRef m) => MonadRef (Fix1T t m) where
 instance (MonadFix1T t m, MonadAtomicRef m) => MonadAtomicRef (Fix1T t m) where
   atomicModifyRef r = lift . atomicModifyRef r
 
-instance (MonadFix1T t m, MonadFile m) => MonadFile (Fix1T t m)
+instance (MonadFix1T t m, MonadFail (Fix1T t m), MonadFile m) => MonadFile (Fix1T t m)
 
 instance (MonadFix1T t m, MonadStore m) => MonadStore (Fix1T t m) where
   addPath' = lift . addPath'
@@ -209,6 +210,7 @@ newtype StandardTF r m a
     , Applicative
     , Alternative
     , Monad
+    , MonadFail
     , MonadPlus
     , MonadFix
     , MonadIO

--- a/src/Nix/Utils/Fix1.hs
+++ b/src/Nix/Utils/Fix1.hs
@@ -11,6 +11,7 @@ module Nix.Utils.Fix1 where
 
 import           Control.Applicative
 import           Control.Monad
+import           Control.Monad.Fail
 import           Control.Monad.Fix
 import           Control.Monad.IO.Class
 import           Control.Monad.Catch
@@ -41,6 +42,7 @@ deriving instance Functor (t (Fix1T t m) m) => Functor (Fix1T t m)
 deriving instance Applicative (t (Fix1T t m) m) => Applicative (Fix1T t m)
 deriving instance Alternative (t (Fix1T t m) m) => Alternative (Fix1T t m)
 deriving instance Monad (t (Fix1T t m) m) => Monad (Fix1T t m)
+deriving instance MonadFail (t (Fix1T t m) m) => MonadFail (Fix1T t m)
 deriving instance MonadPlus (t (Fix1T t m) m) => MonadPlus (Fix1T t m)
 deriving instance MonadFix (t (Fix1T t m) m) => MonadFix (Fix1T t m)
 deriving instance MonadIO (t (Fix1T t m) m) => MonadIO (Fix1T t m)


### PR DESCRIPTION
Note that this is an enforced public API change.

I went with changing the `MonadFile` typeclass rather than threading
through a `MonadFail` at every use-site, but that would be possible as
well if it makes more semantic sense - however, since `MonadFile`
already seems to require an IO-ish implementation, adding that
superclass doesn't seem like an imposition.