### PR TITLE
add CLI key --version

### DIFF
--- a/src/Nix/Options/Parser.hs
+++ b/src/Nix/Options/Parser.hs
@@ -8,6 +8,8 @@ import qualified Data.Text                     as Text
 import           Data.Time
 import           Nix.Options
 import           Options.Applicative     hiding ( ParserResult(..) )
+import           Data.Version                   (showVersion)
+import           Paths_hnix                     (version)
 
 decodeVerbosity :: Int -> Verbosity
 decodeVerbosity 0 = ErrorsOnly
@@ -160,7 +162,13 @@ nixOptions current =
             "Set current time for testing purposes"
           )
     <*> many (strArgument (metavar "FILE" <> help "Path of file to parse"))
+versionOpt :: Parser (a -> a)
+versionOpt = infoOption
+             (showVersion version)
+             (  long "version"
+             <> help "Show release version"
+             )
 
 nixOptionsInfo :: UTCTime -> ParserInfo Options
-nixOptionsInfo current = info (helper <*> nixOptions current)
+nixOptionsInfo current = info (helper <*> versionOpt <*> nixOptions current)
                               (fullDesc <> progDesc "" <> header "hnix")

--- a/src/Nix/Options/Parser.hs
+++ b/src/Nix/Options/Parser.hs
@@ -28,146 +28,167 @@ argPair = option $ str >>= \s -> case Text.findIndex (== '=') s of
 nixOptions :: UTCTime -> Parser Options
 nixOptions current =
   Options
