### PR TITLE
[WIP] Proper (NString :: NAtom)

### DIFF
--- a/hnix.cabal
+++ b/hnix.cabal
@@ -854,6 +854,7 @@ library
     , array >=0.4 && <0.6
     , base >=4.11 && <5
     , binary >= 0.8.5 && < 0.9
+    , binary-instances < 1.1
     , bytestring >= 0.10.8 && < 0.11
     , comonad >= 5.0.4 && < 5.1
     , containers >= 0.5.11.0 && < 0.7

--- a/main/Main.hs
+++ b/main/Main.hs
@@ -149,7 +149,7 @@ main = do
       = liftIO
         .   Text.putStrLn
         .   principledStringIgnoreContext
-        <=< nvalueToJSONNixString
+        <=< nvalueToJSONNString
       | strict opts
       = liftIO . print . prettyNValue <=< normalForm
       | values opts

--- a/src/Nix/Atoms.hs
+++ b/src/Nix/Atoms.hs
@@ -17,6 +17,13 @@ import           Data.Text                      ( Text
                                                 , pack
                                                 )
 import           GHC.Generics
+-- import           Nix.String                          (StringContext)
+import qualified Data.HashSet                  as S
+import           Data.Binary                    ( Binary )
+import           Data.Binary.Instances.UnorderedContainers
+
+import           Data.Aeson
+import           Data.Aeson.TH
 
 -- | Atoms are values that evaluate to themselves. This means that
 -- they appear in both the parsed AST (in the form of literals) and
@@ -33,8 +40,33 @@ data NAtom
   | NBool Bool
   -- | Null values. There's only one of this variant.
   | NNull
+  | NString
+    { nsContents :: !Text
+    , nsContext :: !(S.HashSet StringContext)
+    }
   deriving (Eq, Ord, Generic, Typeable, Data, Show, Read, NFData,
             Hashable)
+
+-- instance Hashable NString
+-- instance Hashable S.HashSet
+-- instance Binary (S.HashSet a)
+
+-- | A 'StringContext' ...
+data StringContext =
+  StringContext { scPath :: !Text
+                , scFlavor :: !ContextFlavor
+                } deriving (Eq, Ord, Show, Generic, Data, Read, NFData, Serialise, Binary, Hashable, ToJSON, FromJSON)
+
+-- instance Hashable StringContext
+
+-- | A 'ContextFlavor' describes the sum of possible derivations for string contexts
+data ContextFlavor =
+    DirectPath
+  | AllOutputs
+  | DerivationOutput !Text
+  deriving (Show, Eq, Ord, Generic, Data, Read, NFData, Serialise, Binary, ToJSON, FromJSON)
+
+instance Hashable ContextFlavor
 
 #ifdef MIN_VERSION_serialise
 instance Serialise NAtom

--- a/src/Nix/Convert.hs
+++ b/src/Nix/Convert.hs
@@ -149,12 +149,12 @@ instance ( Convertible e t f m
          , MonadValue (NValue t f m) m
          , MonadEffects t f m
          )
