### PR TITLE
Require base >= 4.11 / GHC >= 8.4

### DIFF
--- a/hnix.cabal
+++ b/hnix.cabal
@@ -544,22 +544,20 @@ library
   if flag(optimize)
     ghc-options: -fexpose-all-unfoldings -fspecialise-aggressively -O2
   if !impl(ghcjs)
+    exposed-modules:
+        Nix.Options.Parser
     build-depends:
         base16-bytestring >= 0.1.1 && < 0.2
       , cryptohash-md5 >= 0.11.100 && < 0.12
       , cryptohash-sha1 >= 0.11.100 && < 0.12
       , cryptohash-sha256 >= 0.11.101 && < 0.12
       , cryptohash-sha512 >= 0.11.100 && < 0.12
+      , haskeline >= 0.7.4.2 && < 0.8
+      , pretty-show >= 1.9.5 && < 1.10
       , serialise >= 0.2.1 && < 0.3
   -- if !flag(profiling)
   --   build-depends:
   --       ghc-datasize
-  if !impl(ghcjs)
-    exposed-modules:
-        Nix.Options.Parser
-    build-depends:
-        haskeline >= 0.7.4.2 && < 0.8
-      , pretty-show >= 1.9.5 && < 1.10
   default-language: Haskell2010
 
 executable hnix
@@ -573,9 +571,14 @@ executable hnix
   build-depends:
       aeson
     , base
+    , base16-bytestring
     , bytestring
     , comonad
     , containers
+    , cryptohash-md5
+    , cryptohash-sha1
+    , cryptohash-sha256
+    , cryptohash-sha512
     , data-fix
     , deepseq
     , exceptions
@@ -590,6 +593,7 @@ executable hnix
     , prettyprinter
     , ref-tf
     , repline
+    , serialise
     , template-haskell
     , text
     , time
@@ -597,18 +601,8 @@ executable hnix
     , unordered-containers
   if flag(optimize)
     ghc-options: -fexpose-all-unfoldings -fspecialise-aggressively -O2
-  if !impl(ghcjs)
-    build-depends:
-        base16-bytestring
-      , cryptohash-md5
-      , cryptohash-sha1
-      , cryptohash-sha256
-      , cryptohash-sha512
-      , serialise
   if impl(ghcjs)
     buildable: False
-  else
-    buildable: True
   default-language: Haskell2010
 
 test-suite hnix-tests
@@ -630,8 +624,13 @@ test-suite hnix-tests
       Diff
     , Glob
     , base >=4.11 && <5
+    , base16-bytestring
     , bytestring
     , containers
+    , cryptohash-md5
+    , cryptohash-sha1
+    , cryptohash-sha256
+    , cryptohash-sha512
     , data-fix
     , deepseq >=1.4.3 && <1.5
     , dependent-sum
@@ -655,6 +654,7 @@ test-suite hnix-tests
     , tasty-hunit
     , tasty-quickcheck
     , tasty-th
+    , serialise
     , template-haskell
     , text
     , time
@@ -663,18 +663,8 @@ test-suite hnix-tests
     , unordered-containers >=0.2.9 && <0.3
   if flag(optimize)
     ghc-options: -fexpose-all-unfoldings -fspecialise-aggressively -O2
-  if !impl(ghcjs)
-    build-depends:
-        base16-bytestring
-      , cryptohash-md5
-      , cryptohash-sha1
-      , cryptohash-sha256
-      , cryptohash-sha512
-      , serialise
   if impl(ghcjs)
     buildable: False
-  else
-    buildable: True
   default-language: Haskell2010
 
 benchmark hnix-benchmarks
@@ -688,9 +678,14 @@ benchmark hnix-benchmarks
   ghc-options: -Wall
   build-depends:
       base >=4.11 && <5
+    , base16-bytestring
     , bytestring
     , containers
     , criterion
+    , cryptohash-md5
+    , cryptohash-sha1
+    , cryptohash-sha256
+    , cryptohash-sha512
     , data-fix
     , deepseq >=1.4.3 && <1.5
     , exceptions
@@ -699,6 +694,7 @@ benchmark hnix-benchmarks
     , hnix
     , mtl
     , optparse-applicative
+    , serialise
     , template-haskell
     , text
     , time
