### PR TITLE
CI: Travis: upd: maybe this would be able to help

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -116,6 +116,7 @@ before_script:
   - sudo mount -o remount,exec,size=4G,mode=755 /run/user || true
   - sudo mkdir -p /etc/nix
   - echo "trusted-users = root $USER" | sudo tee -a /etc/nix/nix.conf
+  # NOTE: macOS service restart
   - sudo launchctl kickstart -k system/org.nixos.nix-daemon || true
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -91,6 +91,7 @@ env:
   # NOTE: {os} x {jobs} - {exclude} = {build matrix}
   jobs:
     - GHCVERSION=ghc865
+    - GHCVERSION=ghc883
     - GHCVERSION=ghcjs
 
 # 

--- a/.travis.yml
+++ b/.travis.yml
@@ -65,6 +65,7 @@ env:
     - doCheck=true
     # NOTE: doBenchmark: Dependency checking + compilation and execution for benchmarks listed in the package description file.
     - doBenchmark=false
+    - enableExecutableProfiling=false
 
   matrix:
     - GHCVERSION=ghc865 STRICT=false TRACING=false

--- a/.travis.yml
+++ b/.travis.yml
@@ -120,8 +120,13 @@ before_script:
   - sudo launchctl kickstart -k system/org.nixos.nix-daemon || true
 
 script:
-  - nix-env -iA cachix -f https://github.com/NixOS/nixpkgs/tarball/db557aab7b690f5e0e3348459f2e4dc8fd0d9298
-  - cachix use hnix
+  #
+  #
+  # NOTE: Install Cachix client using Nix:
+  - nix-env -iA cachix -f https://cachix.org/api/v1/install
+  - cachix use "$name"
+  #
+  #
   - if [ ! "$CACHIX_SIGNING_KEY" = "" ]; then cachix push hnix --watch-store& fi
   - if [ ! "$CACHIX_SIGNING_KEY" = "" ]; then ./build.sh | cachix push hnix; else ./build.sh; fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,10 +33,10 @@ env:
     - secure: "dm6I+M4+V+C7QMTpcSADdKPE633SvmToXZrTbZ7miNDGmMN+/SfHeN2ybi1+PW6oViMlbPN/7J/aEfiGjSJI8vLk72Y4uCWGmpSb8TXZLu6+whnxtZzzW8+z4tsM4048QJg7CF3N/25U8thRFgs3DqUub1Sf3nG9LrNWdz6ZcDQ="
     # NOTE: Nix by default uses nixpkgs-unstable channel
     # NOTE: Setup for Nixpkgs revision
-    # `rev` vals in order of freshness -> cache & stability (branch causes differ):
+    # `rev` vals in order of freshness -> cache & stability:
     # { master
     # , commitHash
-    # , haskell-updates
+    # , haskell-updates  # Haskell development branch in Nixpkgs, can be inconsistent. Weekly merged into the upstream
     # , nixpkgs-unstable
     # , nixos-unstable
     # , nixos-20.03

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,18 @@ env:
     # NOTE: This is secure CACHIX_SIGNING_KEY=val
     - secure: "dm6I+M4+V+C7QMTpcSADdKPE633SvmToXZrTbZ7miNDGmMN+/SfHeN2ybi1+PW6oViMlbPN/7J/aEfiGjSJI8vLk72Y4uCWGmpSb8TXZLu6+whnxtZzzW8+z4tsM4048QJg7CF3N/25U8thRFgs3DqUub1Sf3nG9LrNWdz6ZcDQ="
     # NOTE: Nix by default uses nixpkgs-unstable channel
+    # NOTE: Setup for Nixpkgs revision
+    # `rev` vals in order of freshness -> cache & stability (branch causes differ):
+    # { master
+    # , commitHash
+    # , haskell-updates
+    # , nixpkgs-unstable
+    # , nixos-unstable
+    # , nixos-20.03
+    # }
+    # - rev=nixos-unstable
+    # # NOTE: Switching into Nixpkgs revision
+    # - NIX_PATH="nixpkgs=https://github.com/nixos/nixpkgs/archive/$rev.tar.gz"
     # NOTE: Enable all our tests in cabal
     - ALL_TESTS=yes
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -131,7 +131,10 @@ script:
   - sleep 2
   #
   #
-  - if [ ! "$CACHIX_SIGNING_KEY" = "" ]; then ./build.sh | cachix push hnix; else ./build.sh; fi
+  # NOTE: Normal GHC build
+  - if [ ! "$GHCVERSION" = 'ghcjs' ]; then ./build.sh; fi
+  #
+  #
 
 branches:
   only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -74,6 +74,7 @@ env:
     - buildStrictly=false
     # NOTE: Disable core optimizations, significantly speeds up the build
     - disableOptimization=true
+    - buildStackProject=false
 
   matrix:
     - GHCVERSION=ghc865 STRICT=false TRACING=false

--- a/.travis.yml
+++ b/.travis.yml
@@ -92,6 +92,7 @@ env:
   jobs:
     - GHCVERSION=ghc865
     - GHCVERSION=ghc883
+    - GHCVERSION=ghc8101
     - GHCVERSION=ghcjs
 
 # 

--- a/.travis.yml
+++ b/.travis.yml
@@ -66,6 +66,7 @@ env:
     # NOTE: doBenchmark: Dependency checking + compilation and execution for benchmarks listed in the package description file.
     - doBenchmark=false
     - enableExecutableProfiling=false
+    - enableLibraryProfiling=false
 
   matrix:
     - GHCVERSION=ghc865 STRICT=false TRACING=false

--- a/.travis.yml
+++ b/.travis.yml
@@ -67,6 +67,8 @@ env:
     - doBenchmark=false
     - enableExecutableProfiling=false
     - enableLibraryProfiling=false
+    # NOTE: Build a source distribution tarball instead of using the source files directly. The effect is that the package is built as if it were published on hackage. This can be used as a test for the source distribution, assuming the build fails when packaging mistakes are in the cabal file.
+    - buildFromSdist=false
 
   matrix:
     - GHCVERSION=ghc865 STRICT=false TRACING=false

