### PR TITLE
CI: Build options consolidation, tweaking builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -73,7 +73,8 @@ env:
     #
     #   command: name of an executable
     #       pkg: Haskell package that builds the executables
-    - generateOptparseApplicativeCompletion=false
+    - generateOptparseApplicativeCompletions=false
+    - executableNamesToShellComplete='[ "hnix" ]'
     # NOTE: Don't fail at configure time if there are multiple versions of the same package in the (recursive) dependencies of the package being built. Will delay failures, if any, to compile time.
     - allowInconsistentDependencies=false
     # NOTE: Log file to dump GHCJS build into

--- a/.travis.yml
+++ b/.travis.yml
@@ -112,19 +112,6 @@ jobs:
       dist: bionic
   allow_failures:
     - env: GHCVERSION=ghcjs
-  #  2020-05-26: NOTE: Discard macOS GHCJS build + -> CI loop becomes ~30-40 minutes shorter
-  exclude:
-    - os: osx
-      env: GHCVERSION=ghcjs
-    - os: osx
-      env: GHCVERSION=ghc8101
-    - os: osx
-      env: GHCVERSION=ghc865
-    - os: osx
-      env: GHCVERSION=ghc844
-    # NOTE: Discard Linux GHC 8.8.3 in favour of macOS GHC 8.8.3, Nixpkgs channel is the same and Nix package code is the same, since we test other Linux deployments and since 8.8.3 builds on macOS - we can be sure it builds inside Nix in Linux also. So lets optimize number of CI builds
-    - os: linux
-      env: GHCVERSION=ghc883
 
 before_script:
   - sudo mount -o remount,exec,size=4G,mode=755 /run/user || true

--- a/.travis.yml
+++ b/.travis.yml
@@ -86,13 +86,16 @@ env:
 jobs:
   include:
     - name: GHC 8.4.4, Linux
-      env: GHCVERSION=ghc844
+      env:
+        - GHCVERSION=ghc844
+        - linkWithGold=true
       os: linux
       dist: bionic
     - name: GHC 8.6.5, Linux, Strict
       env:
         - GHCVERSION=ghc865
         - buildStrictly=true
+        - linkWithGold=true
       os: linux
       dist: bionic
     - name: GHC 8.8.3, macOS
@@ -103,6 +106,7 @@ jobs:
       env:
         - GHCVERSION=ghc8101
         - buildFromSdist=true
+        - linkWithGold=true
       os: linux
       dist: bionic
     - name: GHCJS, Linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -66,7 +66,6 @@ env:
     - buildStrictly=false
     # NOTE: Disable core optimizations, significantly speeds up the build
     - disableOptimization=true
-    - buildStackProject=false
     # NOTE: Modify a Haskell package to add shell completion scripts for the given executable produced by it. These completion scripts will be picked up automatically if the resulting derivation is installed, e.g. by `nix-env -i`.
     # Invocation:
     #   generateOptparseApplicativeCompletions command pkg

--- a/.travis.yml
+++ b/.travis.yml
@@ -102,11 +102,16 @@ jobs:
       env:
         - GHCVERSION=ghc883
       os: osx
-    - name: GHC 8.10.1, Linux, SDist
+    - name: GHC 8.10.1, Linux, SDist, Optimize, Benchmark, Haddock, Shell Completions
       env:
         - GHCVERSION=ghc8101
         - buildFromSdist=true
         - linkWithGold=true
+        - doHaddock=true
+        - doBenchmark=true
+        - disableOptimization=false
+        - enableDeadCodeElimination=true
+        - generateOptparseApplicativeCompletions=true
       os: linux
       dist: bionic
     - name: GHCJS, Linux

