### PR TITLE
Use prettyprinter-1.7.0

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -228,6 +228,34 @@ let
           description = "Fixpoint data types";
           license = stdenv.lib.licenses.bsd3;
         }) {};
+
+      # 2020-08-04 hnix uses custom LayoutOptions and therefore is
+      # likely to be affected by the change in the ribbon width
+      # calculation in prettyprinter-1.7.0.
+      prettyprinter = haskellPackages.callPackage
+       ({ mkDerivation, ansi-wl-pprint, base, base-compat, bytestring
+        , containers, deepseq, doctest, gauge, mtl, pgp-wordlist
+        , QuickCheck, quickcheck-instances, random, tasty, tasty-hunit
+        , tasty-quickcheck, text, transformers, stdenv
+        }:
+        mkDerivation {
+          pname = "prettyprinter";
+          version = "1.7.0";
+          sha256 = "19z04sn0kqxgwcyfn5igjmbxw13xsb3mdhdidkb3kzswib78f6sr";
+          isLibrary = true;
+          isExecutable = true;
+          libraryHaskellDepends = [ base text ];
+          testHaskellDepends = [
+            base bytestring doctest pgp-wordlist QuickCheck
+            quickcheck-instances tasty tasty-hunit tasty-quickcheck text
+          ];
+          benchmarkHaskellDepends = [
+            ansi-wl-pprint base base-compat containers deepseq gauge mtl
+            QuickCheck random text transformers
+          ];
+          description = "A modern, easy to use, well-documented, extensible pretty-printer";
+          license = stdenv.lib.licenses.bsd2;
+        }) {};
     };
 
     modifier = drv: pkgs.haskell.lib.overrideCabal drv (attrs: {

--- a/hnix.cabal
+++ b/hnix.cabal
@@ -415,7 +415,7 @@ library
     , neat-interpolation >= 0.4 && < 0.6
     , optparse-applicative >= 0.14.3 && < 0.16
     , parser-combinators >= 1.0.1 && < 1.3
-    , prettyprinter >= 1.2.1 && < 1.7
+    , prettyprinter >= 1.7.0 && < 1.8
     , process >= 1.6.3 && < 1.7
     , ref-tf >= 0.4.0 && < 0.5
     , regex-tdfa >= 1.2.3 && < 1.4

--- a/main/Main.hs
+++ b/main/Main.hs
@@ -26,8 +26,6 @@ import           Data.Time
 import qualified Data.Text                     as Text
 import qualified Data.Text.IO                  as Text
 import qualified Data.Text.Lazy.IO             as TL
-import           Data.Text.Prettyprint.Doc
-import           Data.Text.Prettyprint.Doc.Render.Text
 import           Nix
 import           Nix.Convert
 import qualified Nix.Eval                      as Eval
@@ -43,6 +41,8 @@ import           Nix.Utils
 import           Nix.Var
 import           Nix.Value.Monad
 import           Options.Applicative     hiding ( ParserResult(..) )
+import           Prettyprinter
+import           Prettyprinter.Render.Text
 import qualified Repl
 import           System.FilePath
 import           System.IO

--- a/main/Repl.hs
+++ b/main/Repl.hs
@@ -36,9 +36,6 @@ import qualified Data.HashMap.Lazy
 import           Data.Text                      (Text)
 import qualified Data.Text
 import qualified Data.Text.IO
-import           Data.Text.Prettyprint.Doc      (Doc, (<+>))
-import qualified Data.Text.Prettyprint.Doc
-import qualified Data.Text.Prettyprint.Doc.Render.Text
 import           Data.Version                   ( showVersion )
 import           Paths_hnix                     ( version )
 
@@ -46,6 +43,10 @@ import           Control.Monad.Catch
 import           Control.Monad.Identity
 import           Control.Monad.Reader
 import           Control.Monad.State.Strict
+
+import           Prettyprinter                  (Doc, (<+>))
+import qualified Prettyprinter
+import qualified Prettyprinter.Render.Text
 
 import           System.Console.Haskeline.Completion
                                                 ( Completion(isFinished)
@@ -456,9 +457,9 @@ helpOptions =
       "set"
       ""
       (    "Set REPL option"
-        <> Data.Text.Prettyprint.Doc.line
+        <> Prettyprinter.line
         <> "Available options:"
-        <> Data.Text.Prettyprint.Doc.line
+        <> Prettyprinter.line
         <> (renderSetOptions helpSetOptions)
       )
       setConfig
@@ -508,14 +509,14 @@ helpSetOptions =
 
 renderSetOptions :: [HelpSetOption] -> Doc ()
 renderSetOptions so =
-  Data.Text.Prettyprint.Doc.indent 4
-    $ Data.Text.Prettyprint.Doc.vsep
+  Prettyprinter.indent 4
+    $ Prettyprinter.vsep
     $ flip map so
     $ \h ->
-             Data.Text.Prettyprint.Doc.pretty (helpSetOptionName h)
+             Prettyprinter.pretty (helpSetOptionName h)
          <+> helpSetOptionSyntax h
-         <>  Data.Text.Prettyprint.Doc.line
-         <>  Data.Text.Prettyprint.Doc.indent 4 (helpSetOptionDoc h)
+         <>  Prettyprinter.line
+         <>  Prettyprinter.indent 4 (helpSetOptionDoc h)
 
 help :: (MonadNix e t f m, MonadIO m)
      => HelpOptions e t f m
@@ -526,14 +527,14 @@ help hs _ = do
   forM_ hs $ \h ->
       liftIO
     . Data.Text.IO.putStrLn
-    . Data.Text.Prettyprint.Doc.Render.Text.renderStrict
-    . Data.Text.Prettyprint.Doc.layoutPretty
-        Data.Text.Prettyprint.Doc.defaultLayoutOptions
+    . Prettyprinter.Render.Text.renderStrict
+    . Prettyprinter.layoutPretty
+        Prettyprinter.defaultLayoutOptions
     $     ":"
-       <>  Data.Text.Prettyprint.Doc.pretty (helpOptionName h)
+       <>  Prettyprinter.pretty (helpOptionName h)
        <+> helpOptionSyntax h
-       <>  Data.Text.Prettyprint.Doc.line
-       <>  Data.Text.Prettyprint.Doc.indent 4 (helpOptionDoc h)
+       <>  Prettyprinter.line
+       <>  Prettyprinter.indent 4 (helpOptionDoc h)
 
 options
   :: (MonadNix e t f m, MonadIO m)

--- a/src/Nix/Effects/Basic.hs
+++ b/src/Nix/Effects/Basic.hs
@@ -23,7 +23,6 @@ import           Data.List.Split
 import           Data.Maybe                     ( maybeToList )
 import           Data.Text                      ( Text )
 import qualified Data.Text                     as Text
-import           Data.Text.Prettyprint.Doc
 import           Nix.Atoms
 import           Nix.Convert
 import           Nix.Effects
@@ -44,6 +43,7 @@ import           Nix.String.Coerce
 import           Nix.Utils
 import           Nix.Value
 import           Nix.Value.Monad
+import           Prettyprinter
 import           System.FilePath
 
 #ifdef MIN_VERSION_ghc_datasize

--- a/src/Nix/Exec.hs
+++ b/src/Nix/Exec.hs
@@ -39,7 +39,6 @@ import           Data.List
 import qualified Data.List.NonEmpty            as NE
 import           Data.Text                      ( Text )
 import qualified Data.Text                     as Text
-import           Data.Text.Prettyprint.Doc
 import           Data.Typeable
 import           Nix.Atoms
 import           Nix.Cited
@@ -59,6 +58,7 @@ import           Nix.Utils
 import           Nix.Value
 import           Nix.Value.Equal
 import           Nix.Value.Monad
+import           Prettyprinter
 #ifdef MIN_VERSION_pretty_show
 import qualified Text.Show.Pretty as PS
 #endif

--- a/src/Nix/Parser.hs
+++ b/src/Nix/Parser.hs
@@ -71,9 +71,6 @@ import           Data.Text               hiding ( map
                                                 , concatMap
                                                 , zipWith
                                                 )
-import           Data.Text.Prettyprint.Doc      ( Doc
-                                                , pretty
-                                                )
 import           Data.Text.Encoding
 import           Data.Typeable                  ( Typeable )
 import           Data.Void
@@ -81,6 +78,9 @@ import           GHC.Generics            hiding ( Prefix )
 import           Nix.Expr                hiding ( ($>) )
 import           Nix.Expr.Strings
 import           Nix.Render
+import           Prettyprinter                  ( Doc
+                                                , pretty
+                                                )
 import           Text.Megaparsec
 import           Text.Megaparsec.Char
 import qualified Text.Megaparsec.Char.Lexer    as L

--- a/src/Nix/Pretty.hs
+++ b/src/Nix/Pretty.hs
@@ -36,7 +36,6 @@ import           Data.Text                      ( pack
                                                 , strip
                                                 )
 import qualified Data.Text                     as Text
-import           Data.Text.Prettyprint.Doc
 import           Nix.Atoms
 import           Nix.Cited
 import           Nix.Expr
@@ -52,6 +51,7 @@ import           Nix.Utils               hiding ( (<$>) )
 #endif
 import           Nix.Value
 import           Prelude                 hiding ( (<$>) )
+import           Prettyprinter
 import           Text.Read                      ( readMaybe )
 
 -- | This type represents a pretty printed nix expression

--- a/src/Nix/Render.hs
+++ b/src/Nix/Render.hs
@@ -22,9 +22,9 @@ import qualified Data.ByteString               as BS
 import qualified Data.Set                      as Set
 import qualified Data.Text                     as T
 import qualified Data.Text.Encoding            as T
-import           Data.Text.Prettyprint.Doc
 import           Data.Void
 import           Nix.Expr.Types.Annotated
+import           Prettyprinter
 import qualified System.Directory              as S
 import qualified System.Posix.Files            as S
 import           Text.Megaparsec.Error

--- a/src/Nix/Render/Frame.hs
+++ b/src/Nix/Render/Frame.hs
@@ -16,7 +16,6 @@ module Nix.Render.Frame where
 import           Control.Monad.Reader
 import           Data.Fix
 import           Data.Typeable
-import           Data.Text.Prettyprint.Doc
 import           Nix.Eval
 import           Nix.Exec
 import           Nix.Expr
@@ -28,6 +27,7 @@ import           Nix.Render
 import           Nix.Thunk
 import           Nix.Utils
 import           Nix.Value
+import           Prettyprinter
 import           Text.Megaparsec.Pos
 #ifdef MIN_VERSION_pretty_show
 import qualified Text.Show.Pretty as PS

--- a/tests/ParserTests.hs
+++ b/tests/ParserTests.hs
@@ -11,13 +11,13 @@ module ParserTests (tests) where
 import Data.Fix
 import Data.List.NonEmpty (NonEmpty(..))
 import Data.Text (Text, unpack)
-import Data.Text.Prettyprint.Doc
-import Data.Text.Prettyprint.Doc.Render.Text
 import NeatInterpolation (text)
 import Nix.Atoms
 import Nix.Expr
 import Nix.Parser
 import Nix.Pretty
+import Prettyprinter
+import Prettyprinter.Render.Text
 import Test.Tasty
 import Test.Tasty.HUnit
 import Test.Tasty.TH

--- a/tests/PrettyParseTests.hs
+++ b/tests/PrettyParseTests.hs
@@ -19,7 +19,6 @@ import qualified Data.List.NonEmpty            as NE
 import           Data.Text                      ( Text
                                                 , pack
                                                 )
-import           Data.Text.Prettyprint.Doc
 import           Hedgehog
 import qualified Hedgehog.Gen                  as Gen
 import qualified Hedgehog.Range                as Range
@@ -27,6 +26,7 @@ import           Nix.Atoms
 import           Nix.Expr
 import           Nix.Parser
 import           Nix.Pretty
+import           Prettyprinter
 import           Test.Tasty
 import           Test.Tasty.Hedgehog
 import           Text.Megaparsec                ( Pos )


### PR DESCRIPTION
Changelog:
http://hackage.haskell.org/package/prettyprinter-1.7.0/changelog

hnix is likely to be affected by this change:

> Use floor instead of round to compute ribbon width.

…due to its use of custom `LayoutOptions`.