### PR TITLE
README.md: REPL: add laziness and strictness

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,29 @@ This also binds the evaluated expression result to the `input` variable, so that
 
 Use the `:help` command for a list of all available REPL commands.
 
+## Nix laziness
+
+Nix is a lazy language with the ability of recursion, so by default REPL and eval prints are lazy:
+
+```
+hnix \
+  --eval \
+  --expr '{ x = true; }'
+  
+{ x = "<CYCLE>"; }
+```
+
+To disable laziness add the `--strict` to commands or `:set strict` in the REPL.
+
+```
+hnix \
+  --eval \
+  # Strictly \
+  --strict \
+  --expr '{ x = true; }'
+  
+{ x = true; }
+```
 
 ## Contributing
 


### PR DESCRIPTION
It is not ideal placement, but because of the current CLI design there is no ideal placement at all, except to place implications of every key in its own headline, which would mean to duplicate most of `--help` in README.

#663 already shows that `--help` is not understandable, because currently everything is intermingled.

Further rehashing of README is of course possible, but I see no way to lay-out needed info cleanly (there is a lot of if/else cases) without the redesign of the CLI.