### PR TITLE
default.nix: filter package root with nix-gitignore

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -180,7 +180,7 @@ let
   # General description of package
   package = haskellPackages.developPackage {
     name = "hnix";
-    root = ./.;
+    root = pkgs.nix-gitignore.gitignoreSource [ ] ./.;
 
     modifier = drv: pkgs.haskell.lib.overrideCabal drv (attrs: {
       buildTools = (attrs.buildTools or []) ++ [


### PR DESCRIPTION
so we don't copy stuff like `dist-newstyle`.