### PR TITLE
cabal, CHANGELOG: 0.10.1 release, unifying the changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,44 +1,62 @@
+
 # Changelog
 
-## [0.10.0](https://github.com/haskell-nix/hnix/compare/0.9.1...0.10.0) (2020-09-12)
+### [(diff)](https://github.com/haskell-nix/hnix/compare/0.10.0...0.10.1#files_bucket) 0.10.1 (2020-09-13)
+
+* Additional:
+  * [(link)](https://github.com/haskell-nix/hnix/pull/715/files) `{Binding, NExpr, NExprF, NKeyName}` gained `Ord1` instances.
+    * These instances were required by downstream projects to be able to use newer HNix.
+  * [(link)](https://github.com/haskell-nix/hnix/pull/712) CLI gained `--long-version` option for gathering a detailed debug information.
+    * Currently, reports Git commit and its date.
+    * [(link)](https://github.com/haskell-nix/hnix/issues/718) Currently does not work in case of use of the `nix-build`, in which case simply returns `UNKNOWN` placeholder.
+
+
+## [(diff)](https://github.com/haskell-nix/hnix/compare/0.9.1...0.10.0#files_bucket) 0.10.0 (2020-09-12)
 
 * Breaking:
-  * [Remove `ToJSON` and `FromJSON` instances for `NExpr`](https://github.com/haskell-nix/hnix/pull/699)
-    * This also removes the JSON output feature for unevaluated expression trees.
+  * [(link)](https://github.com/haskell-nix/hnix/pull/699) Removed `NExpr` `{FromJSON, ToJSON}` instances.
+    * This also removed the JSON output feature for unevaluated expression trees.
 
-* Misc:
-  * [Update `data-fix` dependency to `>= 0.3.0 && < 0.4`](https://github.com/haskell-nix/hnix/pull/686)
-  * [Update `prettyprinter` dependency to `= 1.7.0 && < 1.8`](https://github.com/haskell-nix/hnix/pull/679)
-  * [CLI recieved `--version` option](https://github.com/haskell-nix/hnix/pull/703)
-
-## [0.9.1](https://github.com/haskell-nix/hnix/compare/0.9.0...0.9.1) (2020-07-13)
-
-* Misc:
-  * REPL improvements
-    * Better tab completion
-    * Multi-line input
-    * Support for passing evaluated expression result of `hnix --eval -E`
-      to REPL as `input` variable.
-    * Support for loading `.hnixrc` from current directory
-  * Reporting of `builtins.nixVersion` bumped from 2.0 to 2.3
+* Additional:
+  * [(link)](https://github.com/haskell-nix/hnix/pull/703) CLI gained `--version` option.
   * Dependencies:
-    * Freed from: `interpolate`, `contravariant`, `semigroups`, `generic-random`, `tasty-quickcheck`
-    * `repline >= 0.4.0.0 && < 0.5`
+    * [(link)](https://github.com/haskell-nix/hnix/pull/686) Requires last major `data-fix` (`0.3`).
+    * [(link)](https://github.com/haskell-nix/hnix/pull/679) Requires last major `prettyprinter` (`1.7`).
 
-## [0.9.0](https://github.com/haskell-nix/hnix/compare/0.8.0...0.9.0) (2020-06-15)
 
-* Changelog started. Previous release was `0.8.0`. In new release:
+### [(diff)](https://github.com/haskell-nix/hnix/compare/0.9.0...0.9.1#files_bucket) 0.9.1 (2020-07-13)
+
+* Additional:
+  * REPL:
+    * Better tab completion.
+    * Accepting multi-line input.
+    * Support for passing evaluated expression result of `hnix --eval -E`.
+      to REPL as an `input` variable.
+    * Support for loading `.hnixrc` from the current directory.
+  * Reporting of `builtins.nixVersion` bumped from 2.0 to 2.3.
+  * Dependencies:
+    * Freed from: `{interpolate, contravariant, semigroups, generic-random, tasty-quickcheck}`.
+    * Requires last major `repline` (`0.4`).
+
+
+## [(diff)](https://github.com/haskell-nix/hnix/compare/0.8.0...0.9.0#files_bucket) 0.9.0 (2020-06-15)
 
 * Breaking:
-  * Removed instances due to migration to `haskeline >= 0.8 && < 0.9`:
-    * `instance MonadException m => MonadException(StateT(HashMap FilePath NExprLoc) m)`
-    * `instance MonadException m => MonadException(Fix1T StandardTF m)`
+  * Removed instances due to migration to `haskeline 0.8`:
+    * `instance MonadException m => MonadException(StateT(HashMap FilePath NExprLoc) m)`.
+    * `instance MonadException m => MonadException(Fix1T StandardTF m)`.
+  * Dependencies:
+    * Requires last major `haskeline` (`0.8`).
 
-* Misc:
-  * Library: Official support for `GHC 8.4 - 8.10`
+* Additional:
+  * Library: Official support for `GHC 8.4 - 8.10`.
+  * Executable complies only under `GHC 8.10`.
+
+* Changelog started. Previous release was `0.8.0`.
+
 
 ---
 
-`HNix` uses [PVP Versioning][1].
+HNix uses [PVP Versioning][1].
 
 [1]: https://pvp.haskell.org

--- a/hnix.cabal
+++ b/hnix.cabal
@@ -1,5 +1,5 @@
 name:           hnix
-version:        0.10.0
+version:        0.10.1
 synopsis:       Haskell implementation of the Nix language
 description:    Haskell implementation of the Nix language.
 category:       System, Data, Nix


### PR DESCRIPTION
* "Misc" use was disputed, moving back to use of the "Additional" category.

* Using a (link) pattern for URLs, reasons being:
  * Including the markup into the outlines or hyperlinks considered a
    bad practice and should be used carefully.
  * The human cause:
    The reason for the changelog is so people read through it and get the info.
    Hyperlinks make text colored. Studies of readability have shown that
    people perceive the information of a brightly colored text
   much more poorly than the text of regular coloring.
    And delivering the meaning is what changelog text is for, so the
    informative text should be regularly colored.
  * The technical cause -
    the Hackage does not parse the markup inside the hyperlinks:
    https://hackage.haskell.org/package/hnix-0.10.0/changelog
    Probably because of the reason *1, but Hackage reason alone is enough.
  * Since people perceive and think about the information they are currently reading
    mostly linearly (so in the FIFO manner), so if `(link)` is put before information text,
    they are are placed in the same uniformal space and look more uniform upon reading.
    And upon reading the "link" context gets pushed first from the FIFO mind buffer and
    the further understanding the text the person is not distracted by
    sudden reading (taking-in) of the colored word "link" in the end of the
    semantically challenging text that is required to be understood.

* Dependency requirements of last major versions made literal.

* Link to `(diff)` made more obvious. While professionals tend to look for the
link to the full diff, diff under version number is ambiguous to where the
version number link leads, it can be for example: a GitHub release (where
different forms of packages are provided), diff, commit listing (as it was before
the current change), official forum post, official news... etc.

* Made `(diff)` link to point directly towards the diff.