--- a/.travis.yml
+++ b/.travis.yml
@@ -157,5 +157,6 @@ notifications:
     urls:
       - https://webhooks.gitter.im/e/b0312b18473340459d3e
     on_success: change
-    on_failure: always
+    # NOTE: `master` status in on the front page badge.
+    on_failure: never
     on_start: never

--- a/.travis.yml
+++ b/.travis.yml
@@ -61,6 +61,8 @@ env:
     - doHaddock=false
     # NOTE: Escape the version bounds from the cabal file. You may want to avoid this function.
     - doJailbreak=false
+    # NOTE: Disables Nix dependency checking, compilation and execution of test suites listed in the package description file.
+    - doCheck=true
 
   matrix:
     - GHCVERSION=ghc865 STRICT=false TRACING=false

--- a/.travis.yml
+++ b/.travis.yml
@@ -135,6 +135,17 @@ script:
   - if [ ! "$GHCVERSION" = 'ghcjs' ]; then ./build.sh; fi
   #
   #
+  # NOTE: GHCJS build
+  # HACK: Travis terminates GHCJS because of very huge log,
+  # so `SILENT` mode for it was created
+  # and travis_wait 50 to wait on no outputs (otherwise Travis terminates build in 10 minutes as stale)
+  # and `bash` wrapper so Travis parses `travis_wait` => `if; then; fi` line
+  - travis_wait 50 bash -c 'if [ "$GHCVERSION" = "ghcjs" ]; then ./build.sh; fi'
+  # NOTE: For GHCJS dump the last $ghcjsLogTailLength lines into CI out to see
+  # Since build runs inside `travis_wait` - it was impossible to output log from it
+  - if [ "$GHCVERSION" = "ghcjs" ]; then tail -n "$ghcjsLogTailLength" "$ghcjsTmpLogFile" && rm "$ghcjsTmpLogFile"; fi
+  #
+  #
 
 branches:
   only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -84,6 +84,10 @@ env:
     - generateOptparseApplicativeCompletion=false
     # NOTE: Don't fail at configure time if there are multiple versions of the same package in the (recursive) dependencies of the package being built. Will delay failures, if any, to compile time.
     - allowInconsistentDependencies=false
+    # NOTE: Log file to dump GHCJS build into
+    - ghcjsTmpLogFile='/tmp/ghcjsTmpLogFile.jog'
+    # NOTE: Length of the GHCJS log tail (<40000)
+    - ghcjsLogTailLength=10000
 
   matrix:
     - GHCVERSION=ghc865 STRICT=false TRACING=false

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,6 +46,8 @@ env:
     # - NIX_PATH="nixpkgs=https://github.com/nixos/nixpkgs/archive/$rev.tar.gz"
     # NOTE: Project/binary name
     - name=hnix
+    # NOTE: Used in the `generateOptparseApplicativeCompletions = true`
+    - pkgName='haskellPackages.hnix'
     # NOTE: Enable all our tests in cabal
     - ALL_TESTS=yes
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ version: ~> 1.0
 
 # NOTE: Please, be aware that Travis YAML & docs & API are hard to make work properly. Travis configuration requires a lot of retries and some compromises. Tere are many ways that may look like that can be done in that way, but it would not work most of the time, or not work the way that you expect, need it. Travis config works only the certain particular ways. Some things look possible - but they are impossible in Travis. Current configuration is "the best way possible" that was found in ~100-150-200 retries, depending on what concider a retry.
 
+# NOTE: Let the official Travis YAML checker help you: https://config.travis-ci.com/explore
 
 language: nix
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,7 @@ dist: bionic
 
 env:
   global:
+    # NOTE: This is secure CACHIX_SIGNING_KEY=val
     - secure: "dm6I+M4+V+C7QMTpcSADdKPE633SvmToXZrTbZ7miNDGmMN+/SfHeN2ybi1+PW6oViMlbPN/7J/aEfiGjSJI8vLk72Y4uCWGmpSb8TXZLu6+whnxtZzzW8+z4tsM4048QJg7CF3N/25U8thRFgs3DqUub1Sf3nG9LrNWdz6ZcDQ="
     # NOTE: Enable all our tests in cabal
     - ALL_TESTS=yes

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,6 +54,9 @@ env:
     - failOnAllWarnings=false
     # NOTE: checkUnusedPackages: is `failOnAllWarnings` + `cabal sdist` to ensure all needed files are listed in the Cabal file. Uses `packunused` or GHC internals. Adds a post-build check to verify that dependencies declared in the cabal file are actually used. The first attrset argument can be used to configure the strictness of this check and a list of ignored package names that would otherwise cause false alarms.
     - checkUnusedPackages=false
+    # NOTE: Generation and installation of a coverage report.
+    # See https://wiki.haskell.org/Haskell_program_coverage
+    - doCoverage=false
 
   matrix:
     - GHCVERSION=ghc865 STRICT=false TRACING=false

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,6 +63,8 @@ env:
     - doJailbreak=false
     # NOTE: Disables Nix dependency checking, compilation and execution of test suites listed in the package description file.
     - doCheck=true
+    # NOTE: doBenchmark: Dependency checking + compilation and execution for benchmarks listed in the package description file.
+    - doBenchmark=false
 
   matrix:
     - GHCVERSION=ghc865 STRICT=false TRACING=false

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,7 @@ env:
   global:
     # NOTE: This is secure CACHIX_SIGNING_KEY=val
     - secure: "dm6I+M4+V+C7QMTpcSADdKPE633SvmToXZrTbZ7miNDGmMN+/SfHeN2ybi1+PW6oViMlbPN/7J/aEfiGjSJI8vLk72Y4uCWGmpSb8TXZLu6+whnxtZzzW8+z4tsM4048QJg7CF3N/25U8thRFgs3DqUub1Sf3nG9LrNWdz6ZcDQ="
+    # NOTE: Nix by default uses nixpkgs-unstable channel
     # NOTE: Enable all our tests in cabal
     - ALL_TESTS=yes
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ version: ~> 1.0
 
 language: nix
 
-sudo: required    #  2020-05-26: NOTE: Despite deprecated, but siletly still RAM 4GB -> 7.5GB
+sudo: required    #  2020-05-26: NOTE: This mode is deprecated, but still offers 7.5 GB RAM instead of the default 4GB
 
 git:
   quiet: true # NOTE: Do not log