@@ -706,16 +702,6 @@ benchmark hnix-benchmarks
     , unordered-containers >=0.2.9 && <0.3
   if flag(optimize)
     ghc-options: -fexpose-all-unfoldings -fspecialise-aggressively -O2
-  if !impl(ghcjs)
-    build-depends:
-        base16-bytestring
-      , cryptohash-md5
-      , cryptohash-sha1
-      , cryptohash-sha256
-      , cryptohash-sha512
-      , serialise
   if impl(ghcjs)
     buildable: False
-  else
-    buildable: True
   default-language: Haskell2010

--- a/hnix.cabal
+++ b/hnix.cabal
@@ -489,7 +489,7 @@ library
   build-depends:
       aeson >= 1.4.2 && < 1.5
     , array >=0.4 && <0.6
-    , base >=4.9 && <5
+    , base >=4.11 && <5
     , binary >= 0.8.5 && < 0.9
     , bytestring >= 0.10.8 && < 0.11
     , comonad >= 5.0.4 && < 5.1
@@ -644,7 +644,7 @@ test-suite hnix-tests
   build-depends:
       Diff
     , Glob
-    , base >=4.9 && <5
+    , base >=4.11 && <5
     , bytestring
     , containers
     , data-fix
@@ -705,7 +705,7 @@ benchmark hnix-benchmarks
       benchmarks
   ghc-options: -Wall
   build-depends:
-      base >=4.9 && <5
+      base >=4.11 && <5
     , bytestring
     , containers
     , criterion

--- a/hnix.cabal
+++ b/hnix.cabal
@@ -509,6 +509,8 @@ library
     , http-client-tls >= 0.3.5 && < 0.4
     , http-types >= 0.12.2 && < 0.13
     , interpolate >= 0.2.0 && < 0.3
+    , lens-family >=1.2.2
+    , lens-family-core >=1.2.2
     , lens-family-th >= 0.5.0 && < 0.6
     , logict >= 0.6.0 && < 0.7 || >= 0.7.0.2 && < 0.8
     , megaparsec >=7.0 && <7.1
@@ -540,9 +542,6 @@ library
     , xml >= 1.3.14 && < 1.4
   if flag(optimize)
     ghc-options: -fexpose-all-unfoldings -fspecialise-aggressively -O2
-  if os(linux) && impl(ghc >= 8.2) && impl(ghc < 8.3)
-    build-depends:
-        compact
   if !impl(ghcjs)
     build-depends:
         base16-bytestring >= 0.1.1 && < 0.2
@@ -551,15 +550,7 @@ library
       , cryptohash-sha256 >= 0.11.101 && < 0.12
       , cryptohash-sha512 >= 0.11.100 && < 0.12
       , serialise >= 0.2.1 && < 0.3
-  if impl(ghc < 8.1)
-    build-depends:
-        lens-family ==1.2.1
-      , lens-family-core ==1.2.1
-  else
-    build-depends:
-        lens-family >=1.2.2
-      , lens-family-core >=1.2.2
-  -- if impl(ghc < 8.4.0) && !flag(profiling)
+  -- if !flag(profiling)
   --   build-depends:
   --       ghc-datasize
   if impl(ghcjs)
@@ -609,9 +600,6 @@ executable hnix
     , unordered-containers
   if flag(optimize)
     ghc-options: -fexpose-all-unfoldings -fspecialise-aggressively -O2
-  if os(linux) && impl(ghc >= 8.2) && impl(ghc < 8.3)
-    build-depends:
-        compact
   if !impl(ghcjs)
     build-depends:
         base16-bytestring
@@ -678,9 +666,6 @@ test-suite hnix-tests
     , unordered-containers >=0.2.9 && <0.3
   if flag(optimize)
     ghc-options: -fexpose-all-unfoldings -fspecialise-aggressively -O2
-  if os(linux) && impl(ghc >= 8.2) && impl(ghc < 8.3)
-    build-depends:
-        compact
   if !impl(ghcjs)
     build-depends:
         base16-bytestring
@@ -724,9 +709,6 @@ benchmark hnix-benchmarks
     , unordered-containers >=0.2.9 && <0.3
   if flag(optimize)
     ghc-options: -fexpose-all-unfoldings -fspecialise-aggressively -O2
-  if os(linux) && impl(ghc >= 8.2) && impl(ghc < 8.3)
-    build-depends:
-        compact
   if !impl(ghcjs)
     build-depends:
         base16-bytestring

