### PR TITLE
Use neat-interpolation instead of interpolate

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -207,6 +207,13 @@ let
     name = "hnix";
     root = pkgs.nix-gitignore.gitignoreSource [ ] ./.;
 
+    overrides = self: super: {
+      # 2020-06-26 Due to a behaviour change in neat-interpolation-0.4, we
+      # require n-i >= 0.4. dontCheck helps us avoid conflicts with
+      # neat-interpolation's test dependencies.
+      neat-interpolation = pkgs.haskell.lib.dontCheck super.neat-interpolation_0_5_1;
+    };
+
     modifier = drv: pkgs.haskell.lib.overrideCabal drv (attrs: {
       buildTools = (attrs.buildTools or []) ++ [
         haskellPackages.cabal-install
@@ -248,5 +255,4 @@ let
   composedPackage = pkgs.lib.foldr (funcOnSwitchAppliesFunction) package listOfSetsOfSwitchExtend;
 
 in composedPackage
-
 

--- a/hnix.cabal
+++ b/hnix.cabal
@@ -886,7 +886,6 @@ library
     , http-client >= 0.5.14 && < 0.6 || >= 0.6.4 && < 0.8
     , http-client-tls >= 0.3.5 && < 0.4
     , http-types >= 0.12.2 && < 0.13
-    , interpolate >= 0.2.0 && < 0.3
     , lens-family >=1.2.2 && < 2.2
     , lens-family-core >=1.2.2 && < 2.2
     , lens-family-th >= 0.5.0 && < 0.6
@@ -895,6 +894,7 @@ library
     , monad-control >= 1.0.2 && < 1.1
     , monadlist >= 0.0.2 && < 0.1
     , mtl >= 2.2.2 && < 2.3
+    , neat-interpolation >= 0.4 && < 0.6
     , optparse-applicative >= 0.14.3 && < 0.15 || >= 0.15.0.0 && < 0.16
     , parser-combinators >= 1.0.1 && < 1.3
     , prettyprinter >= 1.2.1 && < 1.7
@@ -1004,9 +1004,9 @@ test-suite hnix-tests
     , filepath
     , hedgehog
     , hnix
-    , interpolate
     , megaparsec >=7.0 && <8.1
     , mtl
+    , neat-interpolation
     , optparse-applicative
     , pretty-show
     , prettyprinter

--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -51,7 +51,6 @@ import           Data.Maybe
 import           Data.Scientific
 import           Data.Set                       ( Set )
 import qualified Data.Set                      as S
-import           Data.String.Interpolate.IsString
 import           Data.Text                      ( Text )
 import qualified Data.Text                     as Text
 import           Data.Text.Encoding
@@ -61,6 +60,7 @@ import           Data.These                     ( fromThese )
 import qualified Data.Time.Clock.POSIX         as Time
 import           Data.Traversable               ( for )
 import qualified Data.Vector                   as V
+import           NeatInterpolation              ( text )
 import           Nix.Atoms
 import           Nix.Convert
 import           Nix.Effects
@@ -170,7 +170,7 @@ builtinsList = sequence
     -- This is compiled in so that we only parse and evaluate it once, at
     -- compile-time.
   , add0 TopLevel "derivation" $(do
-      let Success expr = parseNixText [i|
+      let Success expr = parseNixText [text|
         drvAttrs @ { outputs ? [ "out" ], ... }:
 
         let

--- a/tests/EvalTests.hs
+++ b/tests/EvalTests.hs
@@ -17,9 +17,9 @@ import           Control.Monad.IO.Class
 import           Data.List ((\\))
 import           Data.Maybe (isJust)
 import qualified Data.Set as S
-import           Data.String.Interpolate.IsString
 import           Data.Text (Text)
 import           Data.Time
+import           NeatInterpolation (text)
 import           Nix
 import           Nix.Standard
 import           Nix.TH
@@ -90,7 +90,7 @@ case_function_recursive_args =
     constantEqualText "2" "({ x ? 1, y ? x * 3}: y - x) {}"
 
 case_function_recursive_sets =
-    constantEqualText "[ [ 6 4 100 ] 4 ]" [i|
+    constantEqualText "[ [ 6 4 100 ] 4 ]" [text|
         let x = rec {
 
           y = 2;
@@ -152,7 +152,7 @@ case_lang_version =
     constantEqualText "5" "builtins.langVersion"
 
 case_rec_set_attr_path_simpl =
-    constantEqualText "123" [i|
+    constantEqualText "123" [text|
       let x = rec {
         foo.number = 123;
         foo.function = y: foo.number;
@@ -160,7 +160,7 @@ case_rec_set_attr_path_simpl =
     |]
 
 case_inherit_from_set_has_no_scope =
-    constantEqualText' "false" [i|
+    constantEqualText' "false" [text|
       (builtins.tryEval (
         let x = 1;
             y = { z = 2; };
@@ -171,7 +171,7 @@ case_inherit_from_set_has_no_scope =
 -- github/orblivion (2018-08-05): Adding these failing tests so we fix this feature
 
 -- case_overrides =
---     constantEqualText' "2" [i|
+--     constantEqualText' "2" [text|
 --       let
 --
 --         overrides = { a = 2; };
@@ -184,7 +184,7 @@ case_inherit_from_set_has_no_scope =
 --     |]
 
 -- case_inherit_overrides =
---     constantEqualText' "2" [i|
+--     constantEqualText' "2" [text|
 --       let
 --
 --         __overrides = { a = 2; };
@@ -197,7 +197,7 @@ case_inherit_from_set_has_no_scope =
 --     |]
 
 case_unsafegetattrpos1 =
-    constantEqualText "[ 6 20 ]" [i|
+    constantEqualText "[ 5 14 ]" [text|
       let e = 1;
           f = 1;
           t = {};
@@ -212,7 +212,7 @@ case_unsafegetattrpos1 =
     |]
 
 case_unsafegetattrpos2 =
-    constantEqualText "[ 6 20 ]" [i|
+    constantEqualText "[ 5 14 ]" [text|
       let e = 1;
           f = 1;
           t = {};
@@ -227,7 +227,7 @@ case_unsafegetattrpos2 =
     |]
 
 case_unsafegetattrpos3 =
-    constantEqualText "[ 7 13 ]" [i|
+    constantEqualText "[ 6 7 ]" [text|
       let e = 1;
           f = 1;
           t = {};
@@ -242,7 +242,7 @@ case_unsafegetattrpos3 =
     |]
 
 case_unsafegetattrpos4 =
-    constantEqualText "[ 8 13 ]" [i|
+    constantEqualText "[ 7 7 ]" [text|
       let e = 1;
           f = 1;
           t = {};
@@ -259,7 +259,7 @@ case_unsafegetattrpos4 =
 -- jww (2018-05-09): These two are failing but they shouldn't be
 
 -- case_unsafegetattrpos5 =
---     constantEqualText "[ 7 13 ]" [i|
+--     constantEqualText "[ 7 13 ]" [text|
 --       let e = 1;
 --           f = 1;
 --           t = {};
@@ -274,7 +274,7 @@ case_unsafegetattrpos4 =
 --     |]
 
 -- case_unsafegetattrpos6 =
---     constantEqualText "[ 7 13 ]" [i|
+--     constantEqualText "[ 7 13 ]" [text|
 --       let e = 1;
 --           f = 1;
 --           t = {};
@@ -289,7 +289,7 @@ case_unsafegetattrpos4 =
 --     |]
 
 case_fixed_points =
-    constantEqualText [i|[
+    constantEqualText [text|[
   {
     foobar = "foobar";
     foo = "foo";
@@ -300,7 +300,7 @@ case_fixed_points =
     foo = "foo + ";
     bar = "bar";
   }
-]|] [i|
+]|] [text|
     let
       fix = f: let x = f x; in x;
       extends = f: rattrs: self:
@@ -313,7 +313,7 @@ case_fixed_points =
 |]
 
 case_fixed_points_and_fold =
-    constantEqualText [i|[ {} {} ]|] [i|
+    constantEqualText [text|[ {} {} ]|] [text|
 let
   extends = f: rattrs: self:
     let super = rattrs self; in super // f self super;
@@ -325,7 +325,7 @@ in [ (fix toFixFold) (fix toFix) ]
 |]
 
 case_fixed_points_attrsets =
-    constantEqualText "{ x = { y = { z = 100; }; z = { y = 100; }; }; }" [i|
+    constantEqualText "{ x = { y = { z = 100; }; z = { y = 100; }; }; }" [text|
       let fix = f: let x = f x; in x;
           f = self: { x.z.y = 100; x.y.z = self.x.z.y; };
       in fix f
@@ -360,7 +360,7 @@ case_rec_path_attr =
         "let src = 10; x = rec { passthru.src = src; }; in x.passthru.src"
 
 case_mapattrs_builtin =
-    constantEqualText' "{ a = \"afoo\"; b = \"bbar\"; }" [i|
+    constantEqualText' "{ a = \"afoo\"; b = \"bbar\"; }" [text|
       (builtins.mapAttrs (x: y: x + y) {
         a = "foo";
         b = "bar";
@@ -413,10 +413,10 @@ case_attrset_function_nested_bottom_equal =
 -- Regression test for #527
 
 case_add_string_thunk_left =
-  constantEqualText [i|"cygwin"|] [i|builtins.head ["cyg"] + "win"|]
+  constantEqualText [text|"cygwin"|] [text|builtins.head ["cyg"] + "win"|]
 
 case_add_string_thunk_right =
-  constantEqualText [i|"cygwin"|] [i|"cyg" + builtins.head ["win"]|]
+  constantEqualText [text|"cygwin"|] [text|"cyg" + builtins.head ["win"]|]
 
 case_add_int_thunk_left =
   constantEqualText "3" "builtins.head [1] + 2"
@@ -446,28 +446,33 @@ genEvalCompareTests = do
     mkTestCase td f = testCase f $ assertEvalFileMatchesNix (td </> f)
 
 constantEqual :: NExprLoc -> NExprLoc -> Assertion
-constantEqual a b = do
+constantEqual expected actual = do
     time <- getCurrentTime
     let opts = defaultOptions time
     -- putStrLn =<< lint (stripAnnotation a)
-    res <- runWithBasicEffectsIO opts $ do
-        a' <- normalForm =<< nixEvalExprLoc Nothing a
-        b' <- normalForm =<< nixEvalExprLoc Nothing b
-        valueEqM a' b'
-    assertBool "" res
+    (eq, expectedNF, actualNF) <- runWithBasicEffectsIO opts $ do
+        expectedNF <- normalForm =<< nixEvalExprLoc Nothing expected
+        actualNF <- normalForm =<< nixEvalExprLoc Nothing actual
+        eq <- valueEqM expectedNF actualNF
+        return (eq, expectedNF, actualNF)
+    let message =
+                "Inequal normal forms:\n"
+            <>  "Expected: " <> printNix expectedNF <> "\n"
+            <>  "Actual:   " <> printNix actualNF
+    assertBool message eq
 
 constantEqualText' :: Text -> Text -> Assertion
-constantEqualText' a b = do
-  let Success a' = parseNixTextLoc a
-      Success b' = parseNixTextLoc b
-  constantEqual a' b'
+constantEqualText' expected actual = do
+  let Success expected' = parseNixTextLoc expected
+      Success actual' = parseNixTextLoc actual
+  constantEqual expected' actual'
 
 constantEqualText :: Text -> Text -> Assertion
-constantEqualText a b = do
-  constantEqualText' a b
+constantEqualText expected actual = do
+  constantEqualText' expected actual
   mres <- liftIO $ lookupEnv "ALL_TESTS" <|> lookupEnv "MATCHING_TESTS"
   when (isJust mres) $
-      assertEvalMatchesNix b
+      assertEvalMatchesNix actual
 
 assertNixEvalThrows :: Text -> Assertion
 assertNixEvalThrows a = do

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -12,10 +12,10 @@ import           Control.Monad
 import           Data.Fix
 import           Data.List (isSuffixOf)
 import           Data.Maybe
-import           Data.String.Interpolate.IsString
 import           Data.Text (unpack)
 import           Data.Time
 import qualified EvalTests
+import           NeatInterpolation (text)
 import qualified Nix
 import           Nix.Expr.Types
 import           Nix.String
@@ -50,10 +50,10 @@ ensureNixpkgsCanParse =
     Fix (NAbs (ParamSet params _ _) _) -> do
       let rev    = getString "rev" params
           sha256 = getString "sha256" params
-      consider "fetchTarball expression" (pure $ parseNixTextLoc [i|
+      consider "fetchTarball expression" (pure $ parseNixTextLoc [text|
         builtins.fetchTarball {
-          url    = "https://github.com/NixOS/nixpkgs/archive/#{rev}.tar.gz";
-          sha256 = "#{sha256}";
+          url    = "https://github.com/NixOS/nixpkgs/archive/${rev}.tar.gz";
+          sha256 = "${sha256}";
         }|]) $ \expr -> do
         NVStr ns <- do
           time <- getCurrentTime
@@ -65,7 +65,7 @@ ensureNixpkgsCanParse =
           errorWithoutStackTrace $
             "Directory " ++ show dir ++ " does not exist"
         files <- globDir1 (compile "**/*.nix") (unpack dir)
-        when (length files == 0) $
+        when (null files) $
           errorWithoutStackTrace $
             "Directory " ++ show dir ++ " does not have any files"
         forM_ files $ \file -> do

--- a/tests/ParserTests.hs
+++ b/tests/ParserTests.hs
@@ -10,10 +10,10 @@ module ParserTests (tests) where
 
 import Data.Fix
 import Data.List.NonEmpty (NonEmpty(..))
-import Data.String.Interpolate.IsString
 import Data.Text (Text, unpack)
 import Data.Text.Prettyprint.Doc
 import Data.Text.Prettyprint.Doc.Render.Text
+import NeatInterpolation (text)
 import Nix.Atoms
 import Nix.Expr
 import Nix.Parser
@@ -329,12 +329,12 @@ case_comments = do
   assertParseFile "let-comments.nix" expected
 
 case_select_or_precedence =
-    assertParsePrint [i|let
+    assertParsePrint [text|let
   matchDef = def:   matcher:
                       v:   let
                              case = builtins.head (builtins.attrNames v);
                            in (matcher.case or def case) (v.case);
-in null|] [i|let
+in null|] [text|let
   matchDef = def:
     matcher:
       v:
@@ -344,12 +344,12 @@ in null|] [i|let
 in null|]
 
 case_select_or_precedence2 =
-    assertParsePrint [i|let
+    assertParsePrint [text|let
   matchDef = def:   matcher:
                       v:   let
                              case = builtins.head (builtins.attrNames v);
                            in (matcher.case or null.foo) (v.case);
-in null|] [i|let
+in null|] [text|let
   matchDef = def:
     matcher:
       v:


### PR DESCRIPTION
In addition to `interpolate`, this also removes the following
transitive dependencies:

 - `haskell-src-exts`
 - `haskell-src-meta`
 - `safe`
 - `th-expand-syns`
 - `th-lift`
 - `th-lift-instances`
 - `th-orphans`
 - `th-reify-many`

Since `neat-interpolation`'s `text` quasiquoter trims more whitespace
than `interpolate`'s `i`, the expected output of some tests for
`unsafeGetAttrPos` had to be updated.

This also improves the test failure output of the `constantEqual`
helper.

Fixes #634.