### PR TITLE
default.nix: follow local default <nixpkgs> by default, allow {optional,rolling} `rev`

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -109,8 +109,7 @@ if [ "$GHCVERSION" = "ghcjs" ]
       --arg buildStackProject "$buildStackProject" \
       "$generateOptparseApplicativeCompletion" \
       --arg allowInconsistentDependencies "$allowInconsistentDependencies" \
-      ghcjs \
-      "$@"
+      ghcjs
 
   else
 
@@ -134,8 +133,7 @@ if [ "$GHCVERSION" = "ghcjs" ]
       --arg disableOptimization "$disableOptimization" \
       --arg buildStackProject "$buildStackProject" \
       "$generateOptparseApplicativeCompletion" \
-      --arg allowInconsistentDependencies "$allowInconsistentDependencies" \
-      "$@"
+      --arg allowInconsistentDependencies "$allowInconsistentDependencies"
 
 fi
 }

--- a/build.sh
+++ b/build.sh
@@ -148,6 +148,10 @@ nix upgrade-nix || true
 # NOTE: Superuser update for macOS setup
 sudo nix upgrade-nix || true
 
+# NOTE: Make channels current
+nix-channel --update || true
+sudo nix-channel --update || true
+
 
 # NOTE: Secrets are not shared to PRs from forks
 # NOTE: nix-build | cachix push <name> - uploads binaries, runs&works only in the branches of the main repository, so for PRs - else case runs

--- a/build.sh
+++ b/build.sh
@@ -140,6 +140,15 @@ fi
 
 MAIN() {
 
+
+#  2020-06-01: NOTE: Nix installer installs old Nix version that has bugs that prevented importing Nixpks repository channels, updating to latest Nix since it does not have that bug
+# NOTE: Overall it is useful to have in CI test builds the latest stable Nix
+# NOTE: User-run update for Linux setup
+nix upgrade-nix || true
+# NOTE: Superuser update for macOS setup
+sudo nix upgrade-nix || true
+
+
 # NOTE: Secrets are not shared to PRs from forks
 # NOTE: nix-build | cachix push <name> - uploads binaries, runs&works only in the branches of the main repository, so for PRs - else case runs
 

--- a/default.nix
+++ b/default.nix
@@ -29,14 +29,21 @@
 
 , withHoogle  ? true
 
+
+, useRev ? false
+# Accepts Nixpkgs channel name and Git revision
 , rev ? "nixpkgs-unstable"
 
 , pkgs ?
     if builtins.compareVersions builtins.nixVersion "2.0" < 0
     then abort "hnix requires at least nix 2.0"
-    else import (builtins.fetchTarball "https://github.com/NixOS/nixpkgs/archive/${rev}.tar.gz") {}
+    else
+      if useRev
+        then import (builtins.fetchTarball "https://github.com/NixOS/nixpkgs/archive/${rev}.tar.gz") {}
+      # Please not guard with hash, so we able to use current channels (rolling `rev`) of Haskell&Nixpkgs
+        else import <nixpkgs> {}
       // {
-      config.allowBroken = true;
+        config.allowBroken = true;
       # config.packageOverrides = pkgs: rec {
       #   nix = pkgs.nixStable.overrideDerivation (attrs: with pkgs; rec {
       #     src = if builtins.pathExists ./data/nix/.version
@@ -73,7 +80,7 @@
       #     outputs = builtins.filter (s: s != "doc" && s != "man" ) attrs.outputs;
       #   });
       # };
-    }
+      }
 
 , mkDerivation   ? null
 }:

--- a/default.nix
+++ b/default.nix
@@ -29,7 +29,7 @@
 
 , withHoogle  ? true
 
-, rev ? "29d57de30101b51b016310ee51c2c4ec762f88db" #  2020-05-23: NOTE: UTC 17:00
+, rev ? "nixpkgs-unstable"
 
 , pkgs ?
     if builtins.compareVersions builtins.nixVersion "2.0" < 0

--- a/default.nix
+++ b/default.nix
@@ -34,7 +34,8 @@
 , pkgs ?
     if builtins.compareVersions builtins.nixVersion "2.0" < 0
     then abort "hnix requires at least nix 2.0"
-    else import (builtins.fetchTarball "https://github.com/NixOS/nixpkgs/archive/${rev}.tar.gz") {
+    else import (builtins.fetchTarball "https://github.com/NixOS/nixpkgs/archive/${rev}.tar.gz") {}
+      // {
       config.allowBroken = true;
       # config.packageOverrides = pkgs: rec {
       #   nix = pkgs.nixStable.overrideDerivation (attrs: with pkgs; rec {

--- a/default.nix
+++ b/default.nix
@@ -31,14 +31,10 @@
 
 , rev ? "29d57de30101b51b016310ee51c2c4ec762f88db" #  2020-05-23: NOTE: UTC 17:00
 
-, sha256 ? "1wjljkffb3gzdvpfc4v98mrhzack6k9i7860n8cf5nipyab6jbq9"
-
 , pkgs ?
     if builtins.compareVersions builtins.nixVersion "2.0" < 0
     then abort "hnix requires at least nix 2.0"
-    else import (builtins.fetchTarball {
-           url = "https://github.com/NixOS/nixpkgs/archive/${rev}.tar.gz";
-           inherit sha256; }) {
+    else import (builtins.fetchTarball "https://github.com/NixOS/nixpkgs/archive/${rev}.tar.gz") {
       config.allowBroken = true;
       # config.packageOverrides = pkgs: rec {
       #   nix = pkgs.nixStable.overrideDerivation (attrs: with pkgs; rec {


### PR DESCRIPTION
Idea Report #606

Since as in pure functional language - variables (`rev`) should be initialized at least with a default value, and so - implementation requires separate switch (`useGitRev`), 
Before this - `nix-build` Nixpkgs was overridden in `default.nix`, good that it was updated recently.

Now `default.nix` and so `nix-shell` and `nix-build` use proper default channels that project expected/should use on local systems and in so in CI also.

Also in CI now we would be able to use the already loaded channel in OS, or be able to provide custom `rev`.