--- a/build.sh
+++ b/build.sh
@@ -12,6 +12,10 @@ NIX_PATH=${NIX_PATH:-"nixpkgs=https://github.com/nixos/nixpkgs/archive/$rev.tar.
 export NIX_PATH
 pkgName=${pkgName:-'defaultPkgName'}
 
+# This settings expose most of the Nixpkgs Haskell.lib API: https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/haskell-modules/lib.nix
+
+# Some of these options implicitly enable other options they require, and some counterpoint options clash, obviously
+
 # Don't fail at configure time if there are multiple versions of the same package in the (recursive) dependencies of the package being built. Will delay failures, if any, to compile time.
 allowInconsistentDependencies=${allowInconsistentDependencies:-'false'}
 

--- a/build.sh
+++ b/build.sh
@@ -23,16 +23,39 @@ allowInconsistentDependencies=${allowInconsistentDependencies:-'false'}
 doJailbreak=${doJailbreak:-'false'}
 # Nix dependency checking, compilation and execution of test suites listed in the package description file.
 doCheck=${doCheck:-'true'}
+# Just produce a SDist src tarball
+sdistTarball=${sdistTarball:-'false'}
 # Produce SDist tarball and build project from it
 buildFromSdist=${buildFromSdist:-'false'}
 failOnAllWarnings=${failOnAllWarnings:-'false'}
 # `failOnAllWarnings` + `buildFromSdist`
 buildStrictly=${buildStrictly:-'false'}
+#  2020-06-02: NOTE: enableDeadCodeElimination = true: On GHC =< 8.8.3 macOS build falls due to https://gitlab.haskell.org/ghc/ghc/issues/17283
+enableDeadCodeElimination=${enableDeadCodeElimination:-'false'}
 # Disable GHC code optimizations for faster dev loops. Enable optimizations for production use or benchmarks.
 disableOptimization=${disableOptimization:-'true'}
+# Use faster `gold` ELF linker from GNU binutils instead of older&slower but more versatile GNU linker. Is not available by default since macOS does not have it.
+linkWithGold=${linkWithGold:-'false'}
 # Provide an inventory of performance events and timings for the execution. Provides informaiton in an absolute sense. Nothing is timestamped.
 enableLibraryProfiling=${enableLibraryProfiling:-'false'}
 enableExecutableProfiling=${enableExecutableProfiling:-'false'}
+# Include tracing information & abilities. Tracing records the chronology, often with timestamps and is extensive in time
+doTracing=${doTracing:-'false'}
+# Include DWARF debugging information & abilities
+enableDWARFDebugging=${enableDWARFDebugging:-'false'}
+# Strip results from all debugging symbols
+doStrip=${doStrip:-'false'}
+#	Generate hyperlinked source code for documentation using HsColour, and have Haddock documentation link to it.
+doHyperlinkSource=${doHyperlinkSource:-'false'}
+# Nixpkgs expects shared libraries
+enableSharedLibraries=${enableSharedLibraries:-'true'}
+# Ability to make static libraries
+enableStaticLibraries=${enableStaticLibraries:-'false'}
+# Make hybrid executable that is also a shared library
+enableSharedExecutables=${enableSharedExecutables:-'false'}
+# link executables statically against haskell libs to reduce closure size
+justStaticExecutables=${justStaticExecutables:-'false'}
+enableSeparateBinOutput=${enableSeparateBinOutput:-'false'}
 # Add a post-build check to verify that dependencies declared in the .cabal file are actually used.
 checkUnusedPackages=${checkUnusedPackages:-'false'}
 # Generation and installation of haddock API documentation
@@ -44,6 +67,9 @@ doBenchmark=${doBenchmark:-'false'}
 # NOTE: *Oprparse* key is redifined in the code further
 generateOptparseApplicativeCompletions=${generateOptparseApplicativeCompletions:-'false'}
 executableNamesToShellComplete=${executableNamesToShellComplete:-'[ "defaultBinaryName" ]'}
+
+# Include Hoogle into derivation
+withHoogle=${withHoogle:-'false'}
 
 ghcjsTmpLogFile=${ghcjsTmpLogFile:-'/tmp/ghcjsTmpLogFile.log'}
 ghcjsLogTailLength=${ghcjsLogTailLength:-'10000'}

--- a/build.sh
+++ b/build.sh
@@ -11,21 +11,21 @@ rev=${rev:-'nixpkgs-unstable'}
 NIX_PATH=${NIX_PATH:-"nixpkgs=https://github.com/nixos/nixpkgs/archive/$rev.tar.gz"}
 export NIX_PATH
 pkgName=${pkgName:-'defaultPkgName'}
-failOnAllWarnings=${failOnAllWarnings:-'false'}
-checkUnusedPackages=${checkUnusedPackages:-'false'}
-doCoverage=${doCoverage:-'false'}
-doHaddock=${doHaddock:-'false'}
+allowInconsistentDependencies=${allowInconsistentDependencies:-'false'}
 doJailbreak=${doJailbreak:-'false'}
 doCheck=${doCheck:-'true'}
-doBenchmark=${doBenchmark:-'false'}
-enableExecutableProfiling=${enableExecutableProfiling:-'false'}
-enableLibraryProfiling=${enableLibraryProfiling:-'false'}
 buildFromSdist=${buildFromSdist:-'false'}
+failOnAllWarnings=${failOnAllWarnings:-'false'}
 buildStrictly=${buildStrictly:-'false'}
 disableOptimization=${disableOptimization:-'true'}
+enableLibraryProfiling=${enableLibraryProfiling:-'false'}
+enableExecutableProfiling=${enableExecutableProfiling:-'false'}
+checkUnusedPackages=${checkUnusedPackages:-'false'}
+doHaddock=${doHaddock:-'false'}
+doCoverage=${doCoverage:-'false'}
+doBenchmark=${doBenchmark:-'false'}
 # NOTE: *Oprparse* key is redifined in the code further
 generateOptparseApplicativeCompletions=${generateOptparseApplicativeCompletions:-'false'}
-allowInconsistentDependencies=${allowInconsistentDependencies:-'false'}
 executableNamesToShellComplete=${executableNamesToShellComplete:-'[ "defaultBinaryName" ]'}
 
 ghcjsTmpLogFile=${ghcjsTmpLogFile:-'/tmp/ghcjsTmpLogFile.log'}

--- a/build.sh
+++ b/build.sh
@@ -10,7 +10,6 @@ GHCVERSION=${GHCVERSION:-'ghc883'}
 rev=${rev:-'nixpkgs-unstable'}
 NIX_PATH=${NIX_PATH:-"nixpkgs=https://github.com/nixos/nixpkgs/archive/$rev.tar.gz"}
 export NIX_PATH
-name=${name:-'defaultBinaryName'}
 pkgName=${pkgName:-'defaultPkgName'}
 failOnAllWarnings=${failOnAllWarnings:-'false'}
 checkUnusedPackages=${checkUnusedPackages:-'false'}
@@ -24,7 +23,6 @@ enableLibraryProfiling=${enableLibraryProfiling:-'false'}
 buildFromSdist=${buildFromSdist:-'false'}
 buildStrictly=${buildStrictly:-'false'}
 disableOptimization=${disableOptimization:-'true'}
-buildStackProject=${buildStackProject:-'false'}
 # NOTE: *Oprparse* key is redifined in the code further
 generateOptparseApplicativeCompletions=${generateOptparseApplicativeCompletions:-'false'}
 allowInconsistentDependencies=${allowInconsistentDependencies:-'false'}
@@ -98,7 +96,6 @@ if [ "$GHCVERSION" = "ghcjs" ]
       --arg buildFromSdist "$buildFromSdist" \
       --arg buildStrictly "$buildStrictly" \
       --arg disableOptimization "$disableOptimization" \
-      --arg buildStackProject "$buildStackProject" \
       --arg allowInconsistentDependencies "$allowInconsistentDependencies" \
       --arg generateOptparseApplicativeCompletions "$generateOptparseApplicativeCompletions" \
       --arg executableNamesToShellComplete "$executableNamesToShellComplete" \
@@ -124,7 +121,6 @@ if [ "$GHCVERSION" = "ghcjs" ]
       --arg buildFromSdist "$buildFromSdist" \
       --arg buildStrictly "$buildStrictly" \
       --arg disableOptimization "$disableOptimization" \
-      --arg buildStackProject "$buildStackProject" \
       --arg allowInconsistentDependencies "$allowInconsistentDependencies" \
       --arg generateOptparseApplicativeCompletions "$generateOptparseApplicativeCompletions" \
       --arg executableNamesToShellComplete "$executableNamesToShellComplete"

--- a/build.sh
+++ b/build.sh
@@ -125,48 +125,70 @@ if [ "$GHCVERSION" = "ghcjs" ]
     # But Travis then terminates on 10 min no stdout timeout
     # so HACK: SILENT wrapper allows to surpress the huge log, while still preserves the Cachix caching ability in any case of the build
     # On build failure outputs the last 10000 lines of log (that should be more then enough), and terminates
-    SILENT nix-build                                         \
-      --arg failOnAllWarnings "$failOnAllWarnings"           \
-      --arg buildStrictly "$buildStrictly"                   \
-      --arg checkUnusedPackages "$checkUnusedPackages"       \
-      --arg doCoverage "$doCoverage" \
-      --arg doHaddock "$doHaddock" \
+    SILENT nix-build \
+      --arg allowInconsistentDependencies "$allowInconsistentDependencies" \
       --arg doJailbreak "$doJailbreak" \
       --arg doCheck "$doCheck" \
-      --arg doBenchmark "$doBenchmark" \
-      --arg enableExecutableProfiling "$enableExecutableProfiling" \
-      --arg enableLibraryProfiling "$enableLibraryProfiling" \
+      --arg sdistTarball "$sdistTarball" \
       --arg buildFromSdist "$buildFromSdist" \
+      --arg failOnAllWarnings "$failOnAllWarnings" \
       --arg buildStrictly "$buildStrictly" \
+      --arg enableDeadCodeElimination "$enableDeadCodeElimination" \
       --arg disableOptimization "$disableOptimization" \
-      --arg allowInconsistentDependencies "$allowInconsistentDependencies" \
+      --arg linkWithGold "$linkWithGold" \
+      --arg enableLibraryProfiling "$enableLibraryProfiling" \
+      --arg enableExecutableProfiling "$enableExecutableProfiling" \
+      --arg doTracing "$doTracing" \
+      --arg enableDWARFDebugging "$enableDWARFDebugging" \
+      --arg doStrip "$doStrip" \
+      --arg doHyperlinkSource "$doHyperlinkSource" \
+      --arg enableSharedLibraries "$enableSharedLibraries" \
+      --arg enableStaticLibraries "$enableStaticLibraries" \
+      --arg enableSharedExecutables "$enableSharedExecutables" \
+      --arg justStaticExecutables "$justStaticExecutables" \
+      --arg checkUnusedPackages "$checkUnusedPackages" \
+      --arg doCoverage "$doCoverage" \
+      --arg doHaddock "$doHaddock" \
+      --arg doBenchmark "$doBenchmark" \
       --arg generateOptparseApplicativeCompletions "$generateOptparseApplicativeCompletions" \
       --arg executableNamesToShellComplete "$executableNamesToShellComplete" \
+      --arg withHoogle "$withHoogle" \
       ghcjs
 
   else
 
     # NOTE: Normal GHC build
     # NOTE: GHC sometimes produces logs so big - that Travis terminates builds, so multiple --quiet
-    nix-build                                                \
-      --quiet --quiet                                        \
-      --argstr compiler "$GHCVERSION"                        \
-      --arg failOnAllWarnings "$failOnAllWarnings"           \
-      --arg buildStrictly "$buildStrictly"                   \
-      --arg checkUnusedPackages "$checkUnusedPackages"       \
-      --arg doCoverage "$doCoverage" \
-      --arg doHaddock "$doHaddock" \
+    nix-build \
+      --quiet --quiet \
+      --argstr compiler "$GHCVERSION" \
+      --arg allowInconsistentDependencies "$allowInconsistentDependencies" \
       --arg doJailbreak "$doJailbreak" \
       --arg doCheck "$doCheck" \
-      --arg doBenchmark "$doBenchmark" \
-      --arg enableExecutableProfiling "$enableExecutableProfiling" \
-      --arg enableLibraryProfiling "$enableLibraryProfiling" \
+      --arg sdistTarball "$sdistTarball" \
       --arg buildFromSdist "$buildFromSdist" \
+      --arg failOnAllWarnings "$failOnAllWarnings" \
       --arg buildStrictly "$buildStrictly" \
+      --arg enableDeadCodeElimination "$enableDeadCodeElimination" \
       --arg disableOptimization "$disableOptimization" \
-      --arg allowInconsistentDependencies "$allowInconsistentDependencies" \
+      --arg linkWithGold "$linkWithGold" \
+      --arg enableLibraryProfiling "$enableLibraryProfiling" \
+      --arg enableExecutableProfiling "$enableExecutableProfiling" \
+      --arg doTracing "$doTracing" \
+      --arg enableDWARFDebugging "$enableDWARFDebugging" \
+      --arg doStrip "$doStrip" \
+      --arg doHyperlinkSource "$doHyperlinkSource" \
+      --arg enableSharedLibraries "$enableSharedLibraries" \
+      --arg enableStaticLibraries "$enableStaticLibraries" \
+      --arg enableSharedExecutables "$enableSharedExecutables" \
+      --arg justStaticExecutables "$justStaticExecutables" \
+      --arg checkUnusedPackages "$checkUnusedPackages" \
+      --arg doCoverage "$doCoverage" \
+      --arg doHaddock "$doHaddock" \
+      --arg doBenchmark "$doBenchmark" \
       --arg generateOptparseApplicativeCompletions "$generateOptparseApplicativeCompletions" \
-      --arg executableNamesToShellComplete "$executableNamesToShellComplete"
+      --arg executableNamesToShellComplete "$executableNamesToShellComplete" \
+      --arg withHoogle "$withHoogle"
 
 fi
 }

