### PR TITLE
dep: port to haskeline 0.8

### DIFF
--- a/hnix.cabal
+++ b/hnix.cabal
@@ -914,7 +914,7 @@ library
       , cryptohash-sha1 >= 0.11.100 && < 0.12
       , cryptohash-sha256 >= 0.11.101 && < 0.12
       , cryptohash-sha512 >= 0.11.100 && < 0.12
-      , haskeline >= 0.7.4.2 && < 0.8
+      , haskeline >= 0.8 && < 0.9
       , pretty-show >= 1.9.5 && < 1.11
       , serialise >= 0.2.1 && < 0.3
   -- if !flag(profiling)

--- a/main/Repl.hs
+++ b/main/Repl.hs
@@ -52,13 +52,12 @@ import           Control.Monad.Identity
 import           Control.Monad.Reader
 import           Control.Monad.State.Strict
 
-import           System.Console.Haskeline.MonadException
-import           System.Console.Repline
+import           System.Console.Repline  hiding ( options )
 import           System.Environment
 import           System.Exit
 
 
-main :: (MonadNix e t f m, MonadIO m, MonadException m) => m ()
+main :: (MonadNix e t f m, MonadIO m, MonadMask m) => m ()
 main = flip evalStateT initState
 #if MIN_VERSION_repline(0, 2, 0)
     $ evalRepl (return prefix) cmd options (Just ':') completer welcomeText
@@ -86,7 +85,7 @@ initState :: MonadIO m => IState t f m
 initState = IState M.empty
 
 type Repl e t f m = HaskelineT (StateT (IState t f m) m)
-hoistErr :: MonadIO m => Result a -> Repl e t f m a
+hoistErr :: (MonadIO m, MonadThrow m) => Result a -> Repl e t f m a
 hoistErr (Success val) = return val
 hoistErr (Failure err) = do
   liftIO $ print err
@@ -98,7 +97,7 @@ hoistErr (Failure err) = do
 
 exec
   :: forall e t f m
-   . (MonadNix e t f m, MonadIO m, MonadException m)
+   . (MonadNix e t f m, MonadIO m, MonadMask m)
   => Bool
   -> Text.Text
   -> Repl e t f m (NValue t f m)
@@ -129,7 +128,7 @@ exec update source = do
 
 
 cmd
-  :: (MonadNix e t f m, MonadIO m, MonadException m)
+  :: (MonadNix e t f m, MonadIO m, MonadMask m)
   => String
   -> Repl e t f m ()
 cmd source = do
@@ -153,7 +152,7 @@ browse _ = do
 
 -- :load command
 load
-  :: (MonadNix e t f m, MonadIO m, MonadException m)
+  :: (MonadNix e t f m, MonadIO m, MonadMask m)
   => [String]
   -> Repl e t f m ()
 load args = do
@@ -162,7 +161,7 @@ load args = do
 
 -- :type command
 typeof
-  :: (MonadNix e t f m, MonadException m, MonadIO m)
+  :: (MonadNix e t f m, MonadMask m, MonadIO m)
   => [String]
   -> Repl e t f m ()
 typeof args = do
@@ -199,7 +198,7 @@ comp n = do
                                       )
 
 options
-  :: (MonadNix e t f m, MonadIO m, MonadException m)
+  :: (MonadNix e t f m, MonadIO m, MonadMask m)
   => [(String, [String] -> Repl e t f m ())]
 options =
   [ ( "load"
@@ -213,7 +212,7 @@ options =
 
 help
   :: forall e t f m
-   . (MonadNix e t f m, MonadIO m, MonadException m)
+   . (MonadNix e t f m, MonadIO m, MonadMask m)
   => [String]
   -> Repl e t f m ()
 help _ = liftIO $ do

--- a/src/Nix/Fresh.hs
+++ b/src/Nix/Fresh.hs
@@ -21,9 +21,6 @@ import           Control.Monad.Reader
 import           Control.Monad.Ref
 import           Control.Monad.ST
 import           Data.Typeable
-#ifdef MIN_VERSION_haskeline
-import System.Console.Haskeline.MonadException hiding(catch)
-#endif
 
 import           Nix.Var
 import           Nix.Thunk
@@ -42,9 +39,7 @@ newtype FreshIdT i m a = FreshIdT { unFreshIdT :: ReaderT (Var m i) m a }
     , MonadIO
     , MonadCatch
     , MonadThrow
-#ifdef MIN_VERSION_haskeline
-    , MonadException
-#endif
+    , MonadMask
     )
 
 instance MonadTrans (FreshIdT i) where

--- a/src/Nix/Standard.hs
+++ b/src/Nix/Standard.hs
@@ -47,9 +47,6 @@ import           Nix.Utils.Fix1
 import           Nix.Value
 import           Nix.Value.Monad
 import           Nix.Var
-#ifdef MIN_VERSION_haskeline
-import           System.Console.Haskeline.MonadException hiding(catch)
-#endif
 
 -- All of the following type classes defer to the underlying 'm'.
 
@@ -69,20 +66,7 @@ deriving instance MonadInstantiate (t (Fix1T t m) m) => MonadInstantiate (Fix1T 
 deriving instance MonadExec (t (Fix1T t m) m) => MonadExec (Fix1T t m)
 deriving instance MonadIntrospect (t (Fix1T t m) m) => MonadIntrospect (Fix1T t m)
 
-#ifdef MIN_VERSION_haskeline
--- For whatever reason, using the default StateT instance provided by
--- haskeline does not work.
-instance MonadException m
-  => MonadException(StateT(HashMap FilePath NExprLoc) m) where
-  controlIO f = StateT $ \s -> controlIO $ \(RunIO run) -> let
-    run' = RunIO(fmap(StateT . const) . run . flip runStateT s)
-    in fmap(flip runStateT s) $ f run'
-
-instance MonadException m => MonadException(Fix1T StandardTF m) where
-  controlIO f = mkStandardT $ controlIO $ \(RunIO run) ->
-    let run' = RunIO(fmap mkStandardT . run . runStandardT)
-    in runStandardT <$> f run'
-#endif
+deriving instance MonadMask m => MonadMask (Fix1T StandardTF m)
 
 type MonadFix1T t m = (MonadTrans (Fix1T t), Monad (t (Fix1T t m) m))
 
@@ -219,6 +203,7 @@ newtype StandardTF r m a
     , MonadIO
     , MonadCatch
     , MonadThrow
+    , MonadMask
     , MonadReader (Context r (StdValue r))
     , MonadState (HashMap FilePath NExprLoc)
     )


### PR DESCRIPTION
Breaking change regarding `MonadException` which is now replaced
by `MonadMask` from `exceptions` package.

Allows building with GHC 8.10. This forces `haskeline 0.8` so marking as draft for now.