### PR TITLE
README: code blocks: upd cabal keys to v2-*; unification of markup

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ for interacting with store paths, until `hnix-store` is ready.
 
 ## Getting Started
 
-```bash
+```
 $ git clone --recursive https://github.com/haskell-nix/hnix.git
 ...
 $ cd hnix
@@ -81,8 +81,10 @@ application.
 If you're on macOS, you can use the binary cache at Cachix to avoid building
 the specific dependencies used by hnix. Just use these commands:
 
-    nix-env -iA cachix -f https://github.com/NixOS/nixpkgs/tarball/db557aab7b690f5e0e3348459f2e4dc8fd0d9298
-    cachix use hnix
+```
+$ nix-env -iA cachix -f https://github.com/NixOS/nixpkgs/tarball/db557aab7b690f5e0e3348459f2e4dc8fd0d9298
+$ cachix use hnix
+```
 
 ## How you can help
 
@@ -96,9 +98,10 @@ same. You can talk with everyone live on
 [Gitter](https://gitter.im/haskell-nix/Lobby).
 
 When you're ready to submit a pull request, test it with:
+
 ```
-git submodule update --init --recursive
-nix-shell --run "LANGUAGE_TESTS=yes cabal v2-test"
+$ git submodule update --init --recursive
+$ nix-shell --run "LANGUAGE_TESTS=yes cabal v2-test"
 ```
 
 Make sure that all the tests that were passing prior to your PR are still
@@ -111,5 +114,5 @@ run this yourself, first build hnix with `nix-build`, then run the following
 command:
 
 ```
-./result/bin/hnix --eval -E "import <nixpkgs> {}" --find
+$ ./result/bin/hnix --eval -E "import <nixpkgs> {}" --find
 ```

--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ use:
 
 ```
 $ nix-shell
-$ cabal configure --enable-tests --enable-profiling --flags=profiling --flags=tracing
-$ cabal build
+$ cabal v2-configure --enable-tests --enable-profiling --flags=profiling --flags=tracing
+$ cabal v2-build
 $ ./dist/build/hnix/hnix -v5 --trace <args> +RTS -xc
 ```
 
@@ -49,9 +49,9 @@ To build `hnix` with benchmarks enabled:
 
 ```
 $ nix-shell --arg doBenchmarks true
-$ cabal configure --enable-tests --enable-benchmarks
-$ cabal build
-$ cabal bench
+$ cabal v2-configure --enable-tests --enable-benchmarks
+$ cabal v2-build
+$ cabal v2-bench
 ```
 
 ## Building with profiling enabled
@@ -60,8 +60,8 @@ To build `hnix` with profiling enabled:
 
 ```
 $ nix-shell
-$ cabal configure --enable-tests --enable-profiling --flags=profiling
-$ cabal build
+$ cabal v2-configure --enable-tests --enable-profiling --flags=profiling
+$ cabal v2-build
 $ ./dist/build/hnix/hnix <args> +RTS -p
 ```
 
@@ -98,7 +98,7 @@ same. You can talk with everyone live on
 When you're ready to submit a pull request, test it with:
 ```
 git submodule update --init --recursive
-nix-shell --run "LANGUAGE_TESTS=yes cabal test"
+nix-shell --run "LANGUAGE_TESTS=yes cabal v2-test"
 ```
 
 Make sure that all the tests that were passing prior to your PR are still

--- a/README.md
+++ b/README.md
@@ -18,13 +18,13 @@ $ git clone --recursive https://github.com/haskell-nix/hnix.git
 ...
 $ cd hnix
 $ nix-shell
-$ cabal new-configure --enable-tests
-$ cabal new-build
-$ cabal new-test
+$ cabal v2-configure --enable-tests
+$ cabal v2-build
+$ cabal v2-test
 # To run all of the tests, which takes up to a minute:
-$ env ALL_TESTS=yes cabal new-test
+$ env ALL_TESTS=yes cabal v2-test
 # To run only specific tests (see `tests/Main.hs` for a list)
-$ env NIXPKGS_TESTS=yes PRETTY_TESTS=1 cabal new-test
+$ env NIXPKGS_TESTS=yes PRETTY_TESTS=1 cabal v2-test
 $ ./dist/build/hnix/hnix --help
 ```
 


### PR DESCRIPTION
#### 1. `v2-*` should be used now.

Information: https://www.haskell.org/cabal/users-guide/nix-local-build-overview.html

`v1-*,v2-*` - are future-proof compatible keys;
`new-*` is used for new features in the *beta* stage;
```
cabal --help

 [new-style projects (beta)]
  new-build ...

 [new-style projects (forwards-compatible aliases)]
  v2-build ...
```

So from `Cabal 3.0` all Nix `new-*` are `v2-*` and should be them.

#### 2. Upgraded all `nix-shell -> cabal` to use `v2-*`.

Since Cabal runs inside the Nix-shell - it is obvious that `v2-*` features must be used for Cabal to be proper.

(`v2-*` has some breaking changes in keys from `new-*` (such cases examples shown [here](https://github.com/Anton-Latukha/haskell-notes#95-ghcid)), but in case of HNix instructions - it is a drop-in replacement)

I've tested all README instructions with `v2-*` - commands are proper, have proper additional keys and work.

#### 3. All code blocks have one style.

---

The rendered results can be viewed on my [PR branch](https://github.com/Anton-Latukha/hnix/tree/README-2020-04-18-upd).