### PR TITLE
CI: Travis: add update of Nix packages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -119,6 +119,11 @@ before_script:
   - sudo mount -o remount,exec,size=4G,mode=755 /run/user || true
   - sudo mkdir -p /etc/nix
   - echo "trusted-users = root $USER" | sudo tee -a /etc/nix/nix.conf
+  #
+  # NOTE: Update Nix and Nix packages, Cachix requires that
+  - if [ "${TRAVIS_OS_NAME}" = "linux" ]; then nix upgrade-nix; fi
+  - if [ "${TRAVIS_OS_NAME}" = "osx" ]; then sudo nix upgrade-nix; fi
+  #
   # NOTE: macOS service restart
   - sudo launchctl kickstart -k system/org.nixos.nix-daemon || true
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -125,7 +125,20 @@ before_script:
   - if [ "${TRAVIS_OS_NAME}" = "osx" ]; then sudo nix upgrade-nix; fi
   #
   # NOTE: macOS service restart
-  - sudo launchctl kickstart -k system/org.nixos.nix-daemon || true
+  # HACK: Because Nix can not update its daemon itself between 2.0 -> 2.2:
+  # 1. https://github.com/NixOS/nix/issues/3125#issuecomment-539667327
+  # 2. https://github.com/NixOS/nix/issues/3125#issuecomment-539771768
+  # Since Nix on macOS has problems restarting the service:
+  # Force the real disable, get target file from the symlink, unlink symlink, copy file, and reload service
+  - |
+    if [ "${TRAVIS_OS_NAME}" = "osx" ]; then true && \
+    sudo launchctl unload /Library/LaunchDaemons/org.nixos.nix-daemon.plist && \
+    export NIX_SERVICE_FILE=$(readlink /Library/LaunchDaemons/org.nixos.nix-daemon.plist) && \
+    sudo unlink /Library/LaunchDaemons/org.nixos.nix-daemon.plist && \
+    sudo cp -f "$NIX_SERVICE_FILE" /Library/LaunchDaemons/org.nixos.nix-daemon.plist && \
+    sudo launchctl load /Library/LaunchDaemons/org.nixos.nix-daemon.plist && \
+    sudo launchctl kickstart -k system/org.nixos.nix-daemon && \
+    true; fi
 
 script:
   #

--- a/.travis.yml
+++ b/.travis.yml
@@ -137,7 +137,6 @@ script:
   # NOTE: If key is set - use Cachix push, else - proceed without it
   - if [ ! "$CACHIX_SIGNING_KEY" = "" ]; then cachix push "$name" --watch-store& fi
   # NOTE: Brush timeout for previous daemon to start
-  - sleep 2
   #
   #
   # NOTE: Normal GHC build

--- a/.travis.yml
+++ b/.travis.yml
@@ -131,7 +131,8 @@ script:
   #
   #
   # NOTE: Install Cachix client using Nix:
-  - nix-env -iA cachix -f https://cachix.org/api/v1/install
+  - if [ "${TRAVIS_OS_NAME}" = "linux" ]; then nix-env -iA cachix -f https://cachix.org/api/v1/install; fi
+  - if [ "${TRAVIS_OS_NAME}" = "osx" ]; then sudo nix-env -iA cachix -f https://cachix.org/api/v1/install; fi
   - cachix use "$name"
   # NOTE: If key is set - use Cachix push, else - proceed without it
   - if [ ! "$CACHIX_SIGNING_KEY" = "" ]; then cachix push "$name" --watch-store& fi


### PR DESCRIPTION
Report: #624 

This was due because Nix installer installs very old version of `Nix`, and launches `Nix-daemon`. So now when we need right after right after the install to update - `Nix-daemon` and `Nix` are incompatible after the update.

After Nix updating itself, it fails to operate and needs HACKs to its daemon files and then restart of its daemon so Nix-daemon matches and supports the Nix.

The solution is tweaked out to work of the information from the closed and gorgotten by God report thread.

Just maybe this caveat and how to solve it, should to be documented in the Nix changelogs. And maybe the installer should instal new major version right away in the first place, so users and machines do not need to jump through the hoops on every install and figure-out why everything falls on its face and that is a Nix installation bug and then relearn all the install and migration bugs from the last two years.

We installing Nix on every CI launch, I do not even, why we need to jump though all this just to be able to install&use Cachix.

For what it is it was a major hurdle.