--- a/hnix.cabal
+++ b/hnix.cabal
@@ -496,7 +496,7 @@ library
     , containers >= 0.5.11.0 && < 0.7
     , contravariant >= 1.5 && < 1.6
     , data-fix >= 0.2.0 && <  0.3
-    , deepseq >=1.4.2 && <1.5
+    , deepseq >=1.4.3 && <1.5
     , dependent-sum >= 0.4 && < 0.5 || >= 0.6.2.0 && < 0.7
     , deriving-compat >=0.3 && <0.6
     , directory >= 1.3.1 && < 1.4
@@ -633,7 +633,7 @@ test-suite hnix-tests
     , bytestring
     , containers
     , data-fix
-    , deepseq >=1.4.2 && <1.5
+    , deepseq >=1.4.3 && <1.5
     , dependent-sum
     , directory
     , exceptions
@@ -692,7 +692,7 @@ benchmark hnix-benchmarks
     , containers
     , criterion
     , data-fix
-    , deepseq >=1.4.2 && <1.5
+    , deepseq >=1.4.3 && <1.5
     , exceptions
     , filepath
     , hashing

--- a/hnix.cabal
+++ b/hnix.cabal
@@ -503,6 +503,7 @@ library
     , exceptions >= 0.10.0 && < 0.11
     , filepath >= 1.4.2 && < 1.5
     , free >= 5.1 && < 5.2
+    , hashable >=1.2.5 && < 1.4
     , hashing >= 0.1.0 && < 0.2
     , hnix-store-core >= 0.1.0 && < 0.2
     , http-client >= 0.5.14 && < 0.6 || >= 0.6.4 && < 0.7
@@ -553,15 +554,11 @@ library
   -- if !flag(profiling)
   --   build-depends:
   --       ghc-datasize
-  if impl(ghcjs)
-    build-depends:
-        hashable >=1.2.4 && <1.3 || >= 1.3.0.0 && < 1.4
-  else
+  if !impl(ghcjs)
     exposed-modules:
         Nix.Options.Parser
     build-depends:
-        hashable >=1.2.5 && <1.3 || >= 1.3.0.0 && < 1.4
-      , haskeline >= 0.7.4.2 && < 0.8
+        haskeline >= 0.7.4.2 && < 0.8
       , pretty-show >= 1.9.5 && < 1.10
   default-language: Haskell2010
 

--- a/src/Nix/Cache.hs
+++ b/src/Nix/Cache.hs
@@ -5,7 +5,7 @@ module Nix.Cache where
 import qualified Data.ByteString.Lazy          as BS
 import           Nix.Expr.Types.Annotated
 
-#if defined (__linux__) && MIN_VERSION_base(4, 10, 0)
+#if defined (__linux__)
 #define USE_COMPACT 1
 #endif
 

--- a/src/Nix/Effects.hs
+++ b/src/Nix/Effects.hs
@@ -68,7 +68,7 @@ class Monad m => MonadIntrospect m where
 instance MonadIntrospect IO where
   recursiveSize =
 #ifdef MIN_VERSION_ghc_datasize
-#if MIN_VERSION_ghc_datasize(0,2,0) && __GLASGOW_HASKELL__ >= 804
+#if MIN_VERSION_ghc_datasize(0,2,0)
 recursiveSize
 #else
 \_ -> return 0

--- a/src/Nix/Effects/Basic.hs
+++ b/src/Nix/Effects/Basic.hs
@@ -47,7 +47,7 @@ import           Nix.Value.Monad
 import           System.FilePath
 
 #ifdef MIN_VERSION_ghc_datasize
-#if MIN_VERSION_ghc_datasize(0,2,0) && __GLASGOW_HASKELL__ >= 804
+#if MIN_VERSION_ghc_datasize(0,2,0)
 import           GHC.DataSize
 #endif
 #endif

--- a/src/Nix/Exec.hs
+++ b/src/Nix/Exec.hs
@@ -65,7 +65,7 @@ import qualified Text.Show.Pretty as PS
 #endif
 
 #ifdef MIN_VERSION_ghc_datasize
-#if MIN_VERSION_ghc_datasize(0,2,0) && __GLASGOW_HASKELL__ >= 804
+#if MIN_VERSION_ghc_datasize(0,2,0)
 import           GHC.DataSize
 #endif
 #endif

