### PR TITLE
Merge docs (`build.sh`->`default.nix`)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -108,7 +108,6 @@ jobs:
     - env: compiler='ghcjs'
 
 before_script:
-  - sudo mount -o remount,exec,size=4G,mode=755 /run/user || true
   - sudo mkdir -p /etc/nix
   - echo "trusted-users = root $USER" | sudo tee -a /etc/nix/nix.conf
   - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -110,12 +110,8 @@ jobs:
 before_script:
   - sudo mkdir -p /etc/nix
   - echo "trusted-users = root $USER" | sudo tee -a /etc/nix/nix.conf
-  - |
-    if [ "${TRAVIS_OS_NAME}" = "linux" ]; then true && \
-    sudo systemctl stop nix-daemon.service && \
-    sudo systemctl daemon-reload && \
-    sudo systemctl start nix-daemon.service && \
-    true; fi
+  # # Linux service restart
+  - if [ "${TRAVIS_OS_NAME}" = "linux" ]; then sudo systemctl restart nix-daemon.service;fi
   # # macOS service restart
   - if [ "${TRAVIS_OS_NAME}" = "osx" ]; then sudo launchctl kickstart -k system/org.nixos.nix-daemon; fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -118,11 +118,6 @@ before_script:
     true; fi
   # # macOS service restart
   - if [ "${TRAVIS_OS_NAME}" = "osx" ]; then sudo launchctl kickstart -k system/org.nixos.nix-daemon; fi
-  # update on Linux
-  - if [ "${TRAVIS_OS_NAME}" = "linux" ]; then nix-channel --update && nix-env -iA nixpkgs.nix; fi
-  # update on macOS
-  # 2020-06-24: HACK: Do not ask why different commands on Linux and macOS. IDK, wished they we the same. These are the only commands that worked on according platforms right after the fresh Nix installer rollout.
-  - if [ "${TRAVIS_OS_NAME}" = "osx" ]; then sudo nix upgrade-nix; fi
 
 script:
   #

--- a/build.sh
+++ b/build.sh
@@ -14,17 +14,6 @@ set -Eexuo pipefail
 
 # NOTE: If vars not imported - set to the default value
 compiler=${compiler:-'ghc8101'}
-# NOTE: Nix by default uses nixpkgs-unstable channel
-# Setup for Nixpkgs revision:
-#   `rev` vals in order of freshness -> cache & stability:
-#   { master
-#   , commitHash
-#   , haskell-updates  # Haskell development branch in Nixpkgs, can be inconsistent. Weekly merged into the upstream
-#   , nixpkgs-unstable  # Default branch on Nix installation, default for non NixOS
-#   , nixos-unstable  # nixpkgs-unstable that passes a bunch of base tests
-#   , nixos-20.03  # Last stable release, gets almost no updates to recipes, gets only required backports
-#   ...
-#   }
 rev=${rev:-'nixpkgs-unstable'}
 # If NIX_PATH not imported - construct it from `rev`
 NIX_PATH=${NIX_PATH:-"nixpkgs=https://github.com/nixos/nixpkgs/archive/$rev.tar.gz"}

--- a/build.sh
+++ b/build.sh
@@ -22,70 +22,42 @@ export NIX_PATH
 project=${project:-'defaultProjectName'}
 
 
-# Don't fail at configure time if there are multiple versions of the same package in the (recursive) dependencies of the package being built. Will delay failures, if any, to compile time.
 allowInconsistentDependencies=${allowInconsistentDependencies:-'false'}
-# Escape the version bounds from the cabal file. You may want to avoid this function.
 doJailbreak=${doJailbreak:-'false'}
-# Nix dependency checking, compilation and execution of test suites listed in the package description file.
 doCheck=${doCheck:-'true'}
 
-# Just produce a SDist src tarball
 sdistTarball=${sdistTarball:-'false'}
-# Produce SDist tarball and build project from it
-# The strict packaging process as used on Hackage. Tests consistency of the Cabal file.
 buildFromSdist=${buildFromSdist:-'false'}
 
-# Turn all warn into err with {-Wall,-Werror}
 failOnAllWarnings=${failOnAllWarnings:-'false'}
