### PR TITLE
Fix build failure in Nix.Var

### DIFF
--- a/hnix.cabal
+++ b/hnix.cabal
@@ -860,7 +860,6 @@ library
     , contravariant >= 1.5 && < 1.6
     , data-fix >= 0.2.0 && <  0.3
     , deepseq >=1.4.3 && <1.5
-    , dependent-sum >= 0.4 && < 0.5 || >= 0.6.2.0 && < 0.8
     , deriving-compat >=0.3 && <0.6
     , directory >= 1.3.1 && < 1.4
     , exceptions >= 0.10.0 && < 0.11
@@ -891,6 +890,7 @@ library
     , semialign >= 1 && < 1.2
     , semialign-indexed >= 1 && < 1.2
     , semigroups >=0.18 && <0.19 || >= 0.19.1 && < 0.20
+    , some >= 1.0.1 && < 1.1
     , split >= 0.2.3 && < 0.3
     , syb >= 0.7 && < 0.8
     , template-haskell
@@ -995,7 +995,6 @@ test-suite hnix-tests
     , cryptohash-sha512
     , data-fix
     , deepseq >=1.4.3 && <1.5
-    , dependent-sum
     , directory
     , exceptions
     , filepath

--- a/src/Nix/Var.hs
+++ b/src/Nix/Var.hs
@@ -12,6 +12,7 @@ import           Data.GADT.Compare
 import           Data.IORef
 import           Data.Maybe
 import           Data.STRef
+import           Type.Reflection ((:~:)(Refl))
 
 import           Unsafe.Coerce
 


### PR DESCRIPTION
The `Refl` constructor had previously been re-exported from
`Data.GADT.Compare`.

This also replaces the dependency on `dependent-sum` with `some`,
where the `Data.GADT.Compare` module is now defined.

Tested by building locally with GHC 8.4.4, 8.6.5 and 8.8.3 in `cabal`.

Fixes #585.