--- a/src/Nix/Expr/Types.hs
+++ b/src/Nix/Expr/Types.hs
@@ -77,12 +77,6 @@ hashAt = flip alterF
 -- unfortunate orphans
 instance Hashable1 NonEmpty
 
-#if !MIN_VERSION_binary(0, 8, 4)
-instance Binary a => Binary (NE.NonEmpty a) where
-  get = fmap NE.fromList Bin.get
-  put = Bin.put . NE.toList
-#endif
-
 -- | The main nix expression type. This is polymorphic so that it can be made
 -- a functor, which allows us to traverse expressions and map functions over
 -- them. The actual 'NExpr' type is a fixed point of this functor, defined

--- a/src/Nix/Expr/Types.hs
+++ b/src/Nix/Expr/Types.hs
@@ -43,9 +43,7 @@ import           Data.Eq.Deriving
 import           Data.Fix
 import           Data.Functor.Classes
 import           Data.Hashable
-#if MIN_VERSION_hashable(1, 2, 5)
 import           Data.Hashable.Lifted
-#endif
 import           Data.List                      ( inits
                                                 , tails
                                                 )
@@ -77,9 +75,7 @@ hashAt :: VarName -> Lens' (AttrSet v) (Maybe v)
 hashAt = flip alterF
 
 -- unfortunate orphans
-#if MIN_VERSION_hashable(1, 2, 5)
 instance Hashable1 NonEmpty
-#endif
 
 #if !MIN_VERSION_binary(0, 8, 4)
 instance Binary a => Binary (NE.NonEmpty a) where
@@ -135,9 +131,7 @@ data NExprF r
   deriving (Ord, Eq, Generic, Generic1, Typeable, Data, Functor,
             Foldable, Traversable, Show, NFData, Hashable)
 
-#if MIN_VERSION_hashable(1, 2, 5)
 instance Hashable1 NExprF
-#endif
 
 #if MIN_VERSION_deepseq(1, 4, 3)
 instance NFData1 NExprF
@@ -178,9 +172,7 @@ data Binding r
   deriving (Generic, Generic1, Typeable, Data, Ord, Eq, Functor,
             Foldable, Traversable, Show, NFData, Hashable)
 
-#if MIN_VERSION_hashable(1, 2, 5)
 instance Hashable1 Binding
-#endif
 
 #if MIN_VERSION_deepseq(1, 4, 3)
 instance NFData1 Binding
@@ -202,9 +194,7 @@ data Params r
   deriving (Ord, Eq, Generic, Generic1, Typeable, Data, Functor, Show,
             Foldable, Traversable, NFData, Hashable)
 
-#if MIN_VERSION_hashable(1, 2, 5)
 instance Hashable1 Params
-#endif
 
 #if MIN_VERSION_deepseq(1, 4, 3)
 instance NFData1 Params
@@ -227,7 +217,6 @@ data Antiquoted (v :: *) (r :: *) = Plain !v | EscapedNewline | Antiquoted !r
   deriving (Ord, Eq, Generic, Generic1, Typeable, Data, Functor, Foldable,
             Traversable, Show, Read, NFData, Hashable)
 
-#if MIN_VERSION_hashable(1, 2, 5)
 instance Hashable v => Hashable1 (Antiquoted v)
 
 instance Hashable2 Antiquoted where
@@ -235,7 +224,6 @@ instance Hashable2 Antiquoted where
   liftHashWithSalt2 _ _ salt EscapedNewline = salt `hashWithSalt` (1 :: Int)
   liftHashWithSalt2 _ hb salt (Antiquoted b) =
     hb (salt `hashWithSalt` (2 :: Int)) b
-#endif
 
 #if MIN_VERSION_deepseq(1, 4, 3)
 instance NFData v => NFData1 (Antiquoted v)
@@ -259,9 +247,7 @@ data NString r
   deriving (Eq, Ord, Generic, Generic1, Typeable, Data, Functor, Foldable,
             Traversable, Show, Read, NFData, Hashable)
 
-#if MIN_VERSION_hashable(1, 2, 5)
 instance Hashable1 NString
-#endif
 
 #if MIN_VERSION_deepseq(1, 4, 3)
 instance NFData1 NString