--- a/.travis.yml
+++ b/.travis.yml
@@ -108,6 +108,9 @@ jobs:
       env: GHCVERSION=ghc8101
     - os: osx
       env: GHCVERSION=ghc865
+    # NOTE: Discard Linux GHC 8.8.3 in favour of macOS GHC 8.8.3, Nixpkgs channel is the same and Nix package code is the same, since we test other Linux deployments and since 8.8.3 builds on macOS - we can be sure it builds inside Nix in Linux also. So lets optimize number of CI builds
+    - os: linux
+      env: GHCVERSION=ghc883
 
 before_script:
   - sudo mount -o remount,exec,size=4G,mode=755 /run/user || true

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ language: nix
 sudo: required    #  2020-05-26: NOTE: Despite deprecated, but siletly still RAM 4GB -> 7.5GB
 
 git:
+  quiet: true # NOTE: Do not log
   depth: 4    # NOTE: "The use of clone depth: 1 often results in a git error
               # when a new commit has been pushed to a branch before the CI
               # platform started cloning the intended commit."

--- a/.travis.yml
+++ b/.travis.yml
@@ -57,6 +57,8 @@ env:
     # NOTE: Generation and installation of a coverage report.
     # See https://wiki.haskell.org/Haskell_program_coverage
     - doCoverage=false
+    # NOTE: Generation and installation of haddock API documentation
+    - doHaddock=false
 
   matrix:
     - GHCVERSION=ghc865 STRICT=false TRACING=false

--- a/.travis.yml
+++ b/.travis.yml
@@ -100,6 +100,14 @@ jobs:
   allow_failures:
     - env: GHCVERSION=ghcjs
     - env: GHCVERSION=ghc8101
+  #  2020-05-26: NOTE: Discard macOS GHCJS build + -> CI loop becomes ~30-40 minutes shorter
+  exclude:
+    - os: osx
+      env: GHCVERSION=ghcjs
+    - os: osx
+      env: GHCVERSION=ghc8101
+    - os: osx
+      env: GHCVERSION=ghc865
 
 before_script:
   - sudo mount -o remount,exec,size=4G,mode=755 /run/user || true

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,6 +52,8 @@ env:
     - ALL_TESTS=yes
     # NOTE: Turn all warn into err with {-Wall,-Werror}
     - failOnAllWarnings=false
+    # NOTE: checkUnusedPackages: is `failOnAllWarnings` + `cabal sdist` to ensure all needed files are listed in the Cabal file. Uses `packunused` or GHC internals. Adds a post-build check to verify that dependencies declared in the cabal file are actually used. The first attrset argument can be used to configure the strictness of this check and a list of ignored package names that would otherwise cause false alarms.
+    - checkUnusedPackages=false
 
   matrix:
     - GHCVERSION=ghc865 STRICT=false TRACING=false

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ version: ~> 1.0
 
 language: nix
 
-sudo: required
+sudo: required    #  2020-05-26: NOTE: Despite deprecated, but siletly still RAM 4GB -> 7.5GB
 
 git:
   depth: 4    # NOTE: "The use of clone depth: 1 often results in a git error

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,3 @@
-os:
-  - linux
-  - osx
 
 language: nix
 
@@ -10,6 +7,11 @@ git:
   depth: 4    # NOTE: "The use of clone depth: 1 often results in a git error
               # when a new commit has been pushed to a branch before the CI
               # platform started cloning the intended commit."
+
+# NOTE: {os} x {jobs} - {exclude} = {build matrix}
+os:
+  - linux
+  - osx
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -72,6 +72,8 @@ env:
     # NOTE: Build the package in a strict way to uncover potential problems. This includes buildFromSdist and failOnAllWarnings.
     #  2020-05-26: NOTE: Currently HNix not able to pass Strict
     - buildStrictly=false
+    # NOTE: Disable core optimizations, significantly speeds up the build
+    - disableOptimization=true
 
   matrix:
     - GHCVERSION=ghc865 STRICT=false TRACING=false

--- a/.travis.yml
+++ b/.travis.yml
@@ -69,6 +69,9 @@ env:
     - enableLibraryProfiling=false
     # NOTE: Build a source distribution tarball instead of using the source files directly. The effect is that the package is built as if it were published on hackage. This can be used as a test for the source distribution, assuming the build fails when packaging mistakes are in the cabal file.
     - buildFromSdist=false
+    # NOTE: Build the package in a strict way to uncover potential problems. This includes buildFromSdist and failOnAllWarnings.
+    #  2020-05-26: NOTE: Currently HNix not able to pass Strict
+    - buildStrictly=false
 
   matrix:
     - GHCVERSION=ghc865 STRICT=false TRACING=false

--- a/.travis.yml
+++ b/.travis.yml
@@ -82,6 +82,8 @@ env:
     #   command: name of an executable
     #       pkg: Haskell package that builds the executables
     - generateOptparseApplicativeCompletion=false
+    # NOTE: Don't fail at configure time if there are multiple versions of the same package in the (recursive) dependencies of the package being built. Will delay failures, if any, to compile time.
+    - allowInconsistentDependencies=false
 
   matrix:
     - GHCVERSION=ghc865 STRICT=false TRACING=false

--- a/.travis.yml
+++ b/.travis.yml
@@ -75,6 +75,13 @@ env:
     # NOTE: Disable core optimizations, significantly speeds up the build
     - disableOptimization=true
     - buildStackProject=false
+    # NOTE: Modify a Haskell package to add shell completion scripts for the given executable produced by it. These completion scripts will be picked up automatically if the resulting derivation is installed, e.g. by `nix-env -i`.
+    # Invocation:
+    #   generateOptparseApplicativeCompletions command pkg
+    #
+    #   command: name of an executable
+    #       pkg: Haskell package that builds the executables
+    - generateOptparseApplicativeCompletion=false
 
   matrix:
     - GHCVERSION=ghc865 STRICT=false TRACING=false

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,8 @@ env:
     # - rev=nixos-unstable
     # # NOTE: Switching into Nixpkgs revision
     # - NIX_PATH="nixpkgs=https://github.com/nixos/nixpkgs/archive/$rev.tar.gz"
