### PR TITLE
Fix compound attributes in let bindings

### DIFF
--- a/src/Nix/Eval.hs
+++ b/src/Nix/Eval.hs
@@ -207,8 +207,8 @@ attrSetAlter (k : ks) pos m p val = case M.lookup k m of
     ( M.insert
       k
       (toValue @(AttrSet v, AttrSet SourcePos) =<< (, mempty) <$> sequence st')
-      st
-    , M.insert k pos sp
+      m
+    , M.insert k pos p
     )
 
 desugarBinds :: forall r . ([Binding r] -> r) -> [Binding r] -> [Binding r]

--- a/tests/EvalTests.hs
+++ b/tests/EvalTests.hs
@@ -139,6 +139,12 @@ case_find_file_failure_invalid_arg_no_path =
 case_infinite_recursion =
     assertNixEvalThrows "let foo = a: bar a; bar = a: foo a; in foo 3"
 
+case_nested_let =
+    constantEqualText "3" "let a = 3; x.x = 2; in a"
+
+case_nested_nested_let =
+    constantEqualText "3" "let a = 3; x.x = let b = a; in b; c = x.x; in c"
+
 case_inherit_in_rec_set =
     constantEqualText "1" "let x = 1; in (rec { inherit x; }).x"
 


### PR DESCRIPTION
Fix an issue where compound attributes would discard previous bindings
in a let statement.

`let a=1; b.b=2; c=3; in a` would fail, where
`let a=1; b.b=2; c=3; in c` would work as expected.

The fix is trivial, but we could have a discussion about using `M.insertWith (flip const) k pos p` instead of `M.insert k pos p` to keep the first position where the subset was encountered instead of the last one. There is probably no reason whatsoever to access such a sub-attrset, so the discussion is probably not worth it.

Example:

```
let
  x.a = 1;
  x.b = 2;
in ...
```

Should we consider that x was declared in line 2 or three ? To me, it would make even more sense to say that it was declared nowhere, and use noPos.
