### PR TITLE
shell.nix: use Haskell notation, explicit attrs

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -76,8 +76,8 @@
 , executableNamesToShellComplete ? [ "hnix" ]
 
 
-# Include Hoogle into derivation
-, withHoogle  ? true
+# Include Hoogle executable and DB into derivation
+, withHoogle  ? false
 
 
 # Nix by default updates and uses locally configured nixpkgs-unstable channel

--- a/shell.nix
+++ b/shell.nix
@@ -1,1 +1,5 @@
-{} @ attrs: (import ./. attrs).env
+attrs@
+  { compiler ? "ghc8101"
+  , withHoogle ? true
+  }:
+(import ./. attrs).env

--- a/shell.nix
+++ b/shell.nix
@@ -1,5 +1,6 @@
 attrs@{...}:
 let defaultAttrs = {
+  # Defaults are put in this form deliberately. Details: #748
   withHoogle = true;
   compiler = "ghc8101";
 };

--- a/shell.nix
+++ b/shell.nix
@@ -1,5 +1,6 @@
-attrs@
-  { compiler ? "ghc8101"
-  , withHoogle ? true
-  }:
-(import ./. attrs).env
+attrs@{...}:
+let defaultAttrs = {
+  withHoogle = true;
+  compiler = "ghc8101";
+};
+in (import ./. (defaultAttrs // attrs)).env


### PR DESCRIPTION
This form is 1:1 Haskell.

#747 explains the addition of explicit attr into `shell.nix`.