### PR TITLE
Fix Nix build

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -209,9 +209,25 @@ let
 
     overrides = self: super: {
       # 2020-06-26 Due to a behaviour change in neat-interpolation-0.4, we
-      # require n-i >= 0.4. dontCheck helps us avoid conflicts with
-      # neat-interpolation's test dependencies.
-      neat-interpolation = pkgs.haskell.lib.dontCheck super.neat-interpolation_0_5_1;
+      # require n-i >= 0.4.
+      neat-interpolation = haskellPackages.callPackage
+       ({ mkDerivation, base, megaparsec, QuickCheck, quickcheck-instances
+        , rerebase, tasty, tasty-hunit, tasty-quickcheck, template-haskell
+        , text, stdenv
+        }:
+        mkDerivation {
+          pname = "neat-interpolation";
+          version = "0.5.1.1";
+          sha256 = "1bjl2k3b42kqwq15fsnjxxcadsch5dck9cwf8zvnh4gkyfmkbbx4";
+          libraryHaskellDepends = [ base megaparsec template-haskell text ];
+          testHaskellDepends = [
+            QuickCheck quickcheck-instances rerebase tasty tasty-hunit
+            tasty-quickcheck
+          ];
+          description = "A quasiquoter for neat and simple multiline text interpolation";
+          license = stdenv.lib.licenses.mit;
+          hydraPlatforms = stdenv.lib.platforms.none;
+        }) {};
 
       # 2020-07-23 hnix uses multiple functions that are unavailable in
       # data-fix < 0.3.


### PR DESCRIPTION
Recent versions of Nixpkgs don't provide neat-interpolation_0_5_1.