+    # NOTE: Project/binary name
+    - name=hnix
     # NOTE: Enable all our tests in cabal
     - ALL_TESTS=yes
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -156,6 +156,7 @@ notifications:
   webhooks:
     urls:
       - https://webhooks.gitter.im/e/b0312b18473340459d3e
+    # NOTE: Be silent about CI, until some PR started to pass CI succesfully.
     on_success: change
     # NOTE: `master` status in on the front page badge.
     on_failure: never

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,9 @@ os:
   - linux
   - osx
 
+#  2020-05-26: NOTE: Currently newest Travis dist Ubuntu 18.04 bionic
+dist: bionic
+
 env:
   global:
     - ALL_TESTS=yes

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,9 @@ os:
 #  2020-05-26: NOTE: Currently newest Travis dist Ubuntu 18.04 bionic
 dist: bionic
 
+# #  2020-05-26: NOTE: Currently newest macOS image
+# osx_image: xcode11.4  # NOTE: Official Nix installer fails spectacularly on it.
+
 env:
   global:
     - ALL_TESTS=yes

--- a/.travis.yml
+++ b/.travis.yml
@@ -153,6 +153,8 @@ script:
 cache:
   directories:
     - /nix/store
+
+# NOTE: Track the commits on this repo branches + cron rechecks build
 branches:
   only:
     - master

--- a/.travis.yml
+++ b/.travis.yml
@@ -95,10 +95,10 @@ env:
     - GHCVERSION=ghc8101
     - GHCVERSION=ghcjs
 
-# 
-# matrix:
-#   allow_failures:
-#     - env: GHCVERSION=ghcjs
+#  2020-05-25: NOTE: We still yet to build this in `master`
+jobs:
+  allow_failures:
+    - env: GHCVERSION=ghcjs
 
 before_script:
   - sudo mount -o remount,exec,size=4G,mode=755 /run/user || true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,7 @@
+#  2020-05-26: NOTE: Enabling experimental Travis feature of YAML check inside
+# Look into: Build #NUM -> Job #NUM.N -> View config -> Build config validation
+version: ~> 1.0
+
 
 language: nix
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@
 # Look into: Build #NUM -> Job #NUM.N -> View config -> Build config validation
 version: ~> 1.0
 
+# NOTE: Please, be aware that Travis YAML & docs & API are hard to make work properly. Travis configuration requires a lot of retries and some compromises. Tere are many ways that may look like that can be done in that way, but it would not work most of the time, or not work the way that you expect, need it. Travis config works only the certain particular ways. Some things look possible - but they are impossible in Travis. Current configuration is "the best way possible" that was found in ~100-150-200 retries, depending on what concider a retry.
+
 
 language: nix
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -125,9 +125,10 @@ script:
   # NOTE: Install Cachix client using Nix:
   - nix-env -iA cachix -f https://cachix.org/api/v1/install
   - cachix use "$name"
+  # NOTE: If key is set - use Cachix push, else - proceed without it
+  - if [ ! "$CACHIX_SIGNING_KEY" = "" ]; then cachix push "$name" --watch-store& fi
   #
   #
-  - if [ ! "$CACHIX_SIGNING_KEY" = "" ]; then cachix push hnix --watch-store& fi
   - if [ ! "$CACHIX_SIGNING_KEY" = "" ]; then ./build.sh | cachix push hnix; else ./build.sh; fi
 
 branches:

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,6 +50,8 @@ env:
     - pkgName='haskellPackages.hnix'
     # NOTE: Enable all our tests in cabal
     - ALL_TESTS=yes
+    # NOTE: Turn all warn into err with {-Wall,-Werror}
+    - failOnAllWarnings=false
 
   matrix:
     - GHCVERSION=ghc865 STRICT=false TRACING=false

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,6 +59,8 @@ env:
     - doCoverage=false
     # NOTE: Generation and installation of haddock API documentation
     - doHaddock=false
+    # NOTE: Escape the version bounds from the cabal file. You may want to avoid this function.
+    - doJailbreak=false
 
   matrix:
     - GHCVERSION=ghc865 STRICT=false TRACING=false

--- a/.travis.yml
+++ b/.travis.yml
@@ -99,6 +99,7 @@ env:
 jobs:
   allow_failures:
     - env: GHCVERSION=ghcjs
+    - env: GHCVERSION=ghc8101
 
 before_script:
   - sudo mount -o remount,exec,size=4G,mode=755 /run/user || true

--- a/.travis.yml
+++ b/.travis.yml
@@ -127,6 +127,8 @@ script:
   - cachix use "$name"
   # NOTE: If key is set - use Cachix push, else - proceed without it
   - if [ ! "$CACHIX_SIGNING_KEY" = "" ]; then cachix push "$name" --watch-store& fi
+  # NOTE: Brush timeout for previous daemon to start
+  - sleep 2
   #
   #
   - if [ ! "$CACHIX_SIGNING_KEY" = "" ]; then ./build.sh | cachix push hnix; else ./build.sh; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@
 # Look into: Build #NUM -> Job #NUM.N -> View config -> Build config validation
 version: ~> 1.0
 
-# NOTE: Please, be aware that Travis YAML & docs & API are hard to make work properly. Travis configuration requires a lot of retries and some compromises. Tere are many ways that may look like that can be done in that way, but it would not work most of the time, or not work the way that you expect, need it. Travis config works only the certain particular ways. Some things look possible - but they are impossible in Travis. Current configuration is "the best way possible" that was found in ~100-150-200 retries, depending on what concider a retry.
+# NOTE: Please, be aware that Travis YAML & docs & API are hard to make work properly. Travis configuration requires a lot of retries and some compromises. There are many ways that may look like that can be done in that way, but it would not work most of the time, or not work the way that you expect/need it. Travis config works only in certain particular ways. Some things look possible - but they are impossible in Travis. Current configuration is "the best way possible" that was found in ~100-150-200 retries, depending on what one considers a retry.
 
 # NOTE: Let the official Travis YAML checker help you: https://config.travis-ci.com/explore
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,8 +29,9 @@ dist: bionic
 
 env:
   global:
-    - ALL_TESTS=yes
     - secure: "dm6I+M4+V+C7QMTpcSADdKPE633SvmToXZrTbZ7miNDGmMN+/SfHeN2ybi1+PW6oViMlbPN/7J/aEfiGjSJI8vLk72Y4uCWGmpSb8TXZLu6+whnxtZzzW8+z4tsM4048QJg7CF3N/25U8thRFgs3DqUub1Sf3nG9LrNWdz6ZcDQ="
+    # NOTE: Enable all our tests in cabal
+    - ALL_TESTS=yes
 
   matrix:
     - GHCVERSION=ghc865 STRICT=false TRACING=false

--- a/.travis.yml
+++ b/.travis.yml
@@ -88,10 +88,11 @@ env:
     - ghcjsTmpLogFile='/tmp/ghcjsTmpLogFile.jog'
     # NOTE: Length of the GHCJS log tail (<40000)
     - ghcjsLogTailLength=10000
+  # NOTE: {os} x {jobs} - {exclude} = {build matrix}
+  jobs:
+    - GHCVERSION=ghc865
+    - GHCVERSION=ghcjs
 
-  matrix:
-    - GHCVERSION=ghc865 STRICT=false TRACING=false
-#     - GHCVERSION=ghcjs
 # 
 # matrix:
 #   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -147,6 +147,12 @@ script:
   #
   #
 
+# NOTE: Travis cache allows near fast cache loading of Nix pkgs store,
+# Since the Cachix does not cache PRs - Travis cache is great because it caches PR branch builds
+# During devepment of this PR I had ~40GB cache on the PR branch.
+cache:
+  directories:
+    - /nix/store
 branches:
   only:
     - master

--- a/build.sh
+++ b/build.sh
@@ -6,10 +6,6 @@ set -xe
 set -euo pipefail
 IFS=$'\n\t'
 
-STRICT=${STRICT:-false}
-TRACING=${TRACING:-false}
-NIX_PATH=nixpkgs=https://github.com/NixOS/nixpkgs/archive/6820e2f0dd16104961d6fc7e8e38846807159c4e.tar.gz
-
 if [ "$GHCVERSION" = "ghcjs" ]; then
     nix-build --substituters 'https://nixcache.reflex-frp.org?trusted=1' ghcjs
 else

--- a/build.sh
+++ b/build.sh
@@ -2,6 +2,7 @@
 
 # NOTE: Script for the CI builds. CI comes here from `.travis.yml`
 
