### PR TITLE
clean-up GHC 8.{4,6} warnings, working towards `buildStrictly`

### DIFF
--- a/main/Repl.hs
+++ b/main/Repl.hs
@@ -38,7 +38,6 @@ import           Data.List                      ( isPrefixOf
                                                 , foldl'
                                                 )
 import qualified Data.Map                      as Map
-import           Data.Monoid
 import           Data.Text                      ( unpack
                                                 , pack
                                                 )

--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -59,9 +59,7 @@ import qualified Data.Text.Lazy                as LazyText
 import qualified Data.Text.Lazy.Builder        as Builder
 import           Data.These                     ( fromThese )
 import qualified Data.Time.Clock.POSIX         as Time
-import           Data.Traversable               ( for
-                                                , mapM
-                                                )
+import           Data.Traversable               ( for )
 import qualified Data.Vector                   as V
 import           Nix.Atoms
 import           Nix.Convert

--- a/src/Nix/Exec.hs
+++ b/src/Nix/Exec.hs
@@ -33,7 +33,6 @@ import           Control.Monad
 import           Control.Monad.Catch     hiding ( catchJust )
 import           Control.Monad.Fix
 import           Control.Monad.Reader
-import           Control.Monad.Trans.Reader     ( ReaderT(..) )
 import           Data.Fix
 import qualified Data.HashMap.Lazy             as M
 import           Data.List

--- a/src/Nix/Expr/Strings.hs
+++ b/src/Nix/Expr/Strings.hs
@@ -8,7 +8,6 @@ import           Data.List                      ( intercalate
                                                 , dropWhileEnd
                                                 , inits
                                                 )
-import           Data.Monoid                    ( (<>) )
 import           Data.Text                      ( Text )
 import qualified Data.Text                     as T
 import           Data.Tuple                     ( swap )

--- a/src/Nix/Parser.hs
+++ b/src/Nix/Parser.hs
@@ -58,7 +58,6 @@ import           Data.Char                      ( isAlpha
                                                 , isSpace
                                                 )
 import           Data.Data                      ( Data(..) )
-import           Data.Foldable                  ( concat )
 import           Data.Functor
 import           Data.Functor.Identity
 import           Data.HashSet                   ( HashSet )
@@ -66,7 +65,6 @@ import qualified Data.HashSet                  as HashSet
 import           Data.List.NonEmpty             ( NonEmpty(..) )
 import qualified Data.List.NonEmpty            as NE
 import qualified Data.Map                      as Map
-import           Data.Text                      ( Text )
 import           Data.Text               hiding ( map
                                                 , foldr1
                                                 , concat

--- a/src/Nix/Reduce.hs
+++ b/src/Nix/Reduce.hs
@@ -40,9 +40,6 @@ import           Control.Monad.Fix
 import           Control.Monad.IO.Class
 import           Control.Monad.Reader
 import           Control.Monad.State.Strict
-import           Control.Monad.Trans.Reader     ( ReaderT(..) )
-import           Control.Monad.Trans.State.Strict
-                                                ( StateT(..) )
 import           Data.Fix
 -- import           Data.Foldable
 import           Data.HashMap.Lazy              ( HashMap )

--- a/src/Nix/Type/Infer.hs
+++ b/src/Nix/Type/Infer.hs
@@ -40,7 +40,6 @@ import           Data.Fix                       ( cata )
 import           Data.Foldable
 import qualified Data.HashMap.Lazy             as M
 import           Data.List                      ( delete
-                                                , find
                                                 , nub
                                                 , intersect
                                                 , (\\)

--- a/src/Nix/Utils.hs
+++ b/src/Nix/Utils.hs
@@ -25,9 +25,7 @@ import           Data.Hashable
 import           Data.HashMap.Lazy              ( HashMap )
 import qualified Data.HashMap.Lazy             as M
 import           Data.List                      ( sortOn )
-import           Data.Monoid                    ( Endo
-                                                , (<>)
-                                                )
+import           Data.Monoid                    ( Endo )
 import           Data.Text                      ( Text )
 import qualified Data.Text                     as Text
 import qualified Data.Vector                   as V

--- a/src/Nix/Value.hs
+++ b/src/Nix/Value.hs
@@ -30,20 +30,23 @@
 
 module Nix.Value where
 
-import           Control.Comonad
-import           Control.Exception
-import           Control.Monad
-import           Control.Monad.Free
-import           Control.Monad.Trans.Class
+import           Control.Comonad                ( Comonad, extract )
+import           Control.Exception              ( Exception )
+import           Control.Monad                  ( (<=<) )
+import           Control.Monad.Free             ( Free(..)
+                                                , hoistFree, iter, iterM )
+import           Control.Monad.Trans.Class      ( MonadTrans, lift )
 import qualified Data.Aeson                    as A
-import           Data.Functor.Classes
+import           Data.Functor.Classes           ( Show1
+                                                , liftShowsPrec
+                                                , showsUnaryWith )
 import           Data.HashMap.Lazy              ( HashMap )
 import           Data.Text                      ( Text )
 import           Data.Typeable                  ( Typeable )
-import           GHC.Generics
-import           Lens.Family2
-import           Lens.Family2.Stock
-import           Lens.Family2.TH
+import           GHC.Generics                   ( Generic )
+import           Lens.Family2.Stock             ( _1 )
+import           Lens.Family2.TH                ( makeTraversals
+                                                , makeLenses )
 import           Nix.Atoms
 import           Nix.Expr.Types
 import           Nix.Expr.Types.Annotated


### PR DESCRIPTION
Plainly removed, would see in CI what old GHCs would complain about.

This removes all warnings in `GHC 8.{4,6}`.

`MonadFail` warning in `GHC 8.8` are still in place, because of `GHC 8.{4,6}`. I think it just needs to refactored, probably while OR before #509 finishes.