### PR TITLE
changelog: Clarify GHC support change in v0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
     * `instance MonadException m => MonadException(Fix1T StandardTF m)`
 
 * Minor:
-  * Added support for `GHC 8.4.4, 8.8.3`
+  * Added support for `GHC 8.10`
 
 ---
 


### PR DESCRIPTION
v0.8.0 had already supported GHC 8.4 and 8.8, as the Hackage matrix
indicates:

https://matrix.hackage.haskell.org/#/package/hnix