+BUILD_PROJECT(){
 set -xe
 set -euo pipefail
 IFS=$'\n\t'
@@ -40,6 +41,8 @@ generateOptparseApplicativeCompletion=${generateOptparseApplicativeCompletion:-'
 allowInconsistentDependencies=${allowInconsistentDependencies:-'false'}
 ghcjsTmpLogFile=${ghcjsTmpLogFile:-'/tmp/ghcjsTmpLogFile.jog'}
 ghcjsLogTailLength=${ghcjsLogTailLength:-'10000'}
+
+}
 
 MAIN() {
 

--- a/build.sh
+++ b/build.sh
@@ -65,6 +65,17 @@ allowInconsistentDependencies=${allowInconsistentDependencies:-'false'}
 ghcjsTmpLogFile=${ghcjsTmpLogFile:-'/tmp/ghcjsTmpLogFile.jog'}
 ghcjsLogTailLength=${ghcjsLogTailLength:-'10000'}
 
+
+if [ "$generateOptparseApplicativeCompletion" = 'true' ]
+  then
+    # NOTE: Enable shell complition generation
+    generateOptparseApplicativeCompletion="--arg generateOptparseApplicativeCompletion $name $pkgName"
+  else
+    # NOTE: Skip the shell complition generation
+    generateOptparseApplicativeCompletion=''
+fi
+
+
 if [ "$GHCVERSION" = "ghcjs" ]
   then
 

--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+# NOTE: Script for the CI builds. CI comes here from `.travis.yml`
+
 set -xe
 set -euo pipefail
 IFS=$'\n\t'

--- a/build.sh
+++ b/build.sh
@@ -11,7 +11,7 @@ GHCJS_BUILD(){
 }
 
 SILENT(){
-# NOTE: Funtion that silences the build process
+# NOTE: Function that silences the build process
 # In normal mode outputs only the /nix/store paths
 
   echo "Log: $ghcjsTmpLogFile"
@@ -158,4 +158,3 @@ MAIN() {
 
 # NOTE: Run the entry function of the script
 MAIN
-

--- a/build.sh
+++ b/build.sh
@@ -7,15 +7,6 @@ set -xe
 set -euo pipefail
 IFS=$'\n\t'
 
-if [ "$GHCVERSION" = "ghcjs" ]; then
-    nix-build --substituters 'https://nixcache.reflex-frp.org?trusted=1' ghcjs
-else
-    nix-build                                   \
-        --argstr compiler $GHCVERSION           \
-        --arg doTracing $TRACING                \
-        --arg doStrict $STRICT                  \
-        $@
-fi
 # NOTE: If var not imported - set to the default value
 GHCVERSION=${GHCVERSION:-ghc865}
 rev=${rev:-nixpkgs-unstable}
@@ -42,6 +33,34 @@ allowInconsistentDependencies=${allowInconsistentDependencies:-'false'}
 ghcjsTmpLogFile=${ghcjsTmpLogFile:-'/tmp/ghcjsTmpLogFile.jog'}
 ghcjsLogTailLength=${ghcjsLogTailLength:-'10000'}
 
+if [ "$GHCVERSION" = "ghcjs" ]; then
+    nix-build --substituters 'https://nixcache.reflex-frp.org?trusted=1' ghcjs
+  else
+
+    # NOTE: Normal GHC build
+    # NOTE: GHC sometimes produces logs so big - that Travis terminates builds, so multiple --quiet
+    nix-build                                                \
+      --quiet --quiet                                        \
+      --argstr compiler "$GHCVERSION"                        \
+      --arg failOnAllWarnings "$failOnAllWarnings"           \
+      --arg buildStrictly "$buildStrictly"                   \
+      --arg checkUnusedPackages "$checkUnusedPackages"       \
+      --arg doCoverage "$doCoverage" \
+      --arg doHaddock "$doHaddock" \
+      --arg doJailbreak "$doJailbreak" \
+      --arg doCheck "$doCheck" \
+      --arg doBenchmark "$doBenchmark" \
+      --arg enableExecutableProfiling "$enableExecutableProfiling" \
+      --arg enableLibraryProfiling "$enableLibraryProfiling" \
+      --arg buildFromSdist "$buildFromSdist" \
+      --arg buildStrictly "$buildStrictly" \
+      --arg disableOptimization "$disableOptimization" \
+      --arg buildStackProject "$buildStackProject" \
+      "$generateOptparseApplicativeCompletion" \
+      --arg allowInconsistentDependencies "$allowInconsistentDependencies" \
+      "$@"
+
+fi
 }
 
 MAIN() {

--- a/build.sh
+++ b/build.sh
@@ -68,7 +68,7 @@ ghcjsLogTailLength=${ghcjsLogTailLength:-'10000'}
 
 if [ "$generateOptparseApplicativeCompletion" = 'true' ]
   then
-    # NOTE: Enable shell complition generation
+    # NOTE: Enable shell completion generation
     generateOptparseApplicativeCompletion="--arg generateOptparseApplicativeCompletion $name $pkgName"
   else
     # NOTE: Skip the shell complition generation

--- a/build.sh
+++ b/build.sh
@@ -71,7 +71,7 @@ if [ "$generateOptparseApplicativeCompletion" = 'true' ]
     # NOTE: Enable shell completion generation
     generateOptparseApplicativeCompletion="--arg generateOptparseApplicativeCompletion $name $pkgName"
   else
-    # NOTE: Skip the shell complition generation
+    # NOTE: Skip the shell completion generation
     generateOptparseApplicativeCompletion=''
 fi
 

--- a/build.sh
+++ b/build.sh
@@ -2,6 +2,14 @@
 
 # NOTE: Script for the CI builds. CI comes here from `.travis.yml`
 
+GHCJS_BUILD(){
+# NOTE: Function for GHCJS build that outputs its huge log into a file
+
+  # NOTE: Run the build into Log (log is too long for Travis)
+  "$@" &> "$ghcjsTmpLogFile"
+
+}
+
 BUILD_PROJECT(){
 set -xe
 set -euo pipefail

--- a/build.sh
+++ b/build.sh
@@ -66,6 +66,7 @@ ghcjsTmpLogFile=${ghcjsTmpLogFile:-'/tmp/ghcjsTmpLogFile.jog'}
 ghcjsLogTailLength=${ghcjsLogTailLength:-'10000'}
 
 
+# NOTE: Resulting value injects into `nix-build` commands
 if [ "$generateOptparseApplicativeCompletion" = 'true' ]
   then
     # NOTE: Enable shell completion generation

--- a/build.sh
+++ b/build.sh
@@ -10,6 +10,30 @@ GHCJS_BUILD(){
 
 }
 
+SILENT(){
+# NOTE: Funtion that silences the build process
+# In normal mode outputs only the /nix/store paths
+
+  echo "Log: $ghcjsTmpLogFile"
+  # NOTE: Pass into the ghcjsbuild function the build command
+  if GHCJS_BUILD "$@"
+  then
+
+    # NOTE: Output log lines for stdout -> cachix caching
+    grep '^/nix/store/' "$ghcjsTmpLogFile"
+
+  else
+
+    # NOTE: Output log lines for stdout -> cachix caching
+    grep '^/nix/store/' "$ghcjsTmpLogFile"
+
+    # NOTE: Propagate the error state, fail the CI build
+    exit 1
+
+  fi
+
+}
+
 BUILD_PROJECT(){
 set -xe
 set -euo pipefail

--- a/build.sh
+++ b/build.sh
@@ -14,5 +14,30 @@ else
         --arg doTracing $TRACING                \
         --arg doStrict $STRICT                  \
         $@
-GHCVERSION=${GHCVERSION:-ghc865}
 fi
+# NOTE: If var not imported - set to the default value
+GHCVERSION=${GHCVERSION:-ghc865}
+rev=${rev:-nixpkgs-unstable}
+NIX_PATH=${NIX_PATH:-"nixpkgs=https://github.com/nixos/nixpkgs/archive/$rev.tar.gz"}
+export NIX_PATH
+name=${name:-defaultBinaryName}
+pkgName=${pkgName:-defaultPkgName}
+failOnAllWarnings=${failOnAllWarnings:-'false'}
+checkUnusedPackages=${checkUnusedPackages:-'false'}
+doCoverage=${doCoverage:-'false'}
+doHaddock=${doHaddock:-'false'}
+doJailbreak=${doJailbreak:-'false'}
+doCheck=${doCheck:-'true'}
+doBenchmark=${doBenchmark:-'false'}
+enableExecutableProfiling=${enableExecutableProfiling:-'false'}
+enableLibraryProfiling=${enableLibraryProfiling:-'false'}
+buildFromSdist=${buildFromSdist:-'false'}
+buildStrictly=${buildStrictly:-'false'}
+disableOptimization=${disableOptimization:-'true'}
+buildStackProject=${buildStackProject:-'false'}
+# NOTE: *Oprparse* key is redifined in the code further
+generateOptparseApplicativeCompletion=${generateOptparseApplicativeCompletion:-'false'}
+allowInconsistentDependencies=${allowInconsistentDependencies:-'false'}
+ghcjsTmpLogFile=${ghcjsTmpLogFile:-'/tmp/ghcjsTmpLogFile.jog'}
+ghcjsLogTailLength=${ghcjsLogTailLength:-'10000'}
+

--- a/build.sh
+++ b/build.sh
@@ -41,3 +41,27 @@ allowInconsistentDependencies=${allowInconsistentDependencies:-'false'}
 ghcjsTmpLogFile=${ghcjsTmpLogFile:-'/tmp/ghcjsTmpLogFile.jog'}
 ghcjsLogTailLength=${ghcjsLogTailLength:-'10000'}
 
+MAIN() {
+
+# NOTE: Secrets are not shared to PRs from forks
+# NOTE: nix-build | cachix push <name> - uploads binaries, runs&works only in the branches of the main repository, so for PRs - else case runs
+
+  if [ ! "$CACHIX_SIGNING_KEY" = "" ]
+
+    then
+
+      # NOTE: Build of the inside repo branch - enable push Cachix cache
+      BUILD_PROJECT | cachix push "$name"
+
+    else
+
+      # NOTE: Build of the side repo/PR - can not push Cachix cache
+      BUILD_PROJECT
+
+  fi
+
+}
+
+# NOTE: Run the entry function of the script
+MAIN
+

--- a/build.sh
+++ b/build.sh
@@ -65,8 +65,37 @@ allowInconsistentDependencies=${allowInconsistentDependencies:-'false'}
 ghcjsTmpLogFile=${ghcjsTmpLogFile:-'/tmp/ghcjsTmpLogFile.jog'}
 ghcjsLogTailLength=${ghcjsLogTailLength:-'10000'}
 
-if [ "$GHCVERSION" = "ghcjs" ]; then
-    nix-build --substituters 'https://nixcache.reflex-frp.org?trusted=1' ghcjs
+if [ "$GHCVERSION" = "ghcjs" ]
+  then
+
+    # NOTE: GHC JS build
+    # Bu itselt GHC JS build every tine creates >65000 line logs that are >4MB in size, so Travis terminates due to log size quota.
+    # nixbuild --quiet (x5) does not work on GHC JS build
+    # So there was a need to make it build.
+    # Solution - is to silence the stdout
+    # But Travis then terminates on 10 min no stdout timeout
+    # so HACK: SILENT wrapper allows to surpress the huge log, while still preserves the Cachix caching ability in any case of the build
+    # On build failure outputs the last 10000 lines of log (that should be more then enough), and terminates
+    SILENT nix-build                                         \
+      --arg failOnAllWarnings "$failOnAllWarnings"           \
+      --arg buildStrictly "$buildStrictly"                   \
+      --arg checkUnusedPackages "$checkUnusedPackages"       \
+      --arg doCoverage "$doCoverage" \
+      --arg doHaddock "$doHaddock" \
+      --arg doJailbreak "$doJailbreak" \
+      --arg doCheck "$doCheck" \
+      --arg doBenchmark "$doBenchmark" \
+      --arg enableExecutableProfiling "$enableExecutableProfiling" \
+      --arg enableLibraryProfiling "$enableLibraryProfiling" \
+      --arg buildFromSdist "$buildFromSdist" \
+      --arg buildStrictly "$buildStrictly" \
+      --arg disableOptimization "$disableOptimization" \
+      --arg buildStackProject "$buildStackProject" \
+      "$generateOptparseApplicativeCompletion" \
+      --arg allowInconsistentDependencies "$allowInconsistentDependencies" \
+      ghcjs \
+      "$@"
+
   else
 
     # NOTE: Normal GHC build

--- a/build.sh
+++ b/build.sh
@@ -79,11 +79,11 @@ fi
 if [ "$GHCVERSION" = "ghcjs" ]
   then
 
-    # NOTE: GHC JS build
-    # Bu itselt GHC JS build every tine creates >65000 line logs that are >4MB in size, so Travis terminates due to log size quota.
+    # NOTE: GHCJS build
+    # By itself, GHCJS creates >65000 lines of log that are >4MB in size, so Travis terminates due to log size quota.
     # nixbuild --quiet (x5) does not work on GHC JS build
     # So there was a need to make it build.
-    # Solution - is to silence the stdout
+    # The solution is to silence the stdout
     # But Travis then terminates on 10 min no stdout timeout
     # so HACK: SILENT wrapper allows to surpress the huge log, while still preserves the Cachix caching ability in any case of the build
     # On build failure outputs the last 10000 lines of log (that should be more then enough), and terminates

--- a/build.sh
+++ b/build.sh
@@ -6,7 +6,6 @@ set -xe
 set -euo pipefail
 IFS=$'\n\t'
 
-GHCVERSION=${GHCVERSION:-ghc822}
 STRICT=${STRICT:-false}
 TRACING=${TRACING:-false}
 NIX_PATH=nixpkgs=https://github.com/NixOS/nixpkgs/archive/6820e2f0dd16104961d6fc7e8e38846807159c4e.tar.gz
@@ -19,4 +18,5 @@ else
         --arg doTracing $TRACING                \
         --arg doStrict $STRICT                  \
         $@
+GHCVERSION=${GHCVERSION:-ghc865}
 fi


### PR DESCRIPTION
#### No time to explain!..

Report: https://github.com/haskell-nix/hnix/issues/581

See how latest `CI: Travis` PRs are builing: https://travis-ci.org/github/haskell-nix/hnix/pull_requests

#### CI improvements summary

  :heavy_check_mark: Code in PR is very-very close to the best Travis configuration code possible. Travis YAML API is so hard to put together so reacts properly.
  :heavy_check_mark: Have both Travis and Cachix caching systems. Travis is an internal fast cache sharing inside PR during dev, Cachix shares caches over the whole project.
  :heavy_check_mark: GHC {JS, 8.6.5, 8.8.3, 8.10.1} x {Linux, macOS, and possible Windows}.
  :heavy_check_mark: GHC 8.8.3 already builds by CI both on Linux and macOS :+1: 
  :heavy_check_mark: GHC {JS, 8.10.1} for now optional, as `master` does not pass CI currently.
    * Currently I've chosen to disable macOS GHC{JS, 8.6.5, 8.10.1}. Since: macOS compilations take 1.5-2 times longer, it does not have Hydra CI cache currently, Travis has less active threads for macOS, and they not very needed from my GNU/Linux/NixOS/Emacs point of view. Disabling at least some macOS builds, if not all except the one most important - makes CI build loops `x2-x3` times faster (remember - Hydra CI has a no cache for them, they recompile deps). So - we better check all GHCs on Linux first. Those are the most important production environments and Travis is fast on them. And make macOS build/s - optional CI builds - that would allow making CI checks go even faster. I do not think we claim macOS support currently in the project, we make it available and ready to accept improvements. So we can make macOS build/s optional, and enable fast pass when required builds passed, with the additional macOS builds available to look into.
  :heavy_check_mark: Reduced the level of logging to fit builds into the Travis logging size quotas, so build have a smaller log and builds pass successfully.
  :heavy_check_mark: GHCJS: its build always produces `>4MB` log and Travis terminates on ~55000 lines. And `nix-build --quiet --quiet --quiet --quiet` - does not work on GHCJS. So - I HACKed silencer.
  :heavy_check_mark: GHCJS: HACK: I've silenced its build, but Travis terminates on silence `>10 minutes`, so provided waiting up to `50 minutes` (all free tier build time)
  :heavy_check_mark: GHCJS: HACK: Made so silencer still emits `/nix/store` paths, so Cachix would cache even this hacked GHCJS builds.
  :heavy_check_mark: GHCJS: HACK: Made so this hack only corresponds to GHC JS, normal GHC builds produce logs normally.
    * GHCJS: HACK: There is no tradeoff in functionality, minor tradeoff - is the additional `shell` code and separate build step.
  :heavy_check_mark: GHCJS: now it builds terminate normally, and we indeed can use CI to track its tai logs: https://travis-ci.org/github/haskell-nix/hnix/jobs/691892714
  :heavy_check_mark: Reduced level of build notifications into HNix Gitter to the sanest level of informing only when some PR build starts to pass.
  :heavy_check_mark: Detailed useful documentation on what are those Travis keys and with date info where they are relevant
  :heavy_check_mark: Updated `cachix` from some old 0.1 2018 version to always be the current version.
  :heavy_check_mark: Now there is no 2 year old `NIX_PATH` override in the old `./build.sh`
  :heavy_check_mark: Now the CI uses up-to date `nixpkgs-unstable` that all Nix installers use by default -> newer versions, better caching
  :heavy_check_mark: Provided option to switch Nixpkgs/Hydra CI channels and documentation on it. We may switch into `nixos-unstable` or even into `nixos-20.03` to have more stability of CI builds and even better Hydra CI caches.
  :heavy_check_mark: Once we merge this - due to usage of proper revisions of Nixpkgs and proper caching - we would receive most builds ready from NixOS Hydra CI CDN, and the rest of CI builds would cache into Travis, and what CI would build on master - would be cache on Cachix.
  :heavy_check_mark: Since we would have sync-up: NixOS Hydra CI, our CI, master, Cachix - we would have faster CI builds overall.
  :heavy_check_mark: With a power of Nixpkgs, straight hands, and Emacs macros - too many new features to count:

All CI functionality and its explanation is exposed as an API in the header of the `.travis.yml`. Then those environmental variables are imported into build.sh.
Those keys are the literal functionality API of https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/haskell-modules/lib.nix

```yaml
  # NOTE: Turn all warn into err with {-Wall,-Werror}
  - failOnAllWarnings=false
  # NOTE: failOnAllWarnings + `cabal sdist` to ensure all needed files are listed in the Cabal file. Uses `packunused` or GHC internals. Adds a post-build check to verify that dependencies declared in the cabal file are actually used. The first attrset argument can be used to configure the strictness of this check and a list of ignored package names that would otherwise cause false alarms.
  - checkUnusedPackages=false
  # NOTE: Generation and installation of a coverage report.
  # See https://wiki.haskell.org/Haskell_program_coverage
  - doCoverage=false
  # NOTE: Generation and installation of haddock API documentation
  - doHaddock=false
  # NOTE: Escape the version bounds from the cabal file. You may want to avoid this function.
  - doJailbreak=false
  # NOTE: Disables dependency checking, compilation and execution of test suites listed in the package description file.
  - doCheck=true
  # NOTE: Dependency checking, compilation and execution for benchmarks listed in the package description file.
  - doBenchmark=false
  - enableExecutableProfiling=false
  - enableLibraryProfiling=false
  # NOTE: Build a source distribution tarball instead of using the source files directly. The effect is that the package is built as if it were published on hackage. This can be used as a test for the source distribution, assuming the build fails when packaging mistakes are in the cabal file.
  - buildFromSdist=false
  # NOTE: Build the package in a strict way to uncover potential problems. This includes buildFromSdist and failOnAllWarnings.
  #  2020-05-26: NOTE: Currently HNix not able to pass Strict
  - buildStrictly=false
  # NOTE: Disable core optimizations, significantly speeds up build time
  - disableOptimization=true
  - buildStackProject=false
  # NOTE: Modify a Haskell package to add shell completion scripts for the given executable produced by it. These completion scripts will be picked up automatically if the resulting derivation is installed, e.g. by `nix-env -i`.
  # Invocation:
  #   generateOptparseApplicativeCompletions command pkg
  # 
  #   command: name of an executable
  #       pkg: Haskell package that builds the executables
  - generateOptparseApplicativeCompletion=false
  # NOTE: Don't fail at configure time if there are multiple versions of the same package in the (recursive) dependencies of the package being built. Will delay failures, if any, to compile time.
  - allowInconsistentDependencies=false
```

![Did I automate Travis CI enough](https://user-images.githubusercontent.com/20933385/83078264-e0257d00-a081-11ea-9d64-e2cd2e994c03.jpg)

---

#### Nix macOS installer woes:

  :heavy_multiplication_x:  Nix installer fails on Travis `osx_image: xcode11.4`: https://travis-ci.org/github/haskell-nix/hnix/jobs/691353904. So that error restricts us to use only old Travis `osx` default image: https://docs.travis-ci.com/user/reference/osx/#macos-version
  :heavy_multiplication_x:  Currently macOs Nix installer sometimes results into `error: the user 'nixbld5' in the group 'nixbld' does not exist` from time to time even in default image: https://travis-ci.org/github/haskell-nix/hnix/jobs/691391039
  * There are blog posts that fixes the macOS installer: https://dev.to/louy2/installing-nix-on-macos-catalina-2acb, maybe we should use those unofficial patches

---

#### Travis

Travis, as always, hard to put together so it works properly. Took a lot of time and ~150-200 retries.
Every time Travis is a long journey to assemble somewhat good.

---

M  .travis.yml
M  .build.sh

---

We would probably be able to reuse most of this if we happen to migrate to some other CIs. I would also evaluate them over time.

I've spend couple of days on this, thank you.