--- a/build.sh
+++ b/build.sh
@@ -10,7 +10,7 @@ GHCVERSION=${GHCVERSION:-'ghc8101'}
 rev=${rev:-'nixpkgs-unstable'}
 NIX_PATH=${NIX_PATH:-"nixpkgs=https://github.com/nixos/nixpkgs/archive/$rev.tar.gz"}
 export NIX_PATH
-pkgName=${pkgName:-'defaultPkgName'}
+name=${name:-'defaultProjectName'}
 
 # This settings expose most of the Nixpkgs Haskell.lib API: https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/haskell-modules/lib.nix
 

--- a/build.sh
+++ b/build.sh
@@ -11,18 +11,31 @@ rev=${rev:-'nixpkgs-unstable'}
 NIX_PATH=${NIX_PATH:-"nixpkgs=https://github.com/nixos/nixpkgs/archive/$rev.tar.gz"}
 export NIX_PATH
 pkgName=${pkgName:-'defaultPkgName'}
+
+# Don't fail at configure time if there are multiple versions of the same package in the (recursive) dependencies of the package being built. Will delay failures, if any, to compile time.
 allowInconsistentDependencies=${allowInconsistentDependencies:-'false'}
+
+# Escape the version bounds from the cabal file. You may want to avoid this function.
 doJailbreak=${doJailbreak:-'false'}
