### PR TITLE
default.nix: upd rev to latest Nixpkgs-unstable advance

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -91,7 +91,7 @@
 #   , nixos-20.03  # Last stable release, gets almost no updates to recipes, gets only required backports
 #   ...
 #   }
-, rev ? "3c0e3697520cbe7d9eb3a64bfd87de840bf4aa77" #  2020-09-11: NOTE: This Nixpkgs revision successfully terminates neat-interpolation evaluation.
+, rev ? "51428e8d38271d14146211867984b8742d304ea4"
 
 , pkgs ?
     if builtins.compareVersions builtins.nixVersion "2.0" < 0


### PR DESCRIPTION
Syncing Nixpkgs for the release.