### PR TITLE
default.nix: expose additional part of Nixpkgs haskell.lib API

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -136,6 +136,11 @@ in haskellPackages.developPackage {
     inherit doCheck;
     inherit enableLibraryProfiling;
     inherit enableExecutableProfiling;
+    inherit enableSharedExecutables;
+    inherit enableSharedLibraries;
+    inherit enableStaticLibraries;
+    inherit enableDeadCodeElimination;
+    inherit allowInconsistentDependencies;
 
     configureFlags =
          pkgs.stdenv.lib.optional doTracing  "--flags=tracing"

--- a/default.nix
+++ b/default.nix
@@ -17,7 +17,7 @@
 , doStrict    ? false
 # Escape the version bounds from the cabal file. You may want to avoid this function.
 , doJailbreak ? false
-, enableSharedExecutables ? true
+, enableSharedExecutables ? false
 , enableSharedLibraries ? true
 , enableStaticLibraries ? false
 #  2020-06-02: NOTE: enableDeadCodeElimination = true: On GHC =< 8.8.3 macOS build falls due to https://gitlab.haskell.org/ghc/ghc/issues/17283, so temporarily set default to `false`

--- a/default.nix
+++ b/default.nix
@@ -20,7 +20,8 @@
 , enableSharedExecutables ? true
 , enableSharedLibraries ? true
 , enableStaticLibraries ? false
-, enableDeadCodeElimination ? true
+#  2020-06-02: NOTE: enableDeadCodeElimination = true: On GHC =< 8.8.3 macOS build falls due to https://gitlab.haskell.org/ghc/ghc/issues/17283, so temporarily set default to `false`
+, enableDeadCodeElimination ? false
 , doHyperlinkSource ? false
 , doStrip ? false
 , justStaticExecutables ? false


### PR DESCRIPTION
Reports #581 #566 

This exposes additional part of options.

Arguments (switches) in the header were already provided.

I would further provide other options. When I figure-out how in Nix lang to map over a `[(key,function)]` and apply it to derivation build. Or would provide manually.
And then I need to clean-up CI and `default.ni` header attribute options, I provided them in CI but then understood they all require proper exposition from the library into `default.nix`.

I want to head toward a somewhat universal CI setup that supports `haskell.lib` and to publish it for everyone, so everyone would be able to build test with Nixpkgs.