+# Nix dependency checking, compilation and execution of test suites listed in the package description file.
 doCheck=${doCheck:-'true'}
+# Produce SDist tarball and build project from it
 buildFromSdist=${buildFromSdist:-'false'}
 failOnAllWarnings=${failOnAllWarnings:-'false'}
+# `failOnAllWarnings` + `buildFromSdist`
 buildStrictly=${buildStrictly:-'false'}
+# Disable GHC code optimizations for faster dev loops. Enable optimizations for production use or benchmarks.
 disableOptimization=${disableOptimization:-'true'}
+# Provide an inventory of performance events and timings for the execution. Provides informaiton in an absolute sense. Nothing is timestamped.
 enableLibraryProfiling=${enableLibraryProfiling:-'false'}
 enableExecutableProfiling=${enableExecutableProfiling:-'false'}
+# Add a post-build check to verify that dependencies declared in the .cabal file are actually used.
 checkUnusedPackages=${checkUnusedPackages:-'false'}
+# Generation and installation of haddock API documentation
 doHaddock=${doHaddock:-'false'}
+# Generation and installation of a coverage report. See https://wiki.haskell.org/Haskell_program_coverage
 doCoverage=${doCoverage:-'false'}
+# doBenchmark: Dependency checking + compilation and execution for benchmarks listed in the package description file.
 doBenchmark=${doBenchmark:-'false'}
 # NOTE: *Oprparse* key is redifined in the code further
 generateOptparseApplicativeCompletions=${generateOptparseApplicativeCompletions:-'false'}

