### PR TITLE
default.nix: pin Nixpkgs to last known good rev

### DIFF
--- a/.github/workflows/On-Release-Cabal-Linux.yml
+++ b/.github/workflows/On-Release-Cabal-Linux.yml
@@ -3,7 +3,7 @@ name: "Release testing, Hackage, Cabal, Linux"
 on:
   release:
     # created: a draft is saved, or a release or pre-release is published without previously being saved as a draft
-    - created
+    types: [ created ]
 
 jobs:
 

--- a/default.nix
+++ b/default.nix
@@ -91,7 +91,7 @@
 #   , nixos-20.03  # Last stable release, gets almost no updates to recipes, gets only required backports
 #   ...
 #   }
-, rev ? "default"
+, rev ? "3c0e3697520cbe7d9eb3a64bfd87de840bf4aa77" #  2020-09-11: NOTE: This Nixpkgs revision successfully terminates neat-interpolation evaluation.
 
 , pkgs ?
     if builtins.compareVersions builtins.nixVersion "2.0" < 0


### PR DESCRIPTION
Due to number of frequently occuring issues, latest being #705, #706, #707, #708, #709, and upstream Nixpkgs issues, pinning Nixpkgs for Nix Haskell dev env.

Since Nixpkgs Haskell just happened, and since NixOS release is in progress - it would be some time until Hydra builds cache, so would power through CI cache here.