### PR TITLE
Allow parser-combinators-1.1.*

### DIFF
--- a/hnix.cabal
+++ b/hnix.cabal
@@ -516,7 +516,7 @@ library
     , monadlist >= 0.0.2 && < 0.1
     , mtl >= 2.2.2 && < 2.3
     , optparse-applicative >= 0.14.3 && < 0.15 || >= 0.15.0.0 && < 0.16
-    , parser-combinators >= 1.0.1 && < 1.1 || >= 1.2.0 && < 1.3
+    , parser-combinators >= 1.0.1 && < 1.3
     , prettyprinter >= 1.2.1 && < 1.5
     , process >= 1.6.3 && < 1.7
     , ref-tf >= 0.4.0 && < 0.5


### PR DESCRIPTION
This fixes `nix-build`, which currently contains `parser-combinators-1.1.0`.

`nix-build` would previously fail with

```
Configuring hnix-0.6.1...
CallStack (from HasCallStack):
  die', called at libraries/Cabal/Cabal/Distribution/Simple/Configure.hs:950:20 in Cabal-2.4.0.1:Distribution.Simple.Configure
  configureFinalizedPackage, called at libraries/Cabal/Cabal/Distribution/Simple/Configure.hs:460:12 in Cabal-2.4.0.1:Distribution.Simple.Configure
  configure, called at libraries/Cabal/Cabal/Distribution/Simple.hs:596:20 in Cabal-2.4.0.1:Distribution.Simple
  confHook, called at libraries/Cabal/Cabal/Distribution/Simple/UserHooks.hs:67:5 in Cabal-2.4.0.1:Distribution.Simple.UserHooks
  configureAction, called at libraries/Cabal/Cabal/Distribution/Simple.hs:178:19 in Cabal-2.4.0.1:Distribution.Simple
  defaultMainHelper, called at libraries/Cabal/Cabal/Distribution/Simple.hs:115:27 in Cabal-2.4.0.1:Distribution.Simple
  defaultMain, called at Setup.hs:2:8 in main:Main
Setup: Encountered missing dependencies:
parser-combinators >=1.0.1 && <1.1 || >=1.2.0 && <1.3
```