### PR TITLE
CI: Travis: upd: make GHC 8.10 mandatory, since it passes build in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -99,7 +99,6 @@ env:
 jobs:
   allow_failures:
     - env: GHCVERSION=ghcjs
-    - env: GHCVERSION=ghc8101
   #  2020-05-26: NOTE: Discard macOS GHCJS build + -> CI loop becomes ~30-40 minutes shorter
   exclude:
     - os: osx


### PR DESCRIPTION
Relates to Report: #592 

We got a successful CI build of GHC 8.10!

Let us stabilize on it, and make further checks and accordance of us to the newest compiler mandatory.