### PR TITLE
Travis: Add CI job with linux and GHC-8.4.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -90,6 +90,7 @@ env:
     - ghcjsLogTailLength=10000
   # NOTE: {os} x {jobs} - {exclude} = {build matrix}
   jobs:
+    - GHCVERSION=ghc844
     - GHCVERSION=ghc865
     - GHCVERSION=ghc883
     - GHCVERSION=ghc8101
@@ -108,6 +109,8 @@ jobs:
       env: GHCVERSION=ghc8101
     - os: osx
       env: GHCVERSION=ghc865
+    - os: osx
+      env: GHCVERSION=ghc844
     # NOTE: Discard Linux GHC 8.8.3 in favour of macOS GHC 8.8.3, Nixpkgs channel is the same and Nix package code is the same, since we test other Linux deployments and since 8.8.3 builds on macOS - we can be sure it builds inside Nix in Linux also. So lets optimize number of CI builds
     - os: linux
       env: GHCVERSION=ghc883


### PR DESCRIPTION
GHC 8.4 is still widely used, so it's good to check compatibility
with it.