### PR TITLE
CHANGELOG: 0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,10 @@
 
 ## [0.9.2](https://github.com/haskell-nix/hnix/compare/0.9.1...0.9.2) (yyyy-mm-dd)
 
-* Dependencies:
-  * [Update `data-fix` dependency to `>= 0.3.0 && < 0.4`](https://github.com/haskell-nix/hnix/pull/686)
-  * [Update `prettyprinter` dependency to `>= 1.7.0 && < 1.8`](https://github.com/haskell-nix/hnix/pull/679)
+* Additional:
+  * Dependencies:
+    * [`data-fix >= 0.3.0 && < 0.4`](https://github.com/haskell-nix/hnix/pull/686)
+    * [`prettyprinter >= 1.7.0 && < 1.8`](https://github.com/haskell-nix/hnix/pull/679)
 
 ## [0.9.1](https://github.com/haskell-nix/hnix/compare/0.9.0...0.9.1) (2020-07-13)
 
@@ -15,10 +16,10 @@
     * Support for passing evaluated expression result of `hnix --eval -E`
       to REPL as `input` variable.
     * Support for loading `.hnixrc` from current directory
-  * `builtins.nixVersion` bumped from 2.0 to 2.3
+  * Reporting of `builtins.nixVersion` bumped from 2.0 to 2.3
   * Dependencies:
     * Freed from: `interpolate`, `contravariant`, `semigroups`, `generic-random`, `tasty-quickcheck`
-    * `repline` now `>= 0.4.0.0 && < 0.5`
+    * `repline >= 0.4.0.0 && < 0.5`
 
 ## [0.9.0](https://github.com/haskell-nix/hnix/compare/0.8.0...0.9.0) (2020-06-15)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,15 @@
 # Changelog
 
-## [0.9.2](https://github.com/haskell-nix/hnix/compare/0.9.1...0.9.2) (yyyy-mm-dd)
+## [0.10.0](https://github.com/haskell-nix/hnix/compare/0.9.1...0.10.0)
 
-* Additional:
-  * Dependencies:
-    * [`data-fix >= 0.3.0 && < 0.4`](https://github.com/haskell-nix/hnix/pull/686)
-    * [`prettyprinter >= 1.7.0 && < 1.8`](https://github.com/haskell-nix/hnix/pull/679)
+* [Add `--version` option](https://github.com/haskell-nix/hnix/pull/703)
+
+* [Remove `ToJSON` and `FromJSON` instances for `NExpr`](https://github.com/haskell-nix/hnix/pull/699)
+  * This also removes the JSON output feature for unevaluated expression trees.
+
+* [Update `data-fix` dependency to `>= 0.3.0 && < 0.4`](https://github.com/haskell-nix/hnix/pull/686)
+
+* [Update `prettyprinter` dependency to `= 1.7.0 && < 1.8`](https://github.com/haskell-nix/hnix/pull/679)
 
 ## [0.9.1](https://github.com/haskell-nix/hnix/compare/0.9.0...0.9.1) (2020-07-13)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,19 +1,19 @@
 # Changelog
 
-## [0.10.0](https://github.com/haskell-nix/hnix/compare/0.9.1...0.10.0)
+## [0.10.0](https://github.com/haskell-nix/hnix/compare/0.9.1...0.10.0) (2020-09-12)
 
-* [Add `--version` option](https://github.com/haskell-nix/hnix/pull/703)
+* Breaking:
+  * [Remove `ToJSON` and `FromJSON` instances for `NExpr`](https://github.com/haskell-nix/hnix/pull/699)
+    * This also removes the JSON output feature for unevaluated expression trees.
 
-* [Remove `ToJSON` and `FromJSON` instances for `NExpr`](https://github.com/haskell-nix/hnix/pull/699)
-  * This also removes the JSON output feature for unevaluated expression trees.
-
-* [Update `data-fix` dependency to `>= 0.3.0 && < 0.4`](https://github.com/haskell-nix/hnix/pull/686)
-
-* [Update `prettyprinter` dependency to `= 1.7.0 && < 1.8`](https://github.com/haskell-nix/hnix/pull/679)
+* Misc:
+  * [Update `data-fix` dependency to `>= 0.3.0 && < 0.4`](https://github.com/haskell-nix/hnix/pull/686)
+  * [Update `prettyprinter` dependency to `= 1.7.0 && < 1.8`](https://github.com/haskell-nix/hnix/pull/679)
+  * [CLI recieved `--version` option](https://github.com/haskell-nix/hnix/pull/703)
 
 ## [0.9.1](https://github.com/haskell-nix/hnix/compare/0.9.0...0.9.1) (2020-07-13)
 
-* Additional:
+* Misc:
   * REPL improvements
     * Better tab completion
     * Multi-line input
@@ -29,12 +29,12 @@
 
 * Changelog started. Previous release was `0.8.0`. In new release:
 
-* Major breaking:
+* Breaking:
   * Removed instances due to migration to `haskeline >= 0.8 && < 0.9`:
     * `instance MonadException m => MonadException(StateT(HashMap FilePath NExprLoc) m)`
     * `instance MonadException m => MonadException(Fix1T StandardTF m)`
 
-* Additional:
+* Misc:
   * Library: Official support for `GHC 8.4 - 8.10`
 
 ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.9.2](https://github.com/haskell-nix/hnix/compare/0.9.1...0.9.2) (yyyy-mm-dd)
+
+* Dependencies:
+  * [Update `data-fix` dependency to `>= 0.3.0 && < 0.4`](https://github.com/haskell-nix/hnix/pull/686)
+  * [Update `prettyprinter` dependency to `>= 1.7.0 && < 1.8`](https://github.com/haskell-nix/hnix/pull/679)
+
 ## [0.9.1](https://github.com/haskell-nix/hnix/compare/0.9.0...0.9.1) (2020-07-13)
 
 * Additional:

--- a/hnix.cabal
+++ b/hnix.cabal
@@ -1,5 +1,5 @@
 name:           hnix
-version:        0.9.2
+version:        0.10.0
 synopsis:       Haskell implementation of the Nix language
 description:    Haskell implementation of the Nix language.
 category:       System, Data, Nix

--- a/hnix.cabal
+++ b/hnix.cabal
@@ -1,5 +1,5 @@
 name:           hnix
-version:        0.9.1
+version:        0.9.2
 synopsis:       Haskell implementation of the Nix language
 description:    Haskell implementation of the Nix language.
 category:       System, Data, Nix


### PR DESCRIPTION
Solving the discussion of #689 by putting:
* the cause of the major release - breaking changes, into a `Breaking` section.
* all non breaking changes go into `Misc` section.