### PR TITLE
dep: upd time (1.9.3->1.10.0)

### DIFF
--- a/hnix.cabal
+++ b/hnix.cabal
@@ -896,7 +896,7 @@ library
     , template-haskell
     , text >= 1.2.3 && < 1.3
     , these >= 1.0.1 && < 1.2
-    , time >= 1.8.0 && < 1.9 || >= 1.9.3 && < 1.10
+    , time >= 1.8.0 && < 1.9 || >= 1.9.3 && < 1.11
     , transformers >= 0.5.5 && < 0.6
     , transformers-base >= 0.4.5 && < 0.5
     , unix >= 2.7.2 && < 2.8


### PR DESCRIPTION
A stub PR, waiting on `{time, unix, GHC}` tight triangle to resolve itself (somewhere after GHC 9.0 release): https://gitlab.haskell.org/ghc/ghc/-/wikis/commentary/libraries/version-history

---

Changelog: https://github.com/haskell/time/blob/master/changelog.md#110

Checked that HNix code does not hold the changed lib stuff relying on changelog.

Version code diff of the lib is HUGE:
https://github.com/haskell/time/compare/1.9.3...1.10#files_bucket

To big to read and be sure of anything. So - I use own trust.

Overall build & executes togather with other updates.

M  hnix.cabal