-    <$> (fromMaybe Informational <$> optional
+    <$> (fromMaybe Informational <$>
+        optional
           (option
+
             (do
               a <- str
               if all isDigit a
                 then pure $ decodeVerbosity (read a)
                 else fail "Argument to -v/--verbose must be a number"
             )
-            (short 'v' <> long "verbose" <> help "Verbose output")
+
+            (  short 'v'
+            <> long "verbose"
+            <> help "Verbose output"
+            )
+
           )
         )
     <*> switch
-          (  long "trace"
-          <> help
-               "Enable tracing code (even more can be seen if built with --flags=tracing)"
-          )
+        (  long "trace"
+        <> help "Enable tracing code (even more can be seen if built with --flags=tracing)"
+        )
     <*> switch
-          (long "thunks" <> help
-            "Enable reporting of thunk tracing as well as regular evaluation"
-          )
+        (  long "thunks"
+        <> help "Enable reporting of thunk tracing as well as regular evaluation"
+        )
     <*> switch
-          (  long "values"
-          <> help "Enable reporting of value provenance in error messages"
-          )
+        (  long "values"
+        <> help "Enable reporting of value provenance in error messages"
+        )
     <*> switch
-          (  long "scopes"
-          <> help "Enable reporting of scopes in evaluation traces"
-          )
+        (  long "scopes"
+        <> help "Enable reporting of scopes in evaluation traces"
+        )
     <*> optional
-          (strOption
-            (  long "reduce"
-            <> help
-                 "When done evaluating, output the evaluated part of the expression to FILE"
-            )
+        (strOption
+          (  long "reduce"
+          <> help "When done evaluating, output the evaluated part of the expression to FILE"
           )
+        )
     <*> switch
-          (long "reduce-sets" <> help
-            "Reduce set members that aren't used; breaks if hasAttr is used"
-          )
+        (  long "reduce-sets"
+        <> help "Reduce set members that aren't used; breaks if hasAttr is used"
+        )
     <*> switch
-          (long "reduce-lists" <> help
-            "Reduce list members that aren't used; breaks if elemAt is used"
-          )
+        (  long "reduce-lists"
+        <> help "Reduce list members that aren't used; breaks if elemAt is used"
+        )
     <*> switch
-          (  long "parse"
-          <> help "Whether to parse the file (also the default right now)"
-          )
+        (  long "parse"
+        <> help "Whether to parse the file (also the default right now)"
+        )
     <*> switch
-          (  long "parse-only"
-          <> help "Whether to parse only, no pretty printing or checking"
-          )
-    <*> switch (long "find" <> help "If selected, find paths within attr trees")
+        (  long "parse-only"
+        <> help "Whether to parse only, no pretty printing or checking"
+        )
+    <*> switch
+        (  long "find"
+        <> help "If selected, find paths within attr trees"
+        )
     <*> optional
-          (strOption
-            (  long "find-file"
-            <> help "Look up the given files in Nix's search path"
-            )
+        (strOption
+          (  long "find-file"
+          <> help "Look up the given files in Nix's search path"
           )
+        )
     <*> switch
-          (  long "strict"
-          <> help
-               "When used with --eval, recursively evaluate list elements and attributes"
-          )
-    <*> switch (long "eval" <> help "Whether to evaluate, or just pretty-print")
+        (  long "strict"
+        <> help "When used with --eval, recursively evaluate list elements and attributes"
+        )
     <*> switch
-          (  long "json"
-          <> help "Print the resulting value as an JSON representation"
-          )
+        (  long "eval"
+        <> help "Whether to evaluate, or just pretty-print"
+        )
     <*> switch
-          (  long "xml"
-          <> help "Print the resulting value as an XML representation"
-          )
+        (  long "json"
+        <> help "Print the resulting value as an JSON representation"
+        )
+    <*> switch
+        (  long "xml"
+        <> help "Print the resulting value as an XML representation"
+        )
     <*> optional
-          (strOption
-            (  short 'A'
-            <> long "attr"
-            <> help
-                 "Select an attribute from the top-level Nix expression being evaluated"
-            )
+        (strOption
+          (  short 'A'
+          <> long "attr"
+          <> help "Select an attribute from the top-level Nix expression being evaluated"
           )
+        )
     <*> many
-          (strOption
-            (short 'I' <> long "include" <> help
-              "Add a path to the Nix expression search path"
-            )
+        (strOption
+          (  short 'I'
+          <> long "include"
+          <> help "Add a path to the Nix expression search path"
           )
+        )
     <*> switch
-          (  long "check"
-          <> help "Whether to check for syntax errors after parsing"
-          )
+        (  long "check"
+        <> help "Whether to check for syntax errors after parsing"
+        )
     <*> optional
-          (strOption
-            (  long "read"
-            <> help "Read in an expression tree from a binary cache"
-            )
+        (strOption
+          (  long "read"
+          <> help "Read in an expression tree from a binary cache"
           )
+        )
     <*> switch
-          (  long "cache"
-          <> help "Write out the parsed expression tree to a binary cache"
-          )
+        (  long "cache"
+        <> help "Write out the parsed expression tree to a binary cache"
+        )
     <*> switch
-          (  long "repl"
-          <> help "After performing any indicated actions, enter the REPL"
-          )
+        (  long "repl"
+        <> help "After performing any indicated actions, enter the REPL"
+        )
     <*> switch
-          (  long "ignore-errors"
-          <> help "Continue parsing files, even if there are errors"
-          )
+        (  long "ignore-errors"
+        <> help "Continue parsing files, even if there are errors"
+        )
     <*> optional
-          (strOption
-            (short 'E' <> long "expr" <> help "Expression to parse or evaluate")
-          )
+        (strOption
+          (  short 'E'
+          <> long "expr"
+          <> help "Expression to parse or evaluate")
+        )
     <*> many
-          (argPair
-            (long "arg" <> help "Argument to pass to an evaluated lambda")
-          )
+        (argPair
+          (  long "arg"
+          <> help "Argument to pass to an evaluated lambda")
+        )
     <*> many
-          (argPair
-            (  long "argstr"
-            <> help "Argument string to pass to an evaluated lambda"
-            )
+        (argPair
+          (  long "argstr"
+          <> help "Argument string to pass to an evaluated lambda"
           )
+        )
     <*> optional
-          (strOption
-            (short 'f' <> long "file" <> help
-              "Parse all of the files given in FILE; - means stdin"
-            )
+        (strOption
+          (  short 'f'
+          <> long "file"
+          <> help "Parse all of the files given in FILE; - means stdin"
           )
+        )
     <*> option
-          (parseTimeOrError True defaultTimeLocale "%Y/%m/%d %H:%M:%S" <$> str)
-          (long "now" <> value current <> help
-            "Set current time for testing purposes"
+        (parseTimeOrError True defaultTimeLocale "%Y/%m/%d %H:%M:%S" <$> str)
+        (  long "now"
+        <> value current
+        <> help "Set current time for testing purposes"
+        )
+    <*> many
+        (strArgument
+          (  metavar "FILE"
+          <> help "Path of file to parse"
           )
-    <*> many (strArgument (metavar "FILE" <> help "Path of file to parse"))
+        )
+
 versionOpt :: Parser (a -> a)
 versionOpt = infoOption
-             (showVersion version)
-             (  long "version"
-             <> help "Show release version"
-             )
+              (showVersion version)
+              (  long "version"
+              <> help "Show release version"
+              )
 
 nixOptionsInfo :: UTCTime -> ParserInfo Options
 nixOptionsInfo current = info (helper <*> versionOpt <*> nixOptions current)


### PR DESCRIPTION
Closes #702

The key itself is done in the first commit.

---

#### About `--version` option

`--version` option seems to not belong in `help` head message (`helper`). It, simply, is not a helper-related information.

Tried to include `--version` in `nixOptions` but NOR was successful, NOR `--version` fits to be in `nixOptions` abstraction, which holds interpretation keys.

So, since it does not belong to `{helper, nixOptions}` - `versionOpt` is separate abstraction.

 The proper way to get `version` number (in the current Haskell ecosystem) - is to take it from Cabal autogenerated `Paths_hnix`, so it is loaded right from the `hnix.cabal version:` field, which is done here.

The usage of Cabal provided metadata for this, makes direct `> ghci` command not viable (nor it was in HNix, the project can not be loaded from GHCi for other reasons). Nor GHCi expected to work, since there is `cabal v2-repl` for loading packages.

Proper `version` implementation goes against my request of having Nix package that is not tied to Cabal #545, but that target is not on the horizon, and we should decide on the hardcode policy before that, as project development would face tradeoffs, and some minor hardcode would be an answer some times.

So I decided that returning a `--version` for people is beneficial, people now able to check and guard the version easily, and use the tool to automate things.

---

The second commit is alignment clean-up.