-  => FromValue NixString m (NValue' t f m (NValue t f m)) where
+  => FromValue NAtom m (NValue' t f m (NValue t f m)) where
   fromValueMay = \case
     NVStr' ns -> pure $ Just ns
     NVPath' p ->
       Just
-        .   hackyMakeNixStringWithoutContext
+        .   hackyMakeNStringWithoutContext
         .   Text.pack
         .   unStorePath
         <$> addPath p
@@ -301,12 +301,12 @@ instance Convertible e t f m
   toValue = pure . nvConstant' . NFloat
 
 instance Convertible e t f m
-  => ToValue NixString m (NValue' t f m (NValue t f m)) where
+  => ToValue NAtom m (NValue' t f m (NValue t f m)) where
   toValue = pure . nvStr'
 
 instance Convertible e t f m
   => ToValue ByteString m (NValue' t f m (NValue t f m)) where
-  toValue = pure . nvStr' . hackyMakeNixStringWithoutContext . decodeUtf8
+  toValue = pure . nvStr' . hackyMakeNStringWithoutContext . decodeUtf8
 
 instance Convertible e t f m
   => ToValue Path m (NValue' t f m (NValue t f m)) where
@@ -320,7 +320,7 @@ instance ( Convertible e t f m
          )
   => ToValue SourcePos m (NValue' t f m (NValue t f m)) where
   toValue (SourcePos f l c) = do
-    f' <- toValue (principledMakeNixStringWithoutContext (Text.pack f))
+    f' <- toValue (principledMakeNStringWithoutContext (Text.pack f))
     l' <- toValue (unPos l)
     c' <- toValue (unPos c)
     let pos = M.fromList [("file" :: Text, f'), ("line", l'), ("column", c')]
@@ -362,7 +362,7 @@ instance Convertible e t f m
       else return Nothing
     outputs <- do
       let outputs =
-            fmap principledMakeNixStringWithoutContext $ nlcvOutputs nlcv
+            fmap principledMakeNStringWithoutContext $ nlcvOutputs nlcv
       ts :: [NValue t f m] <- traverse toValue outputs
       case ts of
         [] -> return Nothing

--- a/src/Nix/Effects/Basic.hs
+++ b/src/Nix/Effects/Basic.hs
@@ -146,7 +146,7 @@ findPathBy finder l name = do
       demand p $ fromValue >=> \(Path path) -> case M.lookup "prefix" s of
         Nothing -> tryPath path Nothing
         Just pf -> demand pf $ fromValueMay >=> \case
-          Just (nsPfx :: NixString) ->
+          Just (nsPfx :: NAtom) ->
             let pfx = hackyStringIgnoreContext nsPfx
             in  if not (Text.null pfx)
                   then tryPath path (Just (Text.unpack pfx))

--- a/src/Nix/Eval.hs
+++ b/src/Nix/Eval.hs
@@ -85,7 +85,7 @@ type MonadNixEval v m
   , MonadFix m
   , ToValue Bool m v
   , ToValue [v] m v
-  , FromValue NixString m v
+  , FromValue NAtom m v
   , ToValue (AttrSet v, AttrSet SourcePos) m v
   , FromValue (AttrSet v, AttrSet SourcePos) m v
   )
@@ -337,7 +337,7 @@ evalSelect aset attr = do
 -- *retrieving* a value
 evalGetterKeyName
   :: forall v m
-   . (MonadEval v m, FromValue NixString m v)
+   . (MonadEval v m, FromValue NAtom m v)
   => NKeyName (m v)
   -> m Text
 evalGetterKeyName = evalSetterKeyName >=> \case
@@ -348,7 +348,7 @@ evalGetterKeyName = evalSetterKeyName >=> \case
 -- | Evaluate a component of an attribute path in a context where we are
 -- *binding* a value
 evalSetterKeyName
-  :: (MonadEval v m, FromValue NixString m v)
+  :: (MonadEval v m, FromValue NAtom m v)
   => NKeyName (m v)
   -> m (Maybe Text)
 evalSetterKeyName = \case
@@ -360,9 +360,9 @@ evalSetterKeyName = \case
 
 assembleString
   :: forall v m
-   . (MonadEval v m, FromValue NixString m v)
+   . (MonadEval v m, FromValue NAtom m v)
   => NString (m v)
-  -> m (Maybe NixString)
+  -> m (Maybe NAtom)
 assembleString = \case
   Indented _ parts   -> fromParts parts
   DoubleQuoted parts -> fromParts parts
@@ -370,7 +370,7 @@ assembleString = \case
   fromParts = fmap (fmap principledStringMConcat . sequence) . traverse go
 
   go = runAntiquoted "\n"
-                     (pure . Just . principledMakeNixStringWithoutContext)
+                     (pure . Just . principledMakeNStringWithoutContext)
                      (>>= fromValueMay)
 
 buildArgument

--- a/src/Nix/Exec.hs
+++ b/src/Nix/Exec.hs
@@ -83,7 +83,7 @@ nvConstantP p x = addProvenance p (nvConstant x)
 nvStrP
   :: MonadCited t f m
   => Provenance m (NValue t f m)
-  -> NixString
+  -> NAtom
   -> NValue t f m
 nvStrP p ns = addProvenance p (nvStr ns)
 
@@ -478,7 +478,7 @@ execBinaryOpForced scope span op lval rval = case op of
 
 -- This function is here, rather than in 'Nix.String', because of the need to
 -- use 'throwError'.
-fromStringNoContext :: Framed e m => NixString -> m Text
+fromStringNoContext :: Framed e m => NAtom -> m Text
 fromStringNoContext ns = case principledGetStringNoContext ns of
   Just str -> return str
   Nothing  -> throwError $ ErrorCall "expected string with no context"

--- a/src/Nix/Json.hs
+++ b/src/Nix/Json.hs
@@ -22,8 +22,8 @@ import           Nix.Utils
 import           Nix.Value
 import           Nix.Value.Monad
 
-nvalueToJSONNixString :: MonadNix e t f m => NValue t f m -> m NixString
-nvalueToJSONNixString =
+nvalueToJSONNString :: MonadNix e t f m => NValue t f m -> m NAtom
+nvalueToJSONNString =
   runWithStringContextT
     . fmap
         ( TL.toStrict
@@ -39,7 +39,7 @@ nvalueToJSON = \case
   NVConstant (NFloat n) -> pure $ A.toJSON n
   NVConstant (NBool  b) -> pure $ A.toJSON b
   NVConstant NNull      -> pure $ A.Null
-  NVStr      ns         -> A.toJSON <$> extractNixString ns
+  NVStr      ns         -> A.toJSON <$> extractNString ns
   NVList l ->
     A.Array
       .   V.fromList

--- a/src/Nix/Lint.hs
+++ b/src/Nix/Lint.hs
@@ -262,7 +262,7 @@ instance ToValue Bool m (Symbolic m) where
 
 instance ToValue [Symbolic m] m (Symbolic m) where
 
-instance FromValue NixString m (Symbolic m) where
+instance FromValue NAtom m (Symbolic m) where
 
 instance FromValue (AttrSet (Symbolic m), AttrSet SourcePos) m (Symbolic m) where
 

--- a/src/Nix/Normal.hs
+++ b/src/Nix/Normal.hs
@@ -122,7 +122,7 @@ removeEffects =
     (fmap Free . sequenceNValue' id)
 
 opaque :: Applicative f => NValue t f m
-opaque = nvStr $ principledMakeNixStringWithoutContext "<CYCLE>"
+opaque = nvStr $ principledMakeNStringWithoutContext "<CYCLE>"
 
 dethunk
   :: (MonadThunk t m (NValue t f m), MonadDataContext f m)

--- a/src/Nix/String/Coerce.hs
+++ b/src/Nix/String/Coerce.hs
@@ -49,7 +49,7 @@ coerceToString
   -> CopyToStoreMode
   -> CoercionLevel
   -> NValue t f m
-  -> m NixString
+  -> m NAtom
 coerceToString call ctsm clevel = go
  where
   go x = demand x $ \case
@@ -57,18 +57,18 @@ coerceToString call ctsm clevel = go
       |
         -- TODO Return a singleton for "" and "1"
         b && clevel == CoerceAny -> pure
-      $  principledMakeNixStringWithoutContext "1"
-      | clevel == CoerceAny -> pure $ principledMakeNixStringWithoutContext ""
+      $  principledMakeNStringWithoutContext "1"
+      | clevel == CoerceAny -> pure $ principledMakeNStringWithoutContext ""
     NVConstant (NInt n) | clevel == CoerceAny ->
-      pure $ principledMakeNixStringWithoutContext $ Text.pack $ show n
+      pure $ principledMakeNStringWithoutContext $ Text.pack $ show n
     NVConstant (NFloat n) | clevel == CoerceAny ->
-      pure $ principledMakeNixStringWithoutContext $ Text.pack $ show n
+      pure $ principledMakeNStringWithoutContext $ Text.pack $ show n
     NVConstant NNull | clevel == CoerceAny ->
-      pure $ principledMakeNixStringWithoutContext ""
+      pure $ principledMakeNStringWithoutContext ""
     NVStr ns -> pure ns
     NVPath p
-      | ctsm == CopyToStore -> storePathToNixString <$> addPath p
-      | otherwise -> pure $ principledMakeNixStringWithoutContext $ Text.pack p
+      | ctsm == CopyToStore -> storePathToNString <$> addPath p
+      | otherwise -> pure $ principledMakeNStringWithoutContext $ Text.pack p
     NVList l | clevel == CoerceAny ->
       nixStringUnwords <$> traverse (`demand` go) l
 
@@ -80,9 +80,9 @@ coerceToString call ctsm clevel = go
     v -> throwError $ ErrorCall $ "Expected a string, but saw: " ++ show v
 
   nixStringUnwords =
-    principledIntercalateNixString (principledMakeNixStringWithoutContext " ")
-  storePathToNixString :: StorePath -> NixString
-  storePathToNixString sp = principledMakeNixStringWithSingletonContext
+    principledIntercalateNString (principledMakeNStringWithoutContext " ")
+  storePathToNString :: StorePath -> NAtom
+  storePathToNString sp = principledMakeNStringWithSingletonContext
     t
     (StringContext t DirectPath)
     where t = Text.pack $ unStorePath sp

--- a/src/Nix/Type/Infer.hs
+++ b/src/Nix/Type/Infer.hs
@@ -525,7 +525,7 @@ data Judgment s = Judgment
     }
     deriving Show
 
-instance Monad m => FromValue NixString (InferT s m) (Judgment s) where
+instance Monad m => FromValue NAtom (InferT s m) (Judgment s) where
   fromValueMay _ = return Nothing
   fromValue _ = error "Unused"
 

--- a/src/Nix/Value.hs
+++ b/src/Nix/Value.hs
@@ -58,7 +58,7 @@ data NValueF p m r
     = NVConstantF NAtom
      -- | A string has a value and a context, which can be used to record what a
      -- string has been build from
-    | NVStrF NixString
+    | NVStrF NAtom
     | NVPathF FilePath
     | NVListF [r]
     | NVSetF (AttrSet r) (AttrSet SourcePos)
@@ -315,9 +315,9 @@ nvConstant x = Free (NValue (pure (NVConstantF x)))
 pattern NVStr' ns <- NValue (extract -> NVStrF ns)
 pattern NVStr ns <- Free (NVStr' ns)
 
-nvStr' :: Applicative f => NixString -> NValue' t f m r
+nvStr' :: Applicative f => NAtom -> NValue' t f m r
 nvStr' ns = NValue (pure (NVStrF ns))
-nvStr :: Applicative f => NixString -> NValue t f m
+nvStr :: Applicative f => NAtom -> NValue t f m
 nvStr ns = Free (NValue (pure (NVStrF ns)))
 
 pattern NVPath' x <- NValue (extract -> NVPathF x)

--- a/src/Nix/Value/Equal.hs
+++ b/src/Nix/Value/Equal.hs
@@ -81,7 +81,7 @@ alignEqM eq fa fb = fmap (either (const False) (const True)) $ runExceptT $ do
 alignEq :: (Align f, Traversable f) => (a -> b -> Bool) -> f a -> f b -> Bool
 alignEq eq fa fb = runIdentity $ alignEqM (\x y -> Identity (eq x y)) fa fb
 
-isDerivationM :: Monad m => (t -> m (Maybe NixString)) -> AttrSet t -> m Bool
+isDerivationM :: Monad m => (t -> m (Maybe NAtom)) -> AttrSet t -> m Bool
 isDerivationM f m = case M.lookup "type" m of
   Nothing -> pure False
   Just t  -> do
@@ -92,7 +92,7 @@ isDerivationM f m = case M.lookup "type" m of
       Just s  -> pure $ principledStringIgnoreContext s == "derivation"
       Nothing -> pure False
 
-isDerivation :: Monad m => (t -> Maybe NixString) -> AttrSet t -> Bool
+isDerivation :: Monad m => (t -> Maybe NAtom) -> AttrSet t -> Bool
 isDerivation f = runIdentity . isDerivationM (\x -> Identity (f x))
 
 valueFEqM
@@ -127,7 +127,7 @@ valueFEq attrsEq eq x y = runIdentity $ valueFEqM
 
 compareAttrSetsM
   :: Monad m
-  => (t -> m (Maybe NixString))
+  => (t -> m (Maybe NAtom))
   -> (t -> t -> m Bool)
   -> AttrSet t
   -> AttrSet t
@@ -144,7 +144,7 @@ compareAttrSetsM f eq lm rm = do
   where compareAttrs = alignEqM eq lm rm
 
 compareAttrSets
-  :: (t -> Maybe NixString)
+  :: (t -> Maybe NAtom)
   -> (t -> t -> Bool)
   -> AttrSet t
   -> AttrSet t

--- a/src/Nix/XML.hs
+++ b/src/Nix/XML.hs
@@ -15,7 +15,7 @@ import           Nix.String
 import           Nix.Value
 import           Text.XML.Light
 
-toXML :: forall t f m . MonadDataContext f m => NValue t f m -> NixString
+toXML :: forall t f m . MonadDataContext f m => NValue t f m -> NAtom
 toXML = runWithStringContext . fmap pp . iterNValue (\_ _ -> cyc) phi
  where
   cyc = return $ mkElem "string" "value" "<CYCLE>"
@@ -37,7 +37,7 @@ toXML = runWithStringContext . fmap pp . iterNValue (\_ _ -> cyc) phi
       NNull    -> return $ Element (unqual "null") [] [] Nothing
 
     NVStr' str ->
-      mkElem "string" "value" . Text.unpack <$> extractNixString str
+      mkElem "string" "value" . Text.unpack <$> extractNString str
     NVList' l -> sequence l
       >>= \els -> return $ Element (unqual "list") [] (Elem <$> els) Nothing
 


### PR DESCRIPTION
[Can NixString be the NAtom? #534](https://github.com/haskell-nix/hnix/issues/534)

The night starts and I call the type system
... type system strongly craves and guides me in the night to make itself proper and complete ...

... and says to me "Thank you!" in the end.

We look now at `NAtom`. It changed - we see its:

https://github.com/haskell-nix/hnix/blob/3349e0ebefcfd3dd226c7790d1af978029d9d467/src/Nix/Atoms.hs#L28-L48

... we count data constructors as we see that the heart cleans itself and becomes stronger with every moment.

From now on we know - `NAtom` - is complete - it embodies all `6` cornerstone data types of `Nix` there is!

Now type system would guide us far further, would show how to cleanse itself, make it concise, and would guide us how to implement itself.

I did not contribute the major part in this, I just happen to notice that `6-th` Nix atomic type was not in place, and then followed John's beautiful `HNix` - to put the final stone.

---

As the type system completes - we now also can say that Nix language indeed type checks.

---

There would be a lot of work because of `(NString :: NAtom)`:
  * code restructuring
  * deleting old `hacky*` NixString functions and replacing them with `principled*`
  * dropping `principled` part from names
  * collapsing old `NixString` set of functions into `NAtom` functions
  * into `(NString :: NAtom)` merging infrastructure of string type `(NString :: NString)` 
  * complete the pattern matches everywhere

I'm open and plan to listen to some reviews/suggestions.

And I would work on this PR over time. It makes a big improvement in API obviously.
Since I must put maintenance duties first - I would code this to satisfy my coding crave somewhat. But no challenges so far - but I am very-very happy to do it - it consolidates the basic types and so the project comes together even better.

I still expect to remake/rebase and update this PR several times before it becomes clean.

---

M  hnix.cabal
M  src/Nix/Atoms.hs
M  src/Nix/Builtins.hs
M  src/Nix/Convert.hs
M  src/Nix/Effects/Basic.hs
M  src/Nix/Eval.hs
M  src/Nix/Exec.hs
M  src/Nix/Json.hs
M  src/Nix/Lint.hs
M  src/Nix/Normal.hs
M  src/Nix/String.hs
M  src/Nix/String/Coerce.hs
M  src/Nix/Type/Infer.hs
M  src/Nix/Value.hs
M  src/Nix/Value/Equal.hs
M  src/Nix/XML.hs