### PR TITLE
dep: upd dependent-sum (0.6->0.7)

### DIFF
--- a/hnix.cabal
+++ b/hnix.cabal
@@ -860,7 +860,7 @@ library
     , contravariant >= 1.5 && < 1.6
     , data-fix >= 0.2.0 && <  0.3
     , deepseq >=1.4.3 && <1.5
-    , dependent-sum >= 0.4 && < 0.5 || >= 0.6.2.0 && < 0.7
+    , dependent-sum >= 0.4 && < 0.5 || >= 0.6.2.0 && < 0.8
     , deriving-compat >=0.3 && <0.6
     , directory >= 1.3.1 && < 1.4
     , exceptions >= 0.10.0 && < 0.11


### PR DESCRIPTION
"breaking change in 0.6.2.1/0.6.2.2 and properly do major version bump to
reflect the breaking change"

Changelog: https://hackage.haskell.org/package/dependent-sum-0.7.1.0/changelog

0.7.1.0 - 2020-03-25

    Shift version bounds for some to 1.0.1.* versions.

0.7.0.0 - 2020-03-24

    Fix ChangeLog to include the breaking change in 0.6.2.1/0.6.2.2 and properly do major version bump to reflect the breaking change.

0.6.2.2 - 2020-03-23

    Update GitHub repository in cabal metadata.

0.6.2.1 - 2020-03-21

    (Breaking change) Removed modules Data.GADT.Compare, Data.GADT.Show, Data.Some and now re-export them from the some package. This forced some deprecations to be fully realized.
    Update cabal meta-information (tested with GHC 8.8).

"This forced some deprecations to be fully realized." - it compiles, so
those functions was not used in HNix.

M  hnix.cabal