### PR TITLE
Add proper default 'nix' prefix to search paths

### DIFF
--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -97,7 +97,7 @@ import           Nix.Value
 import           Nix.Value.Equal
 import           Nix.Value.Monad
 import           Nix.XML
-import           System.Nix.Base32             as Base32
+import           System.Nix.Base32              as Base32
 import           System.FilePath
 import           System.Posix.Files             ( isRegularFile
                                                 , isDirectory

--- a/src/Nix/Effects.hs
+++ b/src/Nix/Effects.hs
@@ -28,6 +28,7 @@ import           Nix.Parser
 import           Nix.Render
 import           Nix.Utils
 import           Nix.Value
+import qualified Paths_hnix
 import qualified System.Directory              as S
 import           System.Environment
 import           System.Exit
@@ -42,6 +43,7 @@ class (MonadFile m,
        MonadPutStr m,
        MonadHttp m,
        MonadEnv m,
+       MonadPaths m,
        MonadInstantiate m,
        MonadExec m,
        MonadIntrospect m) => MonadEffects t f m where
@@ -165,6 +167,14 @@ instance MonadEnv IO where
   getCurrentSystemArch = return $ T.pack $ case System.Info.arch of
     "i386" -> "i686"
     arch   -> arch
+
+class Monad m => MonadPaths m where
+    getDataDir :: m FilePath
+    default getDataDir :: (MonadTrans t, MonadPaths m', m ~ t m') => m FilePath
+    getDataDir = lift getDataDir
+
+instance MonadPaths IO where
+    getDataDir = Paths_hnix.getDataDir
 
 class Monad m => MonadHttp m where
     getURL :: Text -> m (Either ErrorCall StorePath)

--- a/src/Nix/Fresh/Basic.hs
+++ b/src/Nix/Fresh/Basic.hs
@@ -24,6 +24,7 @@ instance MonadStore m => MonadStore (StdIdT m) where
 instance MonadPutStr m => MonadPutStr (StdIdT m)
 instance MonadHttp m => MonadHttp (StdIdT m)
 instance MonadEnv m => MonadEnv (StdIdT m)
+instance MonadPaths m => MonadPaths (StdIdT m)
 instance MonadInstantiate m => MonadInstantiate (StdIdT m)
 instance MonadExec m => MonadExec (StdIdT m)
 

--- a/src/Nix/Standard.hs
+++ b/src/Nix/Standard.hs
@@ -55,6 +55,7 @@ import           System.Console.Haskeline.MonadException hiding(catch)
 deriving instance MonadPutStr (t (Fix1 t)) => MonadPutStr (Fix1 t)
 deriving instance MonadHttp (t (Fix1 t)) => MonadHttp (Fix1 t)
 deriving instance MonadEnv (t (Fix1 t)) => MonadEnv (Fix1 t)
+deriving instance MonadPaths (t (Fix1 t)) => MonadPaths (Fix1 t)
 deriving instance MonadInstantiate (t (Fix1 t)) => MonadInstantiate (Fix1 t)
 deriving instance MonadExec (t (Fix1 t)) => MonadExec (Fix1 t)
 deriving instance MonadIntrospect (t (Fix1 t)) => MonadIntrospect (Fix1 t)
@@ -62,6 +63,7 @@ deriving instance MonadIntrospect (t (Fix1 t)) => MonadIntrospect (Fix1 t)
 deriving instance MonadPutStr (t (Fix1T t m) m) => MonadPutStr (Fix1T t m)
 deriving instance MonadHttp (t (Fix1T t m) m) => MonadHttp (Fix1T t m)
 deriving instance MonadEnv (t (Fix1T t m) m) => MonadEnv (Fix1T t m)
+deriving instance MonadPaths (t (Fix1T t m) m) => MonadPaths (Fix1T t m)
 deriving instance MonadInstantiate (t (Fix1T t m) m) => MonadInstantiate (Fix1T t m)
 deriving instance MonadExec (t (Fix1T t m) m) => MonadExec (Fix1T t m)
 deriving instance MonadIntrospect (t (Fix1T t m) m) => MonadIntrospect (Fix1T t m)
@@ -139,6 +141,7 @@ instance ( MonadFix m
          , MonadFile m
          , MonadCatch m
          , MonadEnv m
+         , MonadPaths m
          , MonadExec m
          , MonadHttp m
          , MonadInstantiate m
@@ -224,6 +227,7 @@ instance MonadTrans (StandardTF r) where
 instance (MonadPutStr r, MonadPutStr m) => MonadPutStr (StandardTF r m)
 instance (MonadHttp r, MonadHttp m) => MonadHttp (StandardTF r m)
 instance (MonadEnv r, MonadEnv m) => MonadEnv (StandardTF r m)
+instance (MonadPaths r, MonadPaths m) => MonadPaths (StandardTF r m)
 instance (MonadInstantiate r, MonadInstantiate m) => MonadInstantiate (StandardTF r m)
 instance (MonadExec r, MonadExec m) => MonadExec (StandardTF r m)
 instance (MonadIntrospect r, MonadIntrospect m) => MonadIntrospect (StandardTF r m)

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -96,6 +96,7 @@ main = do
 
   pwd <- getCurrentDirectory
   setEnv "NIX_REMOTE" ("local?root=" ++ pwd ++ "/")
+  setEnv "NIX_DATA_DIR" (pwd ++ "/data")
 
   defaultMain $ testGroup "hnix" $
     [ ParserTests.tests

--- a/tests/NixLanguageTests.hs
+++ b/tests/NixLanguageTests.hs
@@ -147,7 +147,7 @@ assertEval _opts files = do
     [".exp.disabled"]  -> return ()
     [".exp-disabled"]  -> return ()
     [".exp", ".flags"] -> do
-      liftIO $ unsetEnv "NIX_PATH"
+      liftIO $ setEnv "NIX_PATH" "lang/dir4:lang/dir5"
       flags <- Text.readFile (name ++ ".flags")
       let flags' | Text.last flags == '\n' = Text.init flags
                  | otherwise               = flags
@@ -163,16 +163,7 @@ assertEval _opts files = do
               ++ name
               ++ ".flags: "
               ++ show err
-          Opts.Success opts' -> assertLangOk
-            (opts'
-              { include = include opts'
-                            ++ [ "nix=../../../../data/nix/corepkgs"
-                               , "lang/dir4"
-                               , "lang/dir5"
-                               ]
-              }
-            )
-            name
+          Opts.Success opts' -> assertLangOk opts' name
           Opts.CompletionInvoked _ -> error "unused"
     _ -> assertFailure $ "Unknown test type " ++ show files
  where


### PR DESCRIPTION
The search path of Nix contains by default the "nix" prefix that points
to $datadir/nix/corepkgs, where $datadir defaults to $prefix/lib at
installation time, but can be overriden by NIX_DATA_DIR.

We implemented it using `Paths.hnix.getDataDir` and `NIX_DATA_DIR` to
follow Nix behaviour as closely as possible.

A small discrepancy is that we do the lookup on each invocation, where
Nix caches the searchPath at context creation.

/edit Oh, and it fixes #419.