### PR TITLE
dafault.nix: GHC 8.8.3 as default; provide an easy part of the haskell.lib API

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -30,6 +30,8 @@ generateOptparseApplicativeCompletions=${generateOptparseApplicativeCompletions:
 allowInconsistentDependencies=${allowInconsistentDependencies:-'false'}
 ghcjsTmpLogFile=${ghcjsTmpLogFile:-'/tmp/ghcjsTmpLogFile.log'}
 ghcjsLogTailLength=${ghcjsLogTailLength:-'10000'}
+# NOTE: If key not provided (branch is not inside the central repo) - init CACHIX_SIGNING_KEY as empty
+CACHIX_SIGNING_KEY=${CACHIX_SIGNING_KEY:-""}
 
 
 GHCJS_BUILD(){

--- a/default.nix
+++ b/default.nix
@@ -1,14 +1,21 @@
 { compiler    ? "ghc883"
 
+# doBenchmark: Dependency checking + compilation and execution for benchmarks listed in the package description file.
 , doBenchmark ? false
+# Generation and installation of a coverage report.
+# See https://wiki.haskell.org/Haskell_program_coverage
 , doCoverage  ? false
+# Generation and installation of haddock API documentation
 , doHaddock   ? false
+# Nix dependency checking, compilation and execution of test suites listed in the package description file.
 , doCheck     ? true
 , enableLibraryProfiling ? false
 , enableExecutableProfiling ? false
 , doTracing   ? false
-, doOptimize  ? false # enables GHC optimizations for production use
+# Enables GHC optimizations for production use, without optimizations compilation is way faster
+, doOptimize  ? false
 , doStrict    ? false
+# Escape the version bounds from the cabal file. You may want to avoid this function.
 , doJailbreak ? false
 , enableSharedExecutables ? true
 , enableSharedLibraries ? true
@@ -17,6 +24,7 @@
 , doHyperlinkSource ? false
 , doStrip ? false
 , justStaticExecutables ? false
+# Don't fail at configure time if there are multiple versions of the same package in the (recursive) dependencies of the package being built. Will delay failures, if any, to compile time.
 , allowInconsistentDependencies ? false
 
 , withHoogle  ? true

--- a/default.nix
+++ b/default.nix
@@ -18,7 +18,6 @@
     else import (builtins.fetchTarball {
            url = "https://github.com/NixOS/nixpkgs/archive/${rev}.tar.gz";
            inherit sha256; }) {
-      config.allowUnfree = true;
       config.allowBroken = true;
       # config.packageOverrides = pkgs: rec {
       #   nix = pkgs.nixStable.overrideDerivation (attrs: with pkgs; rec {

--- a/default.nix
+++ b/default.nix
@@ -9,6 +9,15 @@
 , doTracing   ? false
 , doOptimize  ? false # enables GHC optimizations for production use
 , doStrict    ? false
+, doJailbreak ? false
+, enableSharedExecutables ? true
+, enableSharedLibraries ? true
+, enableStaticLibraries ? false
+, enableDeadCodeElimination ? true
+, doHyperlinkSource ? false
+, doStrip ? false
+, justStaticExecutables ? false
+, allowInconsistentDependencies ? false
 
 , withHoogle  ? true
 

--- a/default.nix
+++ b/default.nix
@@ -1,9 +1,10 @@
 
 , doBenchmark ? false
 { compiler    ? "ghc883"
+, enableLibraryProfiling ? false
+, enableExecutableProfiling ? false
 , doTracing   ? false
 , doOptimize  ? false # enables GHC optimizations for production use
-, doProfiling ? false # enables profiling support in GHC
 , doStrict    ? false
 
 , withHoogle  ? true
@@ -99,15 +100,14 @@ in haskellPackages.developPackage {
       haskellPackages.cabal-install
     ];
 
-    enableLibraryProfiling = doProfiling;
-    enableExecutableProfiling = doProfiling;
-
     testHaskellDepends = attrs.testHaskellDepends ++ [
       pkgs.nix
       haskellPackages.criterion
     ];
 
     inherit doBenchmark;
+    inherit enableLibraryProfiling;
+    inherit enableExecutableProfiling;
 
     configureFlags =
          pkgs.stdenv.lib.optional doTracing  "--flags=tracing"

--- a/default.nix
+++ b/default.nix
@@ -1,6 +1,6 @@
-{ compiler    ? "ghc865"
 
 , doBenchmark ? false
+{ compiler    ? "ghc883"
 , doTracing   ? false
 , doOptimize  ? false # enables GHC optimizations for production use
 , doProfiling ? false # enables profiling support in GHC

--- a/default.nix
+++ b/default.nix
@@ -1,6 +1,9 @@
+{ compiler    ? "ghc883"
 
 , doBenchmark ? false
-{ compiler    ? "ghc883"
+, doCoverage  ? false
+, doHaddock   ? false
+, doCheck     ? true
 , enableLibraryProfiling ? false
 , enableExecutableProfiling ? false
 , doTracing   ? false
@@ -106,6 +109,9 @@ in haskellPackages.developPackage {
     ];
 
     inherit doBenchmark;
+    inherit doCoverage;
+    inherit doHaddock;
+    inherit doCheck;
     inherit enableLibraryProfiling;
     inherit enableExecutableProfiling;
 


### PR DESCRIPTION
This would also make according to options in the CI work.

`doStrict` is ancient deprecated Nixpkgs option name, that is not used in Nixpkgs, nor in our `default.nix`, it is empty option.

For introduction `haskell.lib` options in CI before here. Sorry, that it is backward, I relearn the design flaws of Nix and its tooling usage again and again over the years.

These options provided - would start to work in CI now.

The rest of the options I would send-in PRs further.

---

Descriptions work, `nix-shell` works, `nix-build` works, project compiles, tests, benchmarks, profiles, with them enabled.