### PR TITLE
default.nix: refactor, provide rest of the Nixpkgs Haskell.lib features, document

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,5 +1,9 @@
 { compiler    ? "ghc883"
 
+# This settings expose most of the Nixpkgs Haskell.lib API: https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/haskell-modules/lib.nix
+
+# Some of these options implicitly enable other options they require, and some counterpoint options clash, obviously
+
 # Don't fail at configure time if there are multiple versions of the same package in the (recursive) dependencies of the package being built. Will delay failures, if any, to compile time.
 , allowInconsistentDependencies ? false
 # Escape the version bounds from the cabal file. You may want to avoid this function.

--- a/default.nix
+++ b/default.nix
@@ -6,6 +6,8 @@
 , doJailbreak ? false
 # Nix dependency checking, compilation and execution of test suites listed in the package description file.
 , doCheck     ? true
+# Just produce a SDist src tarball
+, sdistTarball ? false
 #  2020-06-02: NOTE: enableDeadCodeElimination = true: On GHC =< 8.8.3 macOS build falls due to https://gitlab.haskell.org/ghc/ghc/issues/17283
 # Disable GHC code optimizations for faster dev loops. Enable optimizations for production use or benchmarks.
 , enableDeadCodeElimination ? false
@@ -121,6 +123,10 @@ let
 
   listOfSetsOfSwitchExtend =
     [
+      {
+        switch = sdistTarball;
+        function = pkgs.haskell.lib.sdistTarball;
+      }
     ];
 
   funcOnSwitchAppliesFunction = set: object:

--- a/default.nix
+++ b/default.nix
@@ -123,7 +123,7 @@ let
     [
     ];
 
-  funcOnSwitchAplliesFunction = set: object:
+  funcOnSwitchAppliesFunction = set: object:
     if set.switch
       then set.function object
       else object;
@@ -171,7 +171,7 @@ let
     returnShellEnv = false;
   };
 
-  composedPackage = pkgs.lib.foldr (funcOnSwitchAplliesFunction) package listOfSetsOfSwitchExtend;
+  composedPackage = pkgs.lib.foldr (funcOnSwitchAppliesFunction) package listOfSetsOfSwitchExtend;
 
 in composedPackage
 

--- a/default.nix
+++ b/default.nix
@@ -1,32 +1,34 @@
 { compiler    ? "ghc883"
 
-# doBenchmark: Dependency checking + compilation and execution for benchmarks listed in the package description file.
-, doBenchmark ? false
-# Generation and installation of a coverage report.
-# See https://wiki.haskell.org/Haskell_program_coverage
-, doCoverage  ? false
-# Generation and installation of haddock API documentation
-, doHaddock   ? false
+# Don't fail at configure time if there are multiple versions of the same package in the (recursive) dependencies of the package being built. Will delay failures, if any, to compile time.
+, allowInconsistentDependencies ? false
+# Escape the version bounds from the cabal file. You may want to avoid this function.
+, doJailbreak ? false
 # Nix dependency checking, compilation and execution of test suites listed in the package description file.
 , doCheck     ? true
+#  2020-06-02: NOTE: enableDeadCodeElimination = true: On GHC =< 8.8.3 macOS build falls due to https://gitlab.haskell.org/ghc/ghc/issues/17283
+# Disable GHC code optimizations for faster dev loops. Enable optimizations for production use or benchmarks.
+, enableDeadCodeElimination ? false
 , enableLibraryProfiling ? false
 , enableExecutableProfiling ? false
 , doTracing   ? false
 # Enables GHC optimizations for production use, without optimizations compilation is way faster
 , doOptimize  ? false
 , doStrict    ? false
-# Escape the version bounds from the cabal file. You may want to avoid this function.
-, doJailbreak ? false
-, enableSharedExecutables ? false
+# Strip results from all debugging symbols
+, doStrip ? false
 , enableSharedLibraries ? true
 , enableStaticLibraries ? false
-#  2020-06-02: NOTE: enableDeadCodeElimination = true: On GHC =< 8.8.3 macOS build falls due to https://gitlab.haskell.org/ghc/ghc/issues/17283, so temporarily set default to `false`
-, enableDeadCodeElimination ? false
 , doHyperlinkSource ? false
-, doStrip ? false
+# Make hybrid executable that is also a shared library
+, enableSharedExecutables ? false
 , justStaticExecutables ? false
-# Don't fail at configure time if there are multiple versions of the same package in the (recursive) dependencies of the package being built. Will delay failures, if any, to compile time.
-, allowInconsistentDependencies ? false
+# Generation and installation of haddock API documentation
+, doHaddock   ? false
+# Generation and installation of a coverage report. See https://wiki.haskell.org/Haskell_program_coverage
+, doCoverage  ? false
+# doBenchmark: Dependency checking + compilation and execution for benchmarks listed in the package description file.
+, doBenchmark ? false
 
 , withHoogle  ? true
 

--- a/default.nix
+++ b/default.nix
@@ -8,6 +8,8 @@
 , doCheck     ? true
 # Just produce a SDist src tarball
 , sdistTarball ? false
+# Produce SDist tarball and build project from it
+, buildFromSdist ? true
 #  2020-06-02: NOTE: enableDeadCodeElimination = true: On GHC =< 8.8.3 macOS build falls due to https://gitlab.haskell.org/ghc/ghc/issues/17283
 # Disable GHC code optimizations for faster dev loops. Enable optimizations for production use or benchmarks.
 , enableDeadCodeElimination ? false
@@ -126,6 +128,10 @@ let
       {
         switch = sdistTarball;
         function = pkgs.haskell.lib.sdistTarball;
+      }
+      {
+        switch = buildFromSdist;
+        function = pkgs.haskell.lib.buildFromSdist;
       }
     ];
 

