### PR TITLE
Allow optparse-applicative 0.16

### DIFF
--- a/hnix.cabal
+++ b/hnix.cabal
@@ -413,7 +413,7 @@ library
     , monadlist >= 0.0.2 && < 0.1
     , mtl >= 2.2.2 && < 2.3
     , neat-interpolation >= 0.4 && < 0.6
-    , optparse-applicative >= 0.14.3 && < 0.16
+    , optparse-applicative >= 0.14.3 && < 0.17
     , parser-combinators >= 1.0.1 && < 1.3
     , prettyprinter >= 1.7.0 && < 1.8
     , process >= 1.6.3 && < 1.7


### PR DESCRIPTION
Changelog: http://hackage.haskell.org/package/optparse-applicative-0.16.0.0/changelog

Stackage: https://github.com/commercialhaskell/stackage/issues/5597