### PR TITLE
Allow prettyprinter 1.6

### DIFF
--- a/hnix.cabal
+++ b/hnix.cabal
@@ -520,7 +520,7 @@ library
     , mtl >= 2.2.2 && < 2.3
     , optparse-applicative >= 0.14.3 && < 0.15 || >= 0.15.0.0 && < 0.16
     , parser-combinators >= 1.0.1 && < 1.3
-    , prettyprinter >= 1.2.1 && < 1.6
+    , prettyprinter >= 1.2.1 && < 1.7
     , process >= 1.6.3 && < 1.7
     , ref-tf >= 0.4.0 && < 0.5
     , regex-tdfa >= 1.2.3 && < 1.4


### PR DESCRIPTION
Here's the changelog FYI: http://hackage.haskell.org/package/prettyprinter-1.6.0/changelog