### PR TITLE
default.nix: switch to the GHC 8.10.1, now executable gets build

### DIFF
--- a/.github/workflows/Optional-Nix-dev-env-macOS.yml
+++ b/.github/workflows/Optional-Nix-dev-env-macOS.yml
@@ -13,7 +13,7 @@ on:
 
 
 env:
-  rev: "nixos-unstable"
+  # rev: "nixos-unstable"         #  2020-09-29: NOTE: HNix default.nix currently pins the rev
   cachixAccount: "hnix"
   CACHIX_SIGNING_KEY: ${{ secrets.CACHIX_SIGNING_KEY }}
 

--- a/.github/workflows/Optional-Nix-dev-env-macOS.yml
+++ b/.github/workflows/Optional-Nix-dev-env-macOS.yml
@@ -20,7 +20,7 @@ env:
 
 jobs:
   build10:
-    name: "NixOS-unstable, default GHC (8.8)"
+    name: "Default GHC (8.8)"
     runs-on: macos-latest
     continue-on-error: true
     steps:

--- a/.github/workflows/Optional-Nix-dev-env-main.yml
+++ b/.github/workflows/Optional-Nix-dev-env-main.yml
@@ -22,7 +22,7 @@ env:
   ### and the other part of keys explained in `build.sh`, since those address external procedures aound the builds.
   ### Additional documentation is in Nixpkgs Haskell.lib: https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/haskell-modules/lib.nix
   ###
-  rev: "nixos-unstable"
+  # rev: "nixos-unstable"         #  2020-09-29: NOTE: HNix default.nix currently pins the rev
   cachixAccount: "hnix"
   CACHIX_SIGNING_KEY: ${{ secrets.CACHIX_SIGNING_KEY }}
   allowInconsistentDependencies: "false"
@@ -56,7 +56,6 @@ env:
 
 jobs:
 
-  # NOTE: Basic example
   build10:
     name: "NixOS-unstable channel, strict build, default GHC (8.8)"
     runs-on: ubuntu-latest
@@ -76,7 +75,6 @@ jobs:
         signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
     - name: Determined Nix-build
       env:
-        rev: "nixos-unstable"
         buildStrictly: "true"
       run: ./build.sh
 
@@ -99,7 +97,6 @@ jobs:
         signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
     - name: Determined Nix-build
       env:
-        rev: "nixos-unstable"
         compiler: "ghc8101"
         buildFromSdist: "true"
         linkWithGold: "true"

--- a/.github/workflows/Optional-Nix-dev-env-main.yml
+++ b/.github/workflows/Optional-Nix-dev-env-main.yml
@@ -75,6 +75,7 @@ jobs:
         signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
     - name: Determined Nix-build
       env:
+        compiler: "default"
         buildStrictly: "true"
       run: ./build.sh
 

--- a/.github/workflows/Optional-Nix-dev-env-main.yml
+++ b/.github/workflows/Optional-Nix-dev-env-main.yml
@@ -57,7 +57,7 @@ env:
 jobs:
 
   build10:
-    name: "NixOS-unstable channel, strict build, default GHC (8.8)"
+    name: "Default Nixpkgs GHC (8.8), strict build"
     runs-on: ubuntu-latest
     #  2020-08-01: NOTE: Due to Nixpkgs brittleness to not block project development Nixpkgs made optional, see commit message for more info
     continue-on-error: true
@@ -81,7 +81,7 @@ jobs:
 
 
   build20:
-    name: "Quality build, SDist, Optimizations, Benchmark, Haddock, Completions, GHC 8.10.1"
+    name: "GHC 8.10.1, quality build, SDist, Optimizations, Benchmark, Haddock, Completions"
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:

--- a/default.nix
+++ b/default.nix
@@ -1,7 +1,7 @@
 {
-# Default GHC for Nixpkgs by default, for current default and explicitly supported GHCs https://search.nixos.org/packages?query=ghc&from=0&size=500&channel=unstable, Nixpkgs implicitly supports older minor versions also, until the configuration departs from compatibility with them.
+# For current default and explicitly supported GHCs https://search.nixos.org/packages?query=ghc&from=0&size=500&channel=unstable, Nixpkgs implicitly supports older minor versions also, until the configuration departs from compatibility with them.
 # Compiler in a form ghc8101 <- GHC 8.10.1, just remove spaces and dots
-  compiler    ? "default"
+  compiler    ? "ghc8101"
 
 # Deafult.nix is a unit package abstraciton that allows to abstract over packages even in monorepos:
 # Example: pass --arg cabalName --arg packageRoot "./subprojectDir", or map default.nix over a list of tiples for subprojects.

--- a/default.nix
+++ b/default.nix
@@ -91,7 +91,7 @@
 #   , nixos-20.03  # Last stable release, gets almost no updates to recipes, gets only required backports
 #   ...
 #   }
-, rev ? "daaa0e33505082716beb52efefe3064f0332b521"
+, rev ? "0cfe5377e8993052f9b0dd56d058f8008af45bd9"
 
 , pkgs ?
     if builtins.compareVersions builtins.nixVersion "2.0" < 0


### PR DESCRIPTION
Switching Nix dev env and its CI to GHC 8.10.

To avoid contribution loop problems, since we pin Nixpkgs in default.nix - it is logical by default CI to follow the supported way of building.

The downsides are:
  * Maintainer would need to solve Nix issues by himself, when wants to update the Nixpkgs revision, or play a wait and pick rev game with Nixpkgs.
  * On the rev update, the `Nix-shell & Hoogle` CI build needs to rebuild the whole Haskell stack from the bottom up, so the rev update process takes a lot of wait time (hours), and also should be done from the repo internal branch to save the already built parts of the stack during rev testing.