--- a/build.sh
+++ b/build.sh
@@ -6,7 +6,7 @@
 set -Eexuo pipefail
 
 # NOTE: If var not imported - set to the default value
-GHCVERSION=${GHCVERSION:-'ghc883'}
+GHCVERSION=${GHCVERSION:-'ghc8101'}
 rev=${rev:-'nixpkgs-unstable'}
 NIX_PATH=${NIX_PATH:-"nixpkgs=https://github.com/nixos/nixpkgs/archive/$rev.tar.gz"}
 export NIX_PATH

--- a/build.sh
+++ b/build.sh
@@ -28,6 +28,8 @@ buildStackProject=${buildStackProject:-'false'}
 # NOTE: *Oprparse* key is redifined in the code further
 generateOptparseApplicativeCompletions=${generateOptparseApplicativeCompletions:-'false'}
 allowInconsistentDependencies=${allowInconsistentDependencies:-'false'}
+executableNamesToShellComplete=${executableNamesToShellComplete:-'[ "defaultBinaryName" ]'}
+
 ghcjsTmpLogFile=${ghcjsTmpLogFile:-'/tmp/ghcjsTmpLogFile.log'}
 ghcjsLogTailLength=${ghcjsLogTailLength:-'10000'}
 # NOTE: If key not provided (branch is not inside the central repo) - init CACHIX_SIGNING_KEY as empty
