### PR TITLE
CI: .travis.yml: clean-up, cosmetics, docs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,49 +37,49 @@ env:
     # # NOTE: Switching into Nixpkgs revision
     # - NIX_PATH="nixpkgs=https://github.com/nixos/nixpkgs/archive/$rev.tar.gz"
     # NOTE: Project/binary name
-    - name=hnix
+    - name='hnix'
     # NOTE: Used in the `generateOptparseApplicativeCompletions = true`
     - pkgName='haskellPackages.hnix'
     # NOTE: Enable all our tests in cabal
-    - ALL_TESTS=yes
+    - ALL_TESTS='yes'
     # NOTE: Turn all warn into err with {-Wall,-Werror}
-    - failOnAllWarnings=false
+    - failOnAllWarnings='false'
     # NOTE: checkUnusedPackages: is `failOnAllWarnings` + `cabal sdist` to ensure all needed files are listed in the Cabal file. Uses `packunused` or GHC internals. Adds a post-build check to verify that dependencies declared in the cabal file are actually used. The first attrset argument can be used to configure the strictness of this check and a list of ignored package names that would otherwise cause false alarms.
-    - checkUnusedPackages=false
+    - checkUnusedPackages='false'
     # NOTE: Generation and installation of a coverage report.
     # See https://wiki.haskell.org/Haskell_program_coverage
-    - doCoverage=false
+    - doCoverage='false'
     # NOTE: Generation and installation of haddock API documentation
-    - doHaddock=false
+    - doHaddock='false'
     # NOTE: Escape the version bounds from the cabal file. You may want to avoid this function.
-    - doJailbreak=false
+    - doJailbreak='false'
     # NOTE: Disables Nix dependency checking, compilation and execution of test suites listed in the package description file.
-    - doCheck=true
+    - doCheck='true'
     # NOTE: doBenchmark: Dependency checking + compilation and execution for benchmarks listed in the package description file.
-    - doBenchmark=false
-    - enableExecutableProfiling=false
-    - enableLibraryProfiling=false
+    - doBenchmark='false'
+    - enableExecutableProfiling='false'
+    - enableLibraryProfiling='false'
     # NOTE: Build a source distribution tarball instead of using the source files directly. The effect is that the package is built as if it were published on hackage. This can be used as a test for the source distribution, assuming the build fails when packaging mistakes are in the cabal file.
-    - buildFromSdist=false
+    - buildFromSdist='false'
     # NOTE: Build the package in a strict way to uncover potential problems. This includes buildFromSdist and failOnAllWarnings.
     #  2020-05-26: NOTE: Currently HNix not able to pass Strict on GHC 8.8.3 due to MonalFail migration
-    - buildStrictly=false
+    - buildStrictly='false'
     # NOTE: Disable core optimizations, significantly speeds up the build
-    - disableOptimization=true
+    - disableOptimization='true'
     # NOTE: Modify a Haskell package to add shell completion scripts for the given executable produced by it. These completion scripts will be picked up automatically if the resulting derivation is installed, e.g. by `nix-env -i`.
     # Invocation:
     #   generateOptparseApplicativeCompletions command pkg
     #
     #   command: name of an executable
     #       pkg: Haskell package that builds the executables
-    - generateOptparseApplicativeCompletions=false
+    - generateOptparseApplicativeCompletions='false'
     - executableNamesToShellComplete='[ "hnix" ]'
     # NOTE: Don't fail at configure time if there are multiple versions of the same package in the (recursive) dependencies of the package being built. Will delay failures, if any, to compile time.
-    - allowInconsistentDependencies=false
+    - allowInconsistentDependencies='false'
     # NOTE: Log file to dump GHCJS build into
     - ghcjsTmpLogFile='/tmp/ghcjsTmpLogFile.log'
     # NOTE: Length of the GHCJS log tail (<40000)
-    - ghcjsLogTailLength=10000
+    - ghcjsLogTailLength='10000'
 
 #  2020-05-26: NOTE: Currently newest Travis dist Ubuntu 18.04 bionic
 # NOTE: {os} x {jobs} + {jobs:include} - {jobs:exclude} = {build matrix}
@@ -87,40 +87,40 @@ jobs:
   include:
     - name: GHC 8.4.4, Linux
       env:
-        - GHCVERSION=ghc844
-        - linkWithGold=true
+        - GHCVERSION='ghc844'
+        - linkWithGold='true'
       os: linux
       dist: bionic
     - name: GHC 8.6.5, Linux
       env:
-        - GHCVERSION=ghc865
-        - linkWithGold=true
+        - GHCVERSION='ghc865'
+        - linkWithGold='true'
       os: linux
       dist: bionic
     - name: GHC 8.8.3, macOS, Strict
       env:
-        - GHCVERSION=ghc883
-        - buildStrictly=true
+        - GHCVERSION='ghc883'
+        - buildStrictly='true'
       os: osx
     - name: GHC 8.10.1, Linux, SDist, Optimize, Benchmark, Haddock, Shell Completions
       env:
-        - GHCVERSION=ghc8101
-        - buildFromSdist=true
-        - linkWithGold=true
-        - doHaddock=true
-        - doBenchmark=true
-        - disableOptimization=false
-        - enableDeadCodeElimination=true
-        - generateOptparseApplicativeCompletions=true
+        - GHCVERSION='ghc8101'
+        - buildFromSdist='true'
+        - linkWithGold='true'
+        - doHaddock='true'
+        - doBenchmark='true'
+        - disableOptimization='false'
+        - enableDeadCodeElimination='true'
+        - generateOptparseApplicativeCompletions='true'
       os: linux
       dist: bionic
     - name: GHCJS, Linux
       env:
-        - GHCVERSION=ghcjs
+        - GHCVERSION='ghcjs'
       os: linux
       dist: bionic
   allow_failures:
-    - env: GHCVERSION=ghcjs
+    - env: GHCVERSION='ghcjs'
 
 before_script:
   - sudo mount -o remount,exec,size=4G,mode=755 /run/user || true

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,9 +29,9 @@ env:
     # { master
     # , commitHash
     # , haskell-updates  # Haskell development branch in Nixpkgs, can be inconsistent. Weekly merged into the upstream
-    # , nixpkgs-unstable
-    # , nixos-unstable
-    # , nixos-20.03
+    # , nixpkgs-unstable  # Default branch on Nix installation, default for non NixOS
+    # , nixos-unstable  # nixpkgs-unstable that passes a bunch of base tests
+    # , nixos-20.03  # Last stable release, gets almost no updates to recipes, gets only required backports
     # }
     # - rev=nixos-unstable
     # # NOTE: Switching into Nixpkgs revision

--- a/.travis.yml
+++ b/.travis.yml
@@ -73,6 +73,7 @@ env:
     #   command: name of an executable
     #       pkg: Haskell package that builds the executables
     - generateOptparseApplicativeCompletions='false'
+    # [ "binary1" "binary2" ] - should pass " quotes into Nix interpreter
     - executableNamesToShellComplete='[ "hnix" ]'
     # NOTE: Don't fail at configure time if there are multiple versions of the same package in the (recursive) dependencies of the package being built. Will delay failures, if any, to compile time.
     - allowInconsistentDependencies='false'


### PR DESCRIPTION
Further.

I think to merge most of the documentation into `build.sh`, there is too much duplication of documentation due to the nature of API going through layers of the structure, and then also Nix explicit declarativeness.