--- a/default.nix
+++ b/default.nix
@@ -155,6 +155,10 @@ let
         function = pkgs.haskell.lib.doJailBreak;
       }
       {
+        switch = doStrip;
+        function = pkgs.haskell.lib.doStrip;
+      }
+      {
         switch = enableDWARFDebugging;
         function = pkgs.haskell.lib.enableDWARFDebugging;
       }

--- a/default.nix
+++ b/default.nix
@@ -118,42 +118,49 @@ let
   haskellPackages = pkgs.haskell.packages.${compiler}.override
     overrideHaskellPackages;
 
-in haskellPackages.developPackage {
-  name = "hnix";
-  root = ./.;
+  # General description of package
+  package = haskellPackages.developPackage {
+    name = "hnix";
+    root = ./.;
 
-  modifier = drv: pkgs.haskell.lib.overrideCabal drv (attrs: {
-    buildTools = (attrs.buildTools or []) ++ [
-      haskellPackages.cabal-install
-    ];
+    modifier = drv: pkgs.haskell.lib.overrideCabal drv (attrs: {
+      buildTools = (attrs.buildTools or []) ++ [
+        haskellPackages.cabal-install
+      ];
 
-    testHaskellDepends = attrs.testHaskellDepends ++ [
-      pkgs.nix
-      haskellPackages.criterion
-    ];
+      testHaskellDepends = attrs.testHaskellDepends ++ [
+        pkgs.nix
+        haskellPackages.criterion
+      ];
 
-    inherit doBenchmark;
-    inherit doCoverage;
-    inherit doHaddock;
-    inherit doCheck;
-    inherit enableLibraryProfiling;
-    inherit enableExecutableProfiling;
-    inherit enableSharedExecutables;
-    inherit enableSharedLibraries;
-    inherit enableStaticLibraries;
-    inherit enableDeadCodeElimination;
-    inherit allowInconsistentDependencies;
+      inherit doBenchmark;
+      inherit doCoverage;
+      inherit doHaddock;
+      inherit doCheck;
+      inherit enableLibraryProfiling;
+      inherit enableExecutableProfiling;
+      inherit enableSharedExecutables;
+      inherit enableSharedLibraries;
+      inherit enableStaticLibraries;
+      inherit enableDeadCodeElimination;
+      inherit allowInconsistentDependencies;
 
-    configureFlags =
-         pkgs.stdenv.lib.optional doTracing  "--flags=tracing"
-      ++ pkgs.stdenv.lib.optional doOptimize "--flags=optimize"
-      ++ pkgs.stdenv.lib.optional doStrict   "--ghc-options=-Werror";
+      configureFlags =
+          pkgs.stdenv.lib.optional doTracing  "--flags=tracing"
+        ++ pkgs.stdenv.lib.optional doOptimize "--flags=optimize"
+        ++ pkgs.stdenv.lib.optional doStrict   "--ghc-options=-Werror";
 
-    passthru = {
-      nixpkgs = pkgs;
-      inherit haskellPackages;
-    };
-  });
+      passthru = {
+        nixpkgs = pkgs;
+        inherit haskellPackages;
+      };
+    });
 
-  returnShellEnv = false;
-}
+    returnShellEnv = false;
+  };
+
+  composedPackage = package;
+
+in composedPackage
+
+