@@ -69,16 +71,6 @@ SILENT(){
 BUILD_PROJECT(){
 
 
-# NOTE: Resulting value injects into `nix-build` commands
-if [ "$generateOptparseApplicativeCompletion" = 'true' ]
-  then
-    # NOTE: Enable shell completion generation
-    generateOptparseApplicativeCompletion="--arg generateOptparseApplicativeCompletion $name $pkgName"
-  else
-    # NOTE: Skip the shell completion generation
-    generateOptparseApplicativeCompletion=''
-fi
-
 IFS=$'\n\t'
 
 if [ "$GHCVERSION" = "ghcjs" ]
@@ -107,8 +99,9 @@ if [ "$GHCVERSION" = "ghcjs" ]
       --arg buildStrictly "$buildStrictly" \
       --arg disableOptimization "$disableOptimization" \
       --arg buildStackProject "$buildStackProject" \
-      "$generateOptparseApplicativeCompletion" \
       --arg allowInconsistentDependencies "$allowInconsistentDependencies" \
+      --arg generateOptparseApplicativeCompletions "$generateOptparseApplicativeCompletions" \
+      --arg executableNamesToShellComplete "$executableNamesToShellComplete" \
       ghcjs
 
   else
@@ -132,8 +125,9 @@ if [ "$GHCVERSION" = "ghcjs" ]
       --arg buildStrictly "$buildStrictly" \
       --arg disableOptimization "$disableOptimization" \
       --arg buildStackProject "$buildStackProject" \
-      "$generateOptparseApplicativeCompletion" \
-      --arg allowInconsistentDependencies "$allowInconsistentDependencies"
+      --arg allowInconsistentDependencies "$allowInconsistentDependencies" \
+      --arg generateOptparseApplicativeCompletions "$generateOptparseApplicativeCompletions" \
+      --arg executableNamesToShellComplete "$executableNamesToShellComplete"
 
 fi
 }

--- a/default.nix
+++ b/default.nix
@@ -18,9 +18,8 @@
 # `failOnAllWarnings` + `buildFromSdist`
 , buildStrictly ? false
 #  2020-06-02: NOTE: enableDeadCodeElimination = true: On GHC =< 8.8.3 macOS build falls due to https://gitlab.haskell.org/ghc/ghc/issues/17283
-# Disable GHC code optimizations for faster dev loops. Enable optimizations for production use or benchmarks.
 , enableDeadCodeElimination ? false
-# Optimization disabled for faster compiling/dev loop
+# Disable GHC code optimizations for faster dev loops. Enable optimizations for production use or benchmarks.
 , disableOptimization ? true
 # Use faster `gold` ELF linker from GNU binutils instead of older&slower but more versatile GNU linker. Is not available by default since macOS does not have it.
 , linkWithGold ? false

--- a/default.nix
+++ b/default.nix
@@ -53,7 +53,8 @@
 # doBenchmark: Dependency checking + compilation and execution for benchmarks listed in the package description file.
 , doBenchmark ? false
 # Modify a Haskell package to add shell completion scripts for the given executable produced by it. These completion scripts will be picked up automatically if the resulting derivation is installed
-, generateOptparseApplicativeCompletion ? false
+, generateOptparseApplicativeCompletions ? false
+, executableNamesToShellComplete ? [ "hnix" ]
 
 , withHoogle  ? true
 
@@ -191,8 +192,8 @@ let
         function = pkgs.haskell.lib.checkUnusedPackages {};
       }
       {
-        switch = generateOptparseApplicativeCompletion;
-        function = pkgs.haskell.lib.generateOptparseApplicativeCompletion "hnix";
+        switch = generateOptparseApplicativeCompletions;
+        function = pkgs.haskell.lib.generateOptparseApplicativeCompletions executableNamesToShellComplete;
       }
       {
         switch = doHyperlinkSource;


### PR DESCRIPTION
In this PR I consolidate and all options `{Nixpkgs pkgs.haskell.lib, default.nix, build.sh, .travis.yml}` share between them. So I deliver my promise of these features fully.

As also raising the bar for the default CI test - GHC 8.10 to include also {Optimize, Benchmark, Haddock, Shell Completions}.

PR relates to #581 