@@ -341,13 +327,11 @@ instance Eq1 NKeyName where
   liftEq _  (StaticKey  a) (StaticKey  b) = a == b
   liftEq _  _              _              = False
 
-#if MIN_VERSION_hashable(1, 2, 5)
 instance Hashable1 NKeyName where
   liftHashWithSalt h salt (DynamicKey a) =
     liftHashWithSalt2 (liftHashWithSalt h) h (salt `hashWithSalt` (0 :: Int)) a
   liftHashWithSalt _ salt (StaticKey n) =
     salt `hashWithSalt` (1 :: Int) `hashWithSalt` n
-#endif
 
 -- Deriving this instance automatically is not possible because @r@
 -- occurs not only as last argument in @Antiquoted (NString r) r@

--- a/src/Nix/Expr/Types.hs
+++ b/src/Nix/Expr/Types.hs
@@ -68,10 +68,8 @@ import           Nix.Utils
 import           Text.Megaparsec.Pos
 import           Text.Read.Deriving
 import           Text.Show.Deriving
-#if MIN_VERSION_base(4, 10, 0)
 import           Type.Reflection                ( eqTypeRep )
 import qualified Type.Reflection               as Reflection
-#endif
 
 type VarName = Text
 
@@ -81,14 +79,6 @@ hashAt = flip alterF
 -- unfortunate orphans
 #if MIN_VERSION_hashable(1, 2, 5)
 instance Hashable1 NonEmpty
-#endif
-
-#if !MIN_VERSION_base(4, 10, 0)
-instance Eq1 NonEmpty where
-  liftEq eq (a NE.:| as) (b NE.:| bs) = eq a b && liftEq eq as bs
-instance Show1 NonEmpty where
-  liftShowsPrec shwP shwL p (a NE.:| as) = showParen (p > 5) $
-    shwP 6 a . showString " :| " . shwL as
 #endif
 
 #if !MIN_VERSION_binary(0, 8, 4)
@@ -162,18 +152,11 @@ instance Serialise r => Serialise (NExprF r)
 instance IsString NExpr where
   fromString = Fix . NSym . fromString
 
-#if MIN_VERSION_base(4, 10, 0)
 instance Lift (Fix NExprF) where
   lift = dataToExpQ $ \b ->
     case Reflection.typeOf b `eqTypeRep` Reflection.typeRep @Text of
       Just HRefl -> Just [| pack $(liftString $ unpack b) |]
       Nothing    -> Nothing
-#else
-instance Lift (Fix NExprF) where
-    lift = dataToExpQ $ \b -> case cast b of
-        Just t -> Just [| pack $(liftString $ unpack t) |]
-        Nothing -> Nothing
-#endif
 
 -- | The monomorphic expression type is a fixed point of the polymorphic one.
 type NExpr = Fix NExprF

--- a/src/Nix/Expr/Types.hs
+++ b/src/Nix/Expr/Types.hs
@@ -127,9 +127,7 @@ data NExprF r
 
 instance Hashable1 NExprF
 
-#if MIN_VERSION_deepseq(1, 4, 3)
 instance NFData1 NExprF
-#endif
 
 #ifdef MIN_VERSION_serialise
 instance Serialise r => Serialise (NExprF r)
@@ -168,9 +166,7 @@ data Binding r
 
 instance Hashable1 Binding
 
-#if MIN_VERSION_deepseq(1, 4, 3)
 instance NFData1 Binding
-#endif
 
 #ifdef MIN_VERSION_serialise
 instance Serialise r => Serialise (Binding r)
@@ -190,9 +186,7 @@ data Params r
 
 instance Hashable1 Params
 
-#if MIN_VERSION_deepseq(1, 4, 3)
 instance NFData1 Params
-#endif
 
 #ifdef MIN_VERSION_serialise
 instance Serialise r => Serialise (Params r)
@@ -219,9 +213,7 @@ instance Hashable2 Antiquoted where
   liftHashWithSalt2 _ hb salt (Antiquoted b) =
     hb (salt `hashWithSalt` (2 :: Int)) b
 
-#if MIN_VERSION_deepseq(1, 4, 3)
 instance NFData v => NFData1 (Antiquoted v)
-#endif
 
 #ifdef MIN_VERSION_serialise
 instance (Serialise v, Serialise r) => Serialise (Antiquoted v r)
@@ -243,9 +235,7 @@ data NString r
 
 instance Hashable1 NString
 