--- a/default.nix
+++ b/default.nix
@@ -170,6 +170,10 @@ let
         switch = failOnAllWarnings;
         function = pkgs.haskell.lib.failOnAllWarnings;
       }
+      {
+        switch = justStaticExecutables;
+        function = pkgs.haskell.lib.justStaticExecutables;
+      }
     ];
 
   funcOnSwitchAppliesFunction = set: object:

--- a/default.nix
+++ b/default.nix
@@ -30,9 +30,10 @@
 , enableDWARFDebugging ? true
 # Strip results from all debugging symbols
 , doStrip ? false
+#	Generate hyperlinked source code for documentation using HsColour, and have Haddock documentation link to it.
+, doHyperlinkSource ? false
 , enableSharedLibraries ? true
 , enableStaticLibraries ? false
-, doHyperlinkSource ? false
 # Make hybrid executable that is also a shared library
 , enableSharedExecutables ? false
 , justStaticExecutables ? false
@@ -185,6 +186,10 @@ let
       {
         switch = generateOptparseApplicativeCompletion;
         function = pkgs.haskell.lib.generateOptparseApplicativeCompletion "hnix";
+      }
+      {
+        switch = doHyperlinkSource;
+        function = pkgs.haskell.lib.doHyperlinkSource;
       }
     ];
 

--- a/default.nix
+++ b/default.nix
@@ -26,6 +26,8 @@
 # Enables GHC optimizations for production use, without optimizations compilation is way faster
 , doOptimize  ? false
 , doStrict    ? false
+# Include DWARF debugging information & abilities
+, enableDWARFDebugging ? true
 # Strip results from all debugging symbols
 , doStrip ? false
 , enableSharedLibraries ? true
@@ -147,6 +149,10 @@ let
       {
         switch = disableOptimization;
         function = pkgs.haskell.lib.disableOptimization;
+      }
+      {
+        switch = enableDWARFDebugging;
+        function = pkgs.haskell.lib.enableDWARFDebugging;
       }
       {
         switch = linkWithGold;

--- a/default.nix
+++ b/default.nix
@@ -37,6 +37,8 @@
 , enableSharedExecutables ? false
 , justStaticExecutables ? false
 , enableSeparateBinOutput ? false
+# Add a post-build check to verify that dependencies declared in the .cabal file are actually used.
+, checkUnusedPackages ? false
 # Generation and installation of haddock API documentation
 , doHaddock   ? false
 # Generation and installation of a coverage report. See https://wiki.haskell.org/Haskell_program_coverage
@@ -173,6 +175,10 @@ let
       {
         switch = justStaticExecutables;
         function = pkgs.haskell.lib.justStaticExecutables;
+      }
+      {
+        switch = checkUnusedPackages;
+        function = pkgs.haskell.lib.checkUnusedPackages {};
       }
     ];
 

--- a/default.nix
+++ b/default.nix
@@ -16,6 +16,8 @@
 #  2020-06-02: NOTE: enableDeadCodeElimination = true: On GHC =< 8.8.3 macOS build falls due to https://gitlab.haskell.org/ghc/ghc/issues/17283
 # Disable GHC code optimizations for faster dev loops. Enable optimizations for production use or benchmarks.
 , enableDeadCodeElimination ? false
