### PR TITLE
CI: .travis.yml: switch all builds to nixos-unstable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,9 +31,10 @@ env:
     ### Additional documentation is in Nixpkgs Haskell.lib: https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/haskell-modules/lib.nix
     ###
     #
-    # - rev=nixos-unstable
     # - NIX_PATH="nixpkgs=https://github.com/nixos/nixpkgs/archive/$rev.tar.gz"
     - project='hnix'
+    - useRev='true'
+    - rev='nixos-unstable'
     - allowInconsistentDependencies='false'
     - doJailbreak='false'
     - doCheck='true'


### PR DESCRIPTION
I wanted to try `nixpkgs-unstable` for CI.
And it seems to have not enough stability.

So I as thought previously, decided to switch to more tested `nixos-unstable`.

Also, this month `peti` is on vacation, so the Haskell stack in Nix would take a hit, we better use more stable branch.

So this month is definitely a Nixpkgs "dodging" month.

This is a temporary CI patching anyway, we would untie full relevance on Nixpkgs and introduce classic build and more flexibility in the CI.