### PR TITLE
2020 07 13 Changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,8 +21,8 @@
     * `instance MonadException m => MonadException(StateT(HashMap FilePath NExprLoc) m)`
     * `instance MonadException m => MonadException(Fix1T StandardTF m)`
 
-* Minor:
-  * Added support for `GHC 8.10`
+* Additional:
+  * Library: Official support for `GHC 8.4 - 8.10`
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,15 +2,17 @@
 
 ## [0.9.1](https://github.com/haskell-nix/hnix/compare/0.9.0...0.9.1) (2020-07-13)
 
-* `builtins.nixVersion` bumped from 2.0 to 2.3
-* Documentation improvements for `Nix.{Atoms,Expr.Types}`
-* Reduced number of dependencies
-* REPL improvements
-  * Better tab completion
-  * Multi-line input
-  * Support for passing evaluated expression result of `hnix --eval -E`
-    to REPL as `input` variable.
-  * Support for loading `.hnixrc` from current directory
+* Additional:
+  * REPL improvements
+    * Better tab completion
+    * Multi-line input
+    * Support for passing evaluated expression result of `hnix --eval -E`
+      to REPL as `input` variable.
+    * Support for loading `.hnixrc` from current directory
+  * `builtins.nixVersion` bumped from 2.0 to 2.3
+  * Dependencies:
+    * Freed from: `interpolate`, `contravariant`, `semigroups`, `generic-random`, `tasty-quickcheck`
+    * `repline` now `>= 0.4.0.0 && < 0.5`
 
 ## [0.9.0](https://github.com/haskell-nix/hnix/compare/0.8.0...0.9.0) (2020-06-15)
 


### PR DESCRIPTION
Changelogs should be terse and share the required info.

All this info is not maintainer/engineer action related and does not include in PVP requirements.
It should be explicitly indicated, users should be informed that for lib update and use there is nothing to do for them to support new version, so moved everything to "additional" info.

Reduced: "Documentation improvements", there is no meaning informing users on documentation changes.

"Reduced number of dependencies" does not hold any info except what anyway would happen for users - closure and deps would be reduced automatically. So not include it at all or enumerate what deps changed, since `repline` is important change - enumerated dep changes.