+# Optimization disabled for faster compiling/dev loop
+, disableOptimization ? true
 , enableLibraryProfiling ? false
 , enableExecutableProfiling ? false
 , doTracing   ? false
@@ -139,6 +141,10 @@ let
       {
         switch = buildStrictly;
         function = pkgs.haskell.lib.buildStrictly;
+      }
+      {
+        switch = disableOptimization;
+        function = pkgs.haskell.lib.disableOptimization;
       }
       {
         switch = failOnAllWarnings;

--- a/default.nix
+++ b/default.nix
@@ -23,6 +23,7 @@
 # Make hybrid executable that is also a shared library
 , enableSharedExecutables ? false
 , justStaticExecutables ? false
+, enableSeparateBinOutput ? false
 # Generation and installation of haddock API documentation
 , doHaddock   ? false
 # Generation and installation of a coverage report. See https://wiki.haskell.org/Haskell_program_coverage
@@ -142,6 +143,7 @@ let
       inherit enableSharedLibraries;
       inherit enableStaticLibraries;
       inherit enableSharedExecutables;
+      inherit enableSeparateBinOutput;
       inherit doBenchmark;
       inherit doCoverage;
       inherit doHaddock;

--- a/default.nix
+++ b/default.nix
@@ -23,8 +23,6 @@
 , enableLibraryProfiling ? false
 , enableExecutableProfiling ? false
 , doTracing   ? false
-# Enables GHC optimizations for production use, without optimizations compilation is way faster
-, doOptimize  ? false
 # Include DWARF debugging information & abilities
 , enableDWARFDebugging ? true
 # Strip results from all debugging symbols
@@ -226,9 +224,7 @@ let
       inherit doCoverage;
       inherit doHaddock;
 
-      configureFlags =
-          pkgs.stdenv.lib.optional doTracing  "--flags=tracing"
-        ++ pkgs.stdenv.lib.optional doOptimize "--flags=optimize"
+      configureFlags = pkgs.stdenv.lib.optional doTracing  "--flags=tracing";
 
       passthru = {
         nixpkgs = pkgs;

--- a/default.nix
+++ b/default.nix
@@ -151,6 +151,10 @@ let
         function = pkgs.haskell.lib.disableOptimization;
       }
       {
+        switch = doJailbreak;
+        function = pkgs.haskell.lib.doJailBreak;
+      }
+      {
         switch = enableDWARFDebugging;
         function = pkgs.haskell.lib.enableDWARFDebugging;
       }

--- a/default.nix
+++ b/default.nix
@@ -10,6 +10,7 @@
 , sdistTarball ? false
 # Produce SDist tarball and build project from it
 , buildFromSdist ? true
+, failOnAllWarnings ? false
 #  2020-06-02: NOTE: enableDeadCodeElimination = true: On GHC =< 8.8.3 macOS build falls due to https://gitlab.haskell.org/ghc/ghc/issues/17283
 # Disable GHC code optimizations for faster dev loops. Enable optimizations for production use or benchmarks.
 , enableDeadCodeElimination ? false
@@ -132,6 +133,10 @@ let
       {
         switch = buildFromSdist;
         function = pkgs.haskell.lib.buildFromSdist;
+      }
+      {
+        switch = failOnAllWarnings;
+        function = pkgs.haskell.lib.failOnAllWarnings;
       }
     ];
 

--- a/default.nix
+++ b/default.nix
@@ -139,6 +139,7 @@ let
   haskellPackages = pkgs.haskell.packages.${compiler}.override
     overrideHaskellPackages;
 
+  # Application of functions from this list to the package in code here happens in the reverse order (from the tail). Some options depend on & override others, so if enabling options caused Nix error or not expected result - change the order, and please do not change this order without proper testing.
   listOfSetsOfSwitchExtend =
     [
       {
@@ -195,6 +196,7 @@ let
       }
     ];
 
+  # Function that applies enabled option to the package, used in the fold.
   funcOnSwitchAppliesFunction = set: object:
     if set.switch
       then set.function object
