### PR TITLE
Updating dependencies

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -226,7 +226,7 @@ let
       # 2020-06-26 Due to a behaviour change in neat-interpolation-0.4, we
       # require n-i >= 0.4. dontCheck helps us avoid conflicts with
       # neat-interpolation's test dependencies.
-      neat-interpolation = pkgs.haskell.lib.dontCheck super.neat-interpolation_0_5_1_1;
+      neat-interpolation = pkgs.haskell.lib.dontCheck super.neat-interpolation_0_5_1_2;
 
       # 2020-07-23 hnix uses multiple functions that are unavailable in
       # data-fix < 0.3.

--- a/hnix.cabal
+++ b/hnix.cabal
@@ -408,7 +408,7 @@ library
     , lens-family-core >= 1.2.2 && < 2.2
     , lens-family-th >= 0.5.0 && < 0.6
     , logict >= 0.6.0 && < 0.7 || >= 0.7.0.2 && < 0.8
-    , megaparsec >= 7.0 && < 8.1
+    , megaparsec >= 7.0 && < 9.1
     , monad-control >= 1.0.2 && < 1.1
     , monadlist >= 0.0.2 && < 0.1
     , mtl >= 2.2.2 && < 2.3


### PR DESCRIPTION
* Allowing megaparsec `9.0.x`
* Fixing Nix `neat-interpolation` to available new package version