### PR TITLE
Allow megaparsec 9.0

### DIFF
--- a/hnix.cabal
+++ b/hnix.cabal
@@ -408,7 +408,7 @@ library
     , lens-family-core >= 1.2.2 && < 2.2
     , lens-family-th >= 0.5.0 && < 0.6
     , logict >= 0.6.0 && < 0.7 || >= 0.7.0.2 && < 0.8
-    , megaparsec >= 7.0 && < 8.1
+    , megaparsec >= 7.0 && < 9.1
     , monad-control >= 1.0.2 && < 1.1
     , monadlist >= 0.0.2 && < 0.1
     , mtl >= 2.2.2 && < 2.3


### PR DESCRIPTION
I've tested this locally with

    $ cabal test all --enable-tests -O0 --constraint "megaparsec > 9"