@@ -240,6 +242,9 @@ let
     returnShellEnv = false;
   };
 
+  # One part of Haskell.lib options are argument switches, those are in `inherit`ed list.
+  # Other part - are function wrappers over pkg. Fold allows to compose those.
+  # composePackage = foldr (if switch then function) (package) ([{switch,function}]) == (functionN .. (function1 package))
   composedPackage = pkgs.lib.foldr (funcOnSwitchAppliesFunction) package listOfSetsOfSwitchExtend;
 
 in composedPackage

--- a/default.nix
+++ b/default.nix
@@ -40,8 +40,8 @@
     then abort "hnix requires at least nix 2.0"
     else
       if useRev
+        # Please do not guard with hash, so the package able to use current channels (rolling `rev`) of Haskell&Nixpkgs
         then import (builtins.fetchTarball "https://github.com/NixOS/nixpkgs/archive/${rev}.tar.gz") {}
-      # Please not guard with hash, so we able to use current channels (rolling `rev`) of Haskell&Nixpkgs
         else import <nixpkgs> {}
       // {
         config.allowBroken = true;

--- a/default.nix
+++ b/default.nix
@@ -18,6 +18,8 @@
 , enableDeadCodeElimination ? false
 # Optimization disabled for faster compiling/dev loop
 , disableOptimization ? true
+# Use faster `gold` ELF linker from GNU binutils instead of older&slower but more versatile GNU linker. Is not available by default since macOS does not have it.
+, linkWithGold ? false
 , enableLibraryProfiling ? false
 , enableExecutableProfiling ? false
 , doTracing   ? false
