### PR TITLE
CI: Travis: upd: add mandatory distributive packaging check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -68,7 +68,7 @@ env:
     - enableExecutableProfiling=false
     - enableLibraryProfiling=false
     # NOTE: Build a source distribution tarball instead of using the source files directly. The effect is that the package is built as if it were published on hackage. This can be used as a test for the source distribution, assuming the build fails when packaging mistakes are in the cabal file.
-    - buildFromSdist=false
+    - buildFromSdist=true
     # NOTE: Build the package in a strict way to uncover potential problems. This includes buildFromSdist and failOnAllWarnings.
     #  2020-05-26: NOTE: Currently HNix not able to pass Strict
     - buildStrictly=false


### PR DESCRIPTION
Since HNix has problems with Hackage - this should attend to that.

 :eyes: Lets observe the build