### PR TITLE
default.nix: dep: upd hnix-store 0.2

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -60,15 +60,17 @@
 }:
 
 let
-  hnix-store-src = pkgs.fetchFromGitHub {
-    owner = "haskell-nix";
-    repo = "hnix-store";
-    rev = "0.2.0.0";
-    sha256 = "1qf5rn43d46vgqqgmwqdkjh78rfg6bcp4kypq3z7mx46sdpzvb78";
-  };
+
+  #  2020-05-23: NOTE: Currently HNix-store needs no overlay
+  # hnix-store-src = pkgs.fetchFromGitHub {
+  #   owner = "haskell-nix";
+  #   repo = "hnix-store";
+  #   rev = "0.2.0.0";
+  #   sha256 = "1qf5rn43d46vgqqgmwqdkjh78rfg6bcp4kypq3z7mx46sdpzvb78";
+  # };
 
   overlay = pkgs.lib.foldr pkgs.lib.composeExtensions (_: _: {}) [
-    (import "${hnix-store-src}/overlay.nix")
+    # (import "${hnix-store-src}/overlay.nix")
     (self: super: with pkgs.haskell.lib;
       pkgs.lib.optionalAttrs withHoogle {
       ghc = super.ghc // { withPackages = super.ghc.withHoogle; };

--- a/default.nix
+++ b/default.nix
@@ -97,7 +97,6 @@ in haskellPackages.developPackage {
   modifier = drv: pkgs.haskell.lib.overrideCabal drv (attrs: {
     buildTools = (attrs.buildTools or []) ++ [
       haskellPackages.cabal-install
-      # haskellPackages.brittany
     ];
 
     enableLibraryProfiling = doProfiling;

--- a/default.nix
+++ b/default.nix
@@ -8,7 +8,7 @@
 
 , withHoogle  ? true
 
-, rev ? "8da81465c19fca393a3b17004c743e4d82a98e4f"
+, rev ? "29d57de30101b51b016310ee51c2c4ec762f88db" #  2020-05-23: NOTE: UTC 17:00
 
 , pkgs ?
     if builtins.compareVersions builtins.nixVersion "2.0" < 0

--- a/default.nix
+++ b/default.nix
@@ -63,8 +63,8 @@ let
   hnix-store-src = pkgs.fetchFromGitHub {
     owner = "haskell-nix";
     repo = "hnix-store";
-    rev = "0.1.0.0";
-    sha256 = "1z48msfkiys432rkd00fgimjgspp98dci11kgg3v8ddf4mk1s8g0";
+    rev = "0.2.0.0";
+    sha256 = "1qf5rn43d46vgqqgmwqdkjh78rfg6bcp4kypq3z7mx46sdpzvb78";
   };
 
   overlay = pkgs.lib.foldr pkgs.lib.composeExtensions (_: _: {}) [

--- a/default.nix
+++ b/default.nix
@@ -69,11 +69,8 @@ let
 
   overlay = pkgs.lib.foldr pkgs.lib.composeExtensions (_: _: {}) [
     (import "${hnix-store-src}/overlay.nix")
-    (self: super: with pkgs.haskell.lib; {
-
-      semialign         = super.semialign_1_1;
-
-    } // pkgs.lib.optionalAttrs withHoogle {
+    (self: super: with pkgs.haskell.lib;
+      pkgs.lib.optionalAttrs withHoogle {
       ghc = super.ghc // { withPackages = super.ghc.withHoogle; };
       ghcWithPackages = self.ghc.withPackages;
     })


### PR DESCRIPTION
Report: [Use hnix-store 0.2 #561](https://github.com/haskell-nix/hnix/issues/561)

---

### This PR depends on the: [default.nix: clean-up old overrides #579](https://github.com/haskell-nix/hnix/pull/579) **please merge that first**!

---

`*this` gives us ground to make [New release #560](https://github.com/haskell-nix/hnix/issues/560)

, which would close: [Compatibility woes #551](https://github.com/haskell-nix/hnix/issues/551) 

  - [x] freed the `semialign` from being `1.1` - there are no `1.1` in new `nixpkgs` revisions
  - [x] updated `nixpkgs` revision
  - [x] `hnix-store 0.2` its overlay is empty. `hnix-store 0.2` now works fine from the main repository, no load of its overrides or from source is needed.

---

New `nixpkgs` revision has a lot to compile. Travis probably would fail to compile it in the free tier timeout (~45-60m).

... current Travis build fail (usage of `dependent-sum-0.7.1.0` but `dependent-sum < 0.7` is addressed in: [dep: upd dependent-sum (0.6->0.7) #559](https://github.com/haskell-nix/hnix/issues/559).

---

As always:
  - [x] everything compiles
  - [x] passes tests
  - [x] binary executes and evaluates