### PR TITLE
changelog: add note that binary only for GHC > 8.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+General:
+  * Binary builds only when `GHC >= 8.10` due to easier `haskeline >= 0.8 && < 0.9`.
+
 ## [0.9.0](https://github.com/haskell-nix/hnix/compare/0.8.0...0.9.0) (2020-06-15)
 
 * Changelog started. Previous release was `0.8.0`. In new release:


### PR DESCRIPTION
Nearest Nixpkgs (uses GHC 8.8.3 by default) update shown that note on binary
should be added. Some people may compile/package for binary and wonder why it is
not in the result.