@@ -145,6 +147,10 @@ let
       {
         switch = disableOptimization;
         function = pkgs.haskell.lib.disableOptimization;
+      }
+      {
+        switch = linkWithGold;
+        function = pkgs.haskell.lib.linkWithGold;
       }
       {
         switch = failOnAllWarnings;

--- a/default.nix
+++ b/default.nix
@@ -25,7 +25,6 @@
 , doTracing   ? false
 # Enables GHC optimizations for production use, without optimizations compilation is way faster
 , doOptimize  ? false
-, doStrict    ? false
 # Include DWARF debugging information & abilities
 , enableDWARFDebugging ? true
 # Strip results from all debugging symbols
@@ -230,7 +229,6 @@ let
       configureFlags =
           pkgs.stdenv.lib.optional doTracing  "--flags=tracing"
         ++ pkgs.stdenv.lib.optional doOptimize "--flags=optimize"
-        ++ pkgs.stdenv.lib.optional doStrict   "--ghc-options=-Werror";
 
       passthru = {
         nixpkgs = pkgs;

--- a/default.nix
+++ b/default.nix
@@ -133,17 +133,18 @@ let
         haskellPackages.criterion
       ];
 
+      # Declare that the header set arguments as according Haskell.lib switches
+      inherit allowInconsistentDependencies;
+      inherit doCheck;
+      inherit enableDeadCodeElimination;
+      inherit enableLibraryProfiling;
+      inherit enableExecutableProfiling;
+      inherit enableSharedLibraries;
+      inherit enableStaticLibraries;
+      inherit enableSharedExecutables;
       inherit doBenchmark;
       inherit doCoverage;
       inherit doHaddock;
-      inherit doCheck;
-      inherit enableLibraryProfiling;
-      inherit enableExecutableProfiling;
-      inherit enableSharedExecutables;
-      inherit enableSharedLibraries;
-      inherit enableStaticLibraries;
-      inherit enableDeadCodeElimination;
-      inherit allowInconsistentDependencies;
 
       configureFlags =
           pkgs.stdenv.lib.optional doTracing  "--flags=tracing"

--- a/default.nix
+++ b/default.nix
@@ -20,8 +20,10 @@
 , disableOptimization ? true
 # Use faster `gold` ELF linker from GNU binutils instead of older&slower but more versatile GNU linker. Is not available by default since macOS does not have it.
 , linkWithGold ? false
+# Provide an inventory of performance events and timings for the execution. Provides informaiton in an absolute sense. Nothing is timestamped.
 , enableLibraryProfiling ? false
 , enableExecutableProfiling ? false
+# Include tracing information & abilities. Tracing records the chronology, often with timestamps and is extensive in time
 , doTracing   ? false
 # Include DWARF debugging information & abilities
 , enableDWARFDebugging ? true
@@ -29,10 +31,13 @@
 , doStrip ? false
 #	Generate hyperlinked source code for documentation using HsColour, and have Haddock documentation link to it.
 , doHyperlinkSource ? false
+# Nixpkgs expects shared libraries
 , enableSharedLibraries ? true
+# Ability to make static libraries
 , enableStaticLibraries ? false
 # Make hybrid executable that is also a shared library
 , enableSharedExecutables ? false
+# link executables statically against haskell libs to reduce closure size
 , justStaticExecutables ? false
 , enableSeparateBinOutput ? false
 # Add a post-build check to verify that dependencies declared in the .cabal file are actually used.

--- a/default.nix
+++ b/default.nix
@@ -119,6 +119,15 @@ let
   haskellPackages = pkgs.haskell.packages.${compiler}.override
     overrideHaskellPackages;
 
+  listOfSetsOfSwitchExtend =
+    [
+    ];
+
+  funcOnSwitchAplliesFunction = set: object:
+    if set.switch
+      then set.function object
+      else object;
+
   # General description of package
   package = haskellPackages.developPackage {
     name = "hnix";
@@ -162,7 +171,7 @@ let
     returnShellEnv = false;
   };
 
-  composedPackage = package;
+  composedPackage = pkgs.lib.foldr (funcOnSwitchAplliesFunction) package listOfSetsOfSwitchExtend;
 
 in composedPackage
 

--- a/default.nix
+++ b/default.nix
@@ -11,6 +11,8 @@
 # Produce SDist tarball and build project from it
 , buildFromSdist ? true
 , failOnAllWarnings ? false
+# `failOnAllWarnings` + `buildFromSdist`
+, buildStrictly ? false
 #  2020-06-02: NOTE: enableDeadCodeElimination = true: On GHC =< 8.8.3 macOS build falls due to https://gitlab.haskell.org/ghc/ghc/issues/17283
 # Disable GHC code optimizations for faster dev loops. Enable optimizations for production use or benchmarks.
 , enableDeadCodeElimination ? false
@@ -133,6 +135,10 @@ let
       {
         switch = buildFromSdist;
         function = pkgs.haskell.lib.buildFromSdist;
+      }
+      {
+        switch = buildStrictly;
+        function = pkgs.haskell.lib.buildStrictly;
       }
       {
         switch = failOnAllWarnings;

--- a/default.nix
+++ b/default.nix
@@ -45,6 +45,8 @@
 , doCoverage  ? false
 # doBenchmark: Dependency checking + compilation and execution for benchmarks listed in the package description file.
 , doBenchmark ? false
+# Modify a Haskell package to add shell completion scripts for the given executable produced by it. These completion scripts will be picked up automatically if the resulting derivation is installed
+, generateOptparseApplicativeCompletion ? false
 
 , withHoogle  ? true
 
@@ -179,6 +181,10 @@ let
       {
         switch = checkUnusedPackages;
         function = pkgs.haskell.lib.checkUnusedPackages {};
+      }
+      {
+        switch = generateOptparseApplicativeCompletion;
+        function = pkgs.haskell.lib.generateOptparseApplicativeCompletion "hnix";
       }
     ];
 


### PR DESCRIPTION
This API exposition allow:
  * to easily set all kinds of features in `default.nix` for {development, packaging, debugging, profiling, tracing, extending, testing, ...}
  * and exposes all these features as API to be accessible externally. Through `nix-build --arg ... true`
  * and so - exposes all these features into CI.

And our CI already has most of these features from #583, which it also exposes in its API in https://github.com/haskell-nix/hnix/blob/master/.travis.yml.

So this allows feature-rich development, debugging, testing and automation through the CI.

So now we would be set for the journey.

---

Commit history is atomic.