### PR TITLE
README: add dependencies status badge monitor

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Build Status](https://api.travis-ci.org/haskell-nix/hnix.svg)](https://travis-ci.org/haskell-nix/hnix)
 [![Chat](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/haskell-nix/Lobby)
 <sup>([Hackage Matrix Builder](https://matrix.hackage.haskell.org/package/hnix))</sup>
+[![Dependencies](https://img.shields.io/hackage-deps/v/hnix?label=Dependencies)](https://packdeps.haskellers.com/feed?needle=hnix)
 
 Haskell parser, evaluator and type checker for the Nix language.
 


### PR DESCRIPTION
Solves Repor idea: https://github.com/haskell-nix/hnix/issues/570

Now we would be able to observe if there are new unmet dependency versions.

It also links to the detailed table on `packdeps`.

M  README.md