-# `failOnAllWarnings` + `buildFromSdist`
 buildStrictly=${buildStrictly:-'false'}
 
-#  2020-06-02: NOTE: enableDeadCodeElimination = true: On GHC =< 8.8.3 macOS build falls due to https://gitlab.haskell.org/ghc/ghc/issues/17283
 enableDeadCodeElimination=${enableDeadCodeElimination:-'false'}
-# Disabled GHC code optimizations make build/tolling/dev loops faster. Works for Haskel IDE Engine and GHCID
-# Enable optimizations for production use, and to pass benchmarks.
 disableOptimization=${disableOptimization:-'true'}
-# Use faster `gold` ELF linker from GNU binutils instead of older&slower but more versatile GNU linker. Is not available by default since macOS does not have it.
 linkWithGold=${linkWithGold:-'false'}
 
-# Provide an inventory of performance events and timings for the execution. Provides informaiton in an absolute sense. Nothing is timestamped.
 enableLibraryProfiling=${enableLibraryProfiling:-'false'}
 enableExecutableProfiling=${enableExecutableProfiling:-'false'}
-# Include tracing information & abilities. Tracing records the chronology, often with timestamps and is extensive in time
 doTracing=${doTracing:-'false'}
-# Include DWARF debugging information & abilities
 enableDWARFDebugging=${enableDWARFDebugging:-'false'}
-# Strip results from all debugging symbols
 doStrip=${doStrip:-'false'}
 
-# Nixpkgs expects shared libraries
 enableSharedLibraries=${enableSharedLibraries:-'true'}
-# Ability to make static libraries
 enableStaticLibraries=${enableStaticLibraries:-'false'}
-# Make hybrid executable that is also a shared library
 enableSharedExecutables=${enableSharedExecutables:-'false'}
-# link executables statically against haskell libs to reduce closure size
 justStaticExecutables=${justStaticExecutables:-'false'}
 enableSeparateBinOutput=${enableSeparateBinOutput:-'false'}
 
-# Add a post-build check to verify that dependencies declared in the .cabal file are actually used.
-# checkUnusedPackages: is `failOnAllWarnings` + `cabal sdist` to ensure all needed files are listed in the Cabal file. Currently uses `packunused` or GHC 8.8 internals, later switches into GHC internal feature. Adds a post-build check to verify that dependencies declared in the cabal file are actually used.
 checkUnusedPackages=${checkUnusedPackages:-'false'}
-# Generation and installation of haddock API documentation
 doHaddock=${doHaddock:-'false'}
-#	Generate hyperlinked source code for documentation using HsColour, and have Haddock documentation link to it.
 doHyperlinkSource=${doHyperlinkSource:-'false'}
-# Generation and installation of a coverage report. See https://wiki.haskell.org/Haskell_program_coverage
 doCoverage=${doCoverage:-'false'}
-# doBenchmark: Dependency checking + compilation and execution for benchmarks listed in the package description file.
 doBenchmark=${doBenchmark:-'false'}
-# For binaries named in `executableNamesToShellComplete` list, generate and bundle-into package an automatically loaded shell complettions
 generateOptparseApplicativeCompletions=${generateOptparseApplicativeCompletions:-'false'}
 # [ "binary1" "binary2" ] - should pass " quotes into Nix interpreter
 executableNamesToShellComplete=${executableNamesToShellComplete:-'[ "defaultBinaryName" ]'}
 
 
-# Include Hoogle into derivation
 withHoogle=${withHoogle:-'false'}
 
 # Log file to dump GHCJS build into

--- a/build.sh
+++ b/build.sh
@@ -6,10 +6,11 @@
 set -Eexuo pipefail
 
 ### NOTE: Section handles imports from env, these are settings for Nixpkgs.
+# Settings expose most of the Nixpkgs Haskell.lib API: https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/haskell-modules/lib.nix
 # Some of these options implicitly switch the dependent options.
 
 
-# NOTE: If var not imported - set to the default value
+# NOTE: If vars not imported - set to the default value
 compiler=${compiler:-'ghc8101'}
 # NOTE: Nix by default uses nixpkgs-unstable channel
 # Setup for Nixpkgs revision:
@@ -29,24 +30,25 @@ export NIX_PATH
 # NOTE: Project name, used by cachix
 project=${project:-'defaultProjectName'}
 
-# This settings expose most of the Nixpkgs Haskell.lib API: https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/haskell-modules/lib.nix
 
 # Don't fail at configure time if there are multiple versions of the same package in the (recursive) dependencies of the package being built. Will delay failures, if any, to compile time.
 allowInconsistentDependencies=${allowInconsistentDependencies:-'false'}
-
 # Escape the version bounds from the cabal file. You may want to avoid this function.
 doJailbreak=${doJailbreak:-'false'}
 # Nix dependency checking, compilation and execution of test suites listed in the package description file.
 doCheck=${doCheck:-'true'}
+
 # Just produce a SDist src tarball
 sdistTarball=${sdistTarball:-'false'}
 # Produce SDist tarball and build project from it
 # The strict packaging process as used on Hackage. Tests consistency of the Cabal file.
 buildFromSdist=${buildFromSdist:-'false'}
+
 # Turn all warn into err with {-Wall,-Werror}
 failOnAllWarnings=${failOnAllWarnings:-'false'}
 # `failOnAllWarnings` + `buildFromSdist`
 buildStrictly=${buildStrictly:-'false'}
+
 #  2020-06-02: NOTE: enableDeadCodeElimination = true: On GHC =< 8.8.3 macOS build falls due to https://gitlab.haskell.org/ghc/ghc/issues/17283
 enableDeadCodeElimination=${enableDeadCodeElimination:-'false'}
 # Disabled GHC code optimizations make build/tolling/dev loops faster. Works for Haskel IDE Engine and GHCID
@@ -54,6 +56,7 @@ enableDeadCodeElimination=${enableDeadCodeElimination:-'false'}
 disableOptimization=${disableOptimization:-'true'}
 # Use faster `gold` ELF linker from GNU binutils instead of older&slower but more versatile GNU linker. Is not available by default since macOS does not have it.
 linkWithGold=${linkWithGold:-'false'}
+
 # Provide an inventory of performance events and timings for the execution. Provides informaiton in an absolute sense. Nothing is timestamped.
 enableLibraryProfiling=${enableLibraryProfiling:-'false'}
 enableExecutableProfiling=${enableExecutableProfiling:-'false'}
@@ -63,6 +66,7 @@ doTracing=${doTracing:-'false'}
 enableDWARFDebugging=${enableDWARFDebugging:-'false'}
 # Strip results from all debugging symbols
 doStrip=${doStrip:-'false'}
+
 # Nixpkgs expects shared libraries
 enableSharedLibraries=${enableSharedLibraries:-'true'}
 # Ability to make static libraries
@@ -72,6 +76,7 @@ enableSharedExecutables=${enableSharedExecutables:-'false'}
 # link executables statically against haskell libs to reduce closure size
 justStaticExecutables=${justStaticExecutables:-'false'}
 enableSeparateBinOutput=${enableSeparateBinOutput:-'false'}
+
 # Add a post-build check to verify that dependencies declared in the .cabal file are actually used.
 # checkUnusedPackages: is `failOnAllWarnings` + `cabal sdist` to ensure all needed files are listed in the Cabal file. Currently uses `packunused` or GHC 8.8 internals, later switches into GHC internal feature. Adds a post-build check to verify that dependencies declared in the cabal file are actually used.
 checkUnusedPackages=${checkUnusedPackages:-'false'}
@@ -87,6 +92,7 @@ doBenchmark=${doBenchmark:-'false'}
 generateOptparseApplicativeCompletions=${generateOptparseApplicativeCompletions:-'false'}
 # [ "binary1" "binary2" ] - should pass " quotes into Nix interpreter
 executableNamesToShellComplete=${executableNamesToShellComplete:-'[ "defaultBinaryName" ]'}
+
 
 # Include Hoogle into derivation
 withHoogle=${withHoogle:-'false'}

--- a/build.sh
+++ b/build.sh
@@ -12,13 +12,13 @@ set -Eexuo pipefail
 ### Additional documentation is in Nixpkgs Haskell.lib: https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/haskell-modules/lib.nix
 
 
-# NOTE: If vars not imported - set to the default value
+# NOTE: If vars not imported - init the vars with default values
 compiler=${compiler:-'ghc8101'}
 rev=${rev:-'nixpkgs-unstable'}
 # If NIX_PATH not imported - construct it from `rev`
 NIX_PATH=${NIX_PATH:-"nixpkgs=https://github.com/nixos/nixpkgs/archive/$rev.tar.gz"}
 export NIX_PATH
-# NOTE: Project name, used by cachix
+# Project name, used by cachix
 project=${project:-'defaultProjectName'}
 
 
@@ -72,7 +72,7 @@ CACHIX_SIGNING_KEY=${CACHIX_SIGNING_KEY:-""}
 GHCJS_BUILD(){
 # NOTE: Function for GHCJS build that outputs its huge log into a file
 
-  # NOTE: Run the build into Log (log is too long for Travis)
+  # Run the build into Log (log is too long for Travis)
   "$@" &> "$ghcjsTmpLogFile"
 
 }
@@ -82,19 +82,19 @@ SILENT(){
 # In normal mode outputs only the /nix/store paths
 
   echo "Log: $ghcjsTmpLogFile"
-  # NOTE: Pass into the ghcjsbuild function the build command
+  # Pass into the ghcjsbuild function the build command
   if GHCJS_BUILD "$@"
   then
 
-    # NOTE: Output log lines for stdout -> cachix caching
+    # Output log lines for stdout -> cachix caching
     grep '^/nix/store/' "$ghcjsTmpLogFile"
 
   else
 
-    # NOTE: Output log lines for stdout -> cachix caching
+    # Output log lines for stdout -> cachix caching
     grep '^/nix/store/' "$ghcjsTmpLogFile"
 
-    # NOTE: Propagate the error state, fail the CI build
+    # Propagate the error state, fail the CI build
     exit 1
 
   fi
@@ -109,7 +109,7 @@ IFS=$'\n\t'
 if [ "$compiler" = "ghcjs" ]
   then
 
-    # NOTE: GHCJS build
+    # GHCJS build
     # By itself, GHCJS creates >65000 lines of log that are >4MB in size, so Travis terminates due to log size quota.
     # nixbuild --quiet (x5) does not work on GHC JS build
     # So there was a need to make it build.
@@ -149,8 +149,8 @@ if [ "$compiler" = "ghcjs" ]
 
   else
 
-    # NOTE: Normal GHC build
-    # NOTE: GHC sometimes produces logs so big - that Travis terminates builds, so multiple --quiet
+    # Normal GHC build
+    # GHC sometimes produces logs so big - that Travis terminates builds, so multiple --quiet
     nix-build \
       --quiet --quiet \
       --argstr compiler "$compiler" \
@@ -188,31 +188,30 @@ fi
 MAIN() {
 
 
-# NOTE: Overall it is useful to have in CI test builds the latest stable Nix
-# NOTE: User-run Linux setup old update command, or superuser update for macOS setup
-#  2020-06-24: HACK: Do not ask why different commands on Linux and macOS. IDK, wished they we the same. These are the only commands that worked on according platforms right after the fresh Nix installer rollout.
+# Overall it is useful to have in CI test builds the latest stable Nix
+# 2020-06-24: HACK: Do not ask why different commands on Linux and macOS. IDK, wished they we the same. These are the only commands that worked on according platforms right after the fresh Nix installer rollout.
 (nix-channel --update && nix-env -iA nixpkgs.nix) || (sudo nix upgrade-nix)
 
 
 
-# NOTE: Secrets are not shared to PRs from forks
-# NOTE: nix-build | cachix push <project> - uploads binaries, runs&works only in the branches of the main repository, so for PRs - else case runs
+# Secrets are not shared to PRs from forks
+# nix-build | cachix push <project> - uploads binaries, runs&works only in the branches of the main repository, so for PRs - else case runs
 
   if [ ! "$CACHIX_SIGNING_KEY" = "" ]
 
     then
 
-      # NOTE: Build of the inside repo branch - enable push Cachix cache
+      # Build of the inside repo branch - enable push Cachix cache
       BUILD_PROJECT | cachix push "$project"
 
     else
 
-      # NOTE: Build of the side repo/PR - can not push Cachix cache
+      # Build of the side repo/PR - can not push Cachix cache
       BUILD_PROJECT
 
   fi
 
 }
 
-# NOTE: Run the entry function of the script
+# Run the entry function of the script
 MAIN

--- a/build.sh
+++ b/build.sh
@@ -193,6 +193,9 @@ MAIN() {
 (nix-channel --update && nix-env -iA nixpkgs.nix) || (sudo nix upgrade-nix)
 
 
+# Report the Nixpkgs channel revision
+nix-instantiate --eval -E 'with import <nixpkgs> {}; lib.version or lib.nixpkgsVersion'
+
 
 # Secrets are not shared to PRs from forks
 # nix-build | cachix push <project> - uploads binaries, runs&works only in the branches of the main repository, so for PRs - else case runs

--- a/build.sh
+++ b/build.sh
@@ -6,8 +6,10 @@
 set -Eexuo pipefail
 
 ### NOTE: Section handles imports from env, these are settings for Nixpkgs.
-# Settings expose most of the Nixpkgs Haskell.lib API: https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/haskell-modules/lib.nix
-# Some of these options implicitly switch the dependent options.
+### They use the `default.nix` interface, which exposes expose most of the Nixpkgs Haskell.lib API: https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/haskell-modules/lib.nix
+### Some of these options implicitly switch the dependent options.
+### Documentation of this settings is mosly in `default.nix`, since most settings it Nixpkgs related
+### Additional documentation is in Nixpkgs Haskell.lib: https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/haskell-modules/lib.nix
 
 
 # NOTE: If vars not imported - set to the default value

--- a/default.nix
+++ b/default.nix
@@ -68,7 +68,17 @@
 
 
 , useRev ? false
-# Accepts Nixpkgs channel name and Git revision
+# Nix by default uses nixpkgs-unstable channel
+# Nixpkgs revision options:
+#   `rev` vals in order of freshness -> cache & stability:
+#   { master
+#   , <commitHash>
+#   , haskell-updates  # Haskell development branch in Nixpkgs, can be inconsistent. Weekly merged into the upstream
+#   , nixpkgs-unstable  # Default branch on Nix installation, default for non NixOS
+#   , nixos-unstable  # nixpkgs-unstable that passes a bunch of base tests
+#   , nixos-20.03  # Last stable release, gets almost no updates to recipes, gets only required backports
+#   ...
+#   }
 , rev ? "nixpkgs-unstable"
 
 , pkgs ?

--- a/default.nix
+++ b/default.nix
@@ -12,19 +12,23 @@
 , doJailbreak ? false
 # Nix dependency checking, compilation and execution of test suites listed in the package description file.
 , doCheck     ? true
+
 # Just produce a SDist src tarball
 , sdistTarball ? false
 # Produce SDist tarball and build project from it
 , buildFromSdist ? true
+
 , failOnAllWarnings ? false
 # `failOnAllWarnings` + `buildFromSdist`
 , buildStrictly ? false
+
 #  2020-06-02: NOTE: enableDeadCodeElimination = true: On GHC =< 8.8.3 macOS build falls due to https://gitlab.haskell.org/ghc/ghc/issues/17283
 , enableDeadCodeElimination ? false
 # Disable GHC code optimizations for faster dev loops. Enable optimizations for production use or benchmarks.
 , disableOptimization ? true
 # Use faster `gold` ELF linker from GNU binutils instead of older&slower but more versatile GNU linker. Is not available by default since macOS does not have it.
 , linkWithGold ? false
+
 # Provide an inventory of performance events and timings for the execution. Provides informaiton in an absolute sense. Nothing is timestamped.
 , enableLibraryProfiling ? false
 , enableExecutableProfiling ? false
@@ -34,8 +38,7 @@
 , enableDWARFDebugging ? true
 # Strip results from all debugging symbols
 , doStrip ? false
-#	Generate hyperlinked source code for documentation using HsColour, and have Haddock documentation link to it.
-, doHyperlinkSource ? false
+
 # Nixpkgs expects shared libraries
 , enableSharedLibraries ? true
 # Ability to make static libraries
@@ -45,10 +48,13 @@
 # link executables statically against haskell libs to reduce closure size
 , justStaticExecutables ? false
 , enableSeparateBinOutput ? false
+
 # Add a post-build check to verify that dependencies declared in the .cabal file are actually used.
 , checkUnusedPackages ? false
 # Generation and installation of haddock API documentation
 , doHaddock   ? false
+#	Generate hyperlinked source code for documentation using HsColour, and have Haddock documentation link to it.
+, doHyperlinkSource ? false
 # Generation and installation of a coverage report. See https://wiki.haskell.org/Haskell_program_coverage
 , doCoverage  ? false
 # doBenchmark: Dependency checking + compilation and execution for benchmarks listed in the package description file.
@@ -56,6 +62,7 @@
 # Modify a Haskell package to add shell completion scripts for the given executable produced by it. These completion scripts will be picked up automatically if the resulting derivation is installed
 , generateOptparseApplicativeCompletions ? false
 , executableNamesToShellComplete ? [ "hnix" ]
+
 
 , withHoogle  ? true
 

--- a/default.nix
+++ b/default.nix
@@ -15,16 +15,19 @@
 
 # Just produce a SDist src tarball
 , sdistTarball ? false
-# Produce SDist tarball and build project from it
+# The strict packaging process as used on Hackage. Tests consistency of the Cabal file.
 , buildFromSdist ? true
 
+# Turn all warn into err with {-Wall,-Werror}
 , failOnAllWarnings ? false
 # `failOnAllWarnings` + `buildFromSdist`
 , buildStrictly ? false
 
 #  2020-06-02: NOTE: enableDeadCodeElimination = true: On GHC =< 8.8.3 macOS build falls due to https://gitlab.haskell.org/ghc/ghc/issues/17283
 , enableDeadCodeElimination ? false
-# Disable GHC code optimizations for faster dev loops. Enable optimizations for production use or benchmarks.
+# Disabled GHC code optimizations make build/tolling/dev loops faster.
+# Works also for Haskel IDE Engine and GHCID.
+# Enable optimizations for production use, and to pass benchmarks.
 , disableOptimization ? true
 # Use faster `gold` ELF linker from GNU binutils instead of older&slower but more versatile GNU linker. Is not available by default since macOS does not have it.
 , linkWithGold ? false
@@ -49,7 +52,9 @@
 , justStaticExecutables ? false
 , enableSeparateBinOutput ? false
 
-# Add a post-build check to verify that dependencies declared in the .cabal file are actually used.
+# checkUnusedPackages: is `failOnAllWarnings` + `cabal sdist` + post-build dep check.
+# Currently uses `packunused` or GHC 8.8 internals, later switches into GHC internal feature.
+# Adds a post-build check to verify that dependencies declared in the cabal file are actually used.
 , checkUnusedPackages ? false
 # Generation and installation of haddock API documentation
 , doHaddock   ? false
@@ -59,11 +64,12 @@
 , doCoverage  ? false
 # doBenchmark: Dependency checking + compilation and execution for benchmarks listed in the package description file.
 , doBenchmark ? false
-# Modify a Haskell package to add shell completion scripts for the given executable produced by it. These completion scripts will be picked up automatically if the resulting derivation is installed
+# For binaries named in `executableNamesToShellComplete` list, generate and bundle-into package an automatically loaded shell complettions
 , generateOptparseApplicativeCompletions ? false
 , executableNamesToShellComplete ? [ "hnix" ]
 
 
+# Include Hoogle into derivation
 , withHoogle  ? true
 
 


### PR DESCRIPTION
Good. This looks good.

 - [x] Included some minor clean-up.

  - [x] This consolidates most of the docs for options in the `default.nix`, since it is an entry point for API, it increases its header, but currently, I do not know the more useful, convenient way to expose all these features to the all users.

  This closes the #645.

  - [x] With Nix installer rollout and after refactoring removing obviously redundant previous hack Nix updates in `.travis.yml`.

  - [x] After refactor observed that service changes do not need the `daemon-reload`, so simplified the service to `restart`.

  - [x] We still have Nix and channel update right before builds, so I also added into `build.sh` reporting of Nixpkgs revision of the build.
