### PR TITLE
dep: upd binary (0.8->0.10)

### DIFF
--- a/hnix.cabal
+++ b/hnix.cabal
@@ -853,7 +853,7 @@ library
       aeson >= 1.4.2 && < 1.5
     , array >=0.4 && <0.6
     , base >=4.11 && <5
-    , binary >= 0.8.5 && < 0.9
+    , binary >= 0.8.5 && < 0.11
     , bytestring >= 0.10.8 && < 0.11
     , comonad >= 5.0.4 && < 5.1
     , containers >= 0.5.11.0 && < 0.7


### PR DESCRIPTION
0.9 become 0.8.5 - no breackage
0.10 become 0.8.6.0 - no breackage
So this is free update, it is 0.8.6.

Making this update anyway - free constraint expansion extends the gates if
someone would try to bump into them.

Changelog: https://hackage.haskell.org/package/binary-0.10.0.0/changelog

    Add binary instance for Data.Functor.Identity from base, #146.
    Don't use * when we have TypeOperators, #148.

HNix already properly has TypeOperators.

M  hnix.cabal