### PR TITLE
Add cabal.project, only .gitignore cabal.project.local

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,7 @@
 /nix-test-eval*
 /nix/
 TAGS
-cabal.project*
+cabal.project.local
 ctags
 dist-newstyle
 result*

--- a/cabal.project
+++ b/cabal.project
@@ -1,0 +1,2 @@
+packages:
+  ./hnix.cabal


### PR DESCRIPTION
This prevents accidental surprises like the one I've managed to hit
today - `git worktree add master` and cabal build in master directory
tries to look-up `cabal.project` but only discovers one in parent
directory and starts reusing `dist-newstyle` for the build.

Better to have this explicit which devs can also use as a template to
add other temporary deps.

Edit: Reflect edited commit message typos.