### PR TITLE
CI: Cabal-Linux: add cache

### DIFF
--- a/.github/workflows/Cabal-Linux.yml
+++ b/.github/workflows/Cabal-Linux.yml
@@ -12,11 +12,12 @@ on:
 jobs:
 
   build10:
-    name: GHC 8.10
+    name: GHC
     runs-on: ubuntu-latest
     strategy:
       matrix:
         packageRoots: [ ./ ]
+        ghc: [ "8.10", "8.4" ]
     defaults:
       run:
         working-directory: ${{ matrix.packageRoots }}
@@ -26,40 +27,12 @@ jobs:
           submodules: recursive
       - uses: actions/setup-haskell@v1.1
         with:
-          ghc-version: "8.10"
-          # cabal-version: "3.0.0.0"
+          ghc-version: ${{ matrix.ghc }}
       - name: Install additional system packages
         run: sudo apt install libsodium-dev
       #  2020-08-01: NOTE: Nix instantiate still needed for HNix tests
       - name: Install Nix
         uses: cachix/install-nix-action@v10
       - run: cabal v2-configure --disable-optimization --enable-tests --enable-deterministic
-      - run: cabal v2-build
-      - run: cabal v2-test
-
-
-  build20:
-    name: GHC 8.4
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        packageRoots: [ ./ ]
-    defaults:
-      run:
-        working-directory: ${{ matrix.packageRoots }}
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          submodules: recursive
-      - uses: actions/setup-haskell@v1.1
-        with:
-          ghc-version: "8.4"
-          # cabal-version: "3.0.0.0"
-      - name: Install additional system packages
-        run: sudo apt install libsodium-dev
-      #  2020-08-01: NOTE: Nix instantiate still needed for HNix tests
-      - name: Install Nix
-        uses: cachix/install-nix-action@v10
-      - run: cabal v2-configure --disable-optimization --enable-tests
       - run: cabal v2-build
       - run: cabal v2-test

--- a/.github/workflows/Cabal-Linux.yml
+++ b/.github/workflows/Cabal-Linux.yml
@@ -25,6 +25,14 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: recursive
+      - name: Cache of ~/.cabal/packages, ~/.cabal/store and dist-newstyle
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cabal/packages
+            ~/.cabal/store
+            dist-newstyle
+          key: ${{ runner.os }}-Cabal-${{ matrix.ghc }}
       - uses: actions/setup-haskell@v1.1
         with:
           ghc-version: ${{ matrix.ghc }}


### PR DESCRIPTION
Cabal in CIs used to install GHC, pull everything from Hackage, build packages on every Cabal Hackage CI build.

Now it has a 5Gb of internal cache. I observed rapid speed gain even on `haskell-with-nixpkgs` empty package build, since GHC still needs to install and some deps still needed to be pulled and built, while GitHub cache is fast to connect and transfer, uses `zstd` compression.