### PR TITLE
Allow pretty-show 1.11

### DIFF
--- a/hnix.cabal
+++ b/hnix.cabal
@@ -915,7 +915,7 @@ library
       , cryptohash-sha256 >= 0.11.101 && < 0.12
       , cryptohash-sha512 >= 0.11.100 && < 0.12
       , haskeline >= 0.7.4.2 && < 0.8
-      , pretty-show >= 1.9.5 && < 1.10
+      , pretty-show >= 1.9.5 && < 1.11
       , serialise >= 0.2.1 && < 0.3
   -- if !flag(profiling)
   --   build-depends:


### PR DESCRIPTION
Resolves: #541.


<details><summary>Full report</summary>

---
<p>

  1. [The previous release of the package](https://hackage.haskell.org/package/pretty-show-1.9.5) (v 1.9.5,  date `Dec 27 16:54:42 UTC 2018`, [tree](https://github.com/yav/pretty-show/tree/1b484f4b16974a40d80ca43e586337bc90f5d269)).
  2. [Curren release](https://hackage.haskell.org/package/pretty-show-1.10) (v1.10, date `Thu Jan 30 19:08:20 UTC 2020`, [tree](https://github.com/yav/pretty-show/tree/0ff7959238d17547f3d9813be854730e863f01cb)).

  3. Full diff is: https://github.com/yav/pretty-show/compare/1b484f4b16974a40d80ca43e586337bc90f5d269..0ff7959238d17547f3d9813be854730e863f01cb

:heavy_check_mark: Source diff proves [changelog](https://hackage.haskell.org/package/pretty-show-1.10/changelog) statement true:
```text
Changes in 1.10
  * Add support for quasi-quotes, as the preferred way of dealing
    with non-properly showable things.
```

So, an extension in the functionality of the API for printing to humans.

:heavy_check_mark: Tests.

---
</details>