### PR TITLE
Release: 0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog
+
+## [0.9.0](https://github.com/haskell-nix/hnix/compare/0.8.0...0.9.0) (2020-06-15)
+
+* Changelog started. Previous release was `0.8.0`. In new release:
+
+* Major breaking:
+  * Removed instances due to migration to `haskeline >= 0.8 && < 0.9`:
+    * `instance MonadException m => MonadException(StateT(HashMap FilePath NExprLoc) m)`
+    * `instance MonadException m => MonadException(Fix1T StandardTF m)`
+
+* Minor:
+  * Added support for `GHC 8.4.4, 8.8.3`
+
+---
+
+`HNix` uses [PVP Versioning][1].
+
+[1]: https://pvp.haskell.org

--- a/hnix.cabal
+++ b/hnix.cabal
@@ -758,6 +758,7 @@ extra-source-files:
     data/let.nix
     LICENSE
     README.md
+    CHANGELOG.md
     tests/eval-compare/builtins.split-01.nix
     tests/eval-compare/builtins.split-02.nix
     tests/eval-compare/builtins.split-03.nix

--- a/hnix.cabal
+++ b/hnix.cabal
@@ -888,8 +888,8 @@ library
     , http-client-tls >= 0.3.5 && < 0.4
     , http-types >= 0.12.2 && < 0.13
     , interpolate >= 0.2.0 && < 0.3
-    , lens-family >=1.2.2
-    , lens-family-core >=1.2.2
+    , lens-family >=1.2.2 && < 2.2
+    , lens-family-core >=1.2.2 && < 2.2
     , lens-family-th >= 0.5.0 && < 0.6
     , logict >= 0.6.0 && < 0.7 || >= 0.7.0.2 && < 0.8
     , megaparsec >=7.0 && <8.1
@@ -909,7 +909,7 @@ library
     , some >= 1.0.1 && < 1.1
     , split >= 0.2.3 && < 0.3
     , syb >= 0.7 && < 0.8
-    , template-haskell
+    , template-haskell >= 2.13 && < 2.17
     , text >= 1.2.3 && < 1.3
     , these >= 1.0.1 && < 1.2
     , time >= 1.8.0 && < 1.9 || >= 1.9.3 && < 1.10

--- a/hnix.cabal
+++ b/hnix.cabal
@@ -1,5 +1,5 @@
 name:           hnix
-version:        0.8.0
+version:        0.9.0
 synopsis:       Haskell implementation of the Nix language
 description:    Haskell implementation of the Nix language.
 category:       System, Data, Nix


### PR DESCRIPTION
### 0.9.0

* Changelog started, changes from previous release `0.8.0`:

* Major breaking:
  * Removed instances due to migration to `haskeline >= 0.8 && < 0.9`:
    * `instance MonadException m => MonadException(StateT(HashMap FilePath NExprLoc) m)`
    * `instance MonadException m => MonadException(Fix1T StandardTF m)`

* Minor:
  * Development package neetly exposes majority of `Nixpkgs haskell.lib` features
  * Fixed SDist build
  * Changes in some REPL funtion types, including `main` function
  * Freed from `cryptohash-{md5,sha1,sha256,sha512}` dependencies in favour of `hashing` for the time being
  * New CI:
    * Provides `Nixpkgs haskell.lib` features
    * SDist build
    * Strict build (compilation with `-Werror`) for `GHC < 8.8`
  * Added support for GHC 8.4.4