-#if MIN_VERSION_deepseq(1, 4, 3)
 instance NFData1 NString
-#endif
 
 #ifdef MIN_VERSION_serialise
 instance Serialise r => Serialise (NString r)
@@ -304,13 +294,11 @@ instance Generic1 NKeyName where
   from1 = id
   to1   = id
 
-#if MIN_VERSION_deepseq(1, 4, 3)
 instance NFData1 NKeyName where
   liftRnf _ (StaticKey  !_            ) = ()
   liftRnf _ (DynamicKey (Plain !_)    ) = ()
   liftRnf _ (DynamicKey EscapedNewline) = ()
   liftRnf k (DynamicKey (Antiquoted r)) = k r
-#endif
 
 -- | Most key names are just static text, so this instance is convenient.
 instance IsString (NKeyName r) where
@@ -409,10 +397,6 @@ instance Serialise NRecordType
 paramName :: Params r -> Maybe VarName
 paramName (Param n       ) = Just n
 paramName (ParamSet _ _ n) = n
-
-#if !MIN_VERSION_deepseq(1, 4, 3)
-instance NFData NExpr
-#endif
 
 $(deriveEq1 ''NExprF)
 $(deriveEq1 ''NString)

--- a/src/Nix/Expr/Types/Annotated.hs
+++ b/src/Nix/Expr/Types/Annotated.hs
@@ -39,9 +39,7 @@ import           Data.Fix
 import           Data.Function                  ( on )
 import           Data.Functor.Compose
 import           Data.Hashable
-#if MIN_VERSION_hashable(1, 2, 5)
 import           Data.Hashable.Lifted
-#endif
 import           Data.Ord.Deriving
 import           Data.Text                      ( Text
                                                 , pack
@@ -78,9 +76,7 @@ data Ann ann a = Ann
     deriving (Ord, Eq, Data, Generic, Generic1, Typeable, Functor, Foldable,
               Traversable, Read, Show, NFData, Hashable)
 
-#if MIN_VERSION_hashable(1, 2, 5)
 instance Hashable ann => Hashable1 (Ann ann)
-#endif
 
 #ifdef MIN_VERSION_serialise
 instance (Serialise ann, Serialise a) => Serialise (Ann ann a)
@@ -124,9 +120,7 @@ instance NFData NExprLoc
 instance Serialise NExprLoc
 #endif
 
-#if MIN_VERSION_hashable(1, 2, 5)
 instance Hashable NExprLoc
-#endif
 
 instance Binary SrcSpan
 instance (Binary ann, Binary a) => Binary (Ann ann a)

--- a/src/Nix/Expr/Types/Annotated.hs
+++ b/src/Nix/Expr/Types/Annotated.hs
@@ -82,9 +82,7 @@ instance Hashable ann => Hashable1 (Ann ann)
 instance (Serialise ann, Serialise a) => Serialise (Ann ann a)
 #endif
 
-#if MIN_VERSION_deepseq(1, 4, 3)
 instance NFData ann => NFData1 (Ann ann)
-#endif
 
 $(deriveEq1   ''Ann)
 $(deriveEq2   ''Ann)
@@ -109,10 +107,6 @@ type NExprLocF = AnnF SrcSpan NExprF
 
 -- | A nix expression with source location at each subexpression.
 type NExprLoc = Fix NExprLocF
-
-#if !MIN_VERSION_deepseq(1, 4, 3)
-instance (NFData (f (g a)), NFData (g a)) => NFData (Compose f g a)
-#endif
 
 instance NFData NExprLoc
 

--- a/src/Nix/String/Coerce.hs
+++ b/src/Nix/String/Coerce.hs
@@ -17,7 +17,7 @@ import           Nix.Value
 import           Nix.Value.Monad
 
 #ifdef MIN_VERSION_ghc_datasize
-#if MIN_VERSION_ghc_datasize(0,2,0) && __GLASGOW_HASKELL__ >= 804
+#if MIN_VERSION_ghc_datasize(0,2,0)
 import           GHC.DataSize
 #endif
 #endif


### PR DESCRIPTION
Previously there were a lot of build failures related to (<>) and Semigroup not being in scope.

The version restriction allowed me to remove a lot of compatibility logic.

I've tested this locally with GHC-8.4.4 and GHC-8.6.5.