### PR TITLE
Support uploading filtered paths to the store

### DIFF
--- a/hnix.cabal
+++ b/hnix.cabal
@@ -341,6 +341,7 @@ library
       Nix.Convert
       Nix.Effects
       Nix.Effects.Basic
+      Nix.Effects.Derivation
       Nix.Eval
       Nix.Exec
       Nix.Expr
@@ -401,8 +402,9 @@ library
     , gitrev >= 1.1.0 && < 1.4
     , hashable >= 1.2.5 && < 1.4
     , hashing >= 0.1.0 && < 0.2
-    , hnix-store-core >= 0.1.0 && < 0.3
-    , http-client >= 0.5.14 && < 0.6 || >= 0.6.4 && < 0.8
+    , hnix-store-core >= 0.2.0 && < 0.3
+    , hnix-store-remote >= 0.2.0 && < 0.3
+    , http-client >= 0.5.14 && < 0.6 || >= 0.6.4 && < 0.7
     , http-client-tls >= 0.3.5 && < 0.4
     , http-types >= 0.12.2 && < 0.13
     , lens-family >= 1.2.2 && < 2.2

--- a/hnix.cabal
+++ b/hnix.cabal
@@ -402,8 +402,8 @@ library
     , gitrev >= 1.1.0 && < 1.4
     , hashable >= 1.2.5 && < 1.4
     , hashing >= 0.1.0 && < 0.2
-    , hnix-store-core >= 0.2.0 && < 0.3
-    , hnix-store-remote >= 0.2.0 && < 0.3
+    , hnix-store-core
+    , hnix-store-remote
     , http-client >= 0.5.14 && < 0.6 || >= 0.6.4 && < 0.7
     , http-client-tls >= 0.3.5 && < 0.4
     , http-types >= 0.12.2 && < 0.13

--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -255,9 +255,9 @@ builtinsList = sequence
   , add  Normal   "fromTOML"         fromTOML
   -}
   , add  Normal   "getContext"       getContext
-  {-
-  , add  Normal   "path"             path
-  -}
+  --, add  Normal   "hashFile"         hashFile
+  , add  Normal   "isPath"           isPath
+  --, add  Normal   "path"             path
   , add2 TopLevel "removeAttrs"      removeAttrs
   , add3 Normal   "replaceStrings"   replaceStrings
   , add2 TopLevel "scopedImport"     scopedImport
@@ -1085,6 +1085,10 @@ isBool = hasKind @Bool
 isNull
   :: forall e t f m . MonadNix e t f m => NValue t f m -> m (NValue t f m)
 isNull = hasKind @()
+
+isPath
+  :: forall e t f m . MonadNix e t f m => NValue t f m -> m (NValue t f m)
+isPath = hasKind @Path
 
 -- isString cannot use `hasKind` because it coerces derivations to strings.
 isString :: MonadNix e t f m => NValue t f m -> m (NValue t f m)

--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -1040,10 +1040,6 @@ isList
   :: forall e t f m . MonadNix e t f m => NValue t f m -> m (NValue t f m)
 isList = hasKind @[NValue t f m]
 
-isString
-  :: forall e t f m . MonadNix e t f m => NValue t f m -> m (NValue t f m)
-isString = hasKind @NixString
-
 isInt
   :: forall e t f m . MonadNix e t f m => NValue t f m -> m (NValue t f m)
 isInt = hasKind @Int
@@ -1059,6 +1055,12 @@ isBool = hasKind @Bool
 isNull
   :: forall e t f m . MonadNix e t f m => NValue t f m -> m (NValue t f m)
 isNull = hasKind @()
+
+-- isString cannot use `hasKind` because it coerces derivations to strings.
+isString :: MonadNix e t f m => NValue t f m -> m (NValue t f m)
+isString v = demand v $ \case
+  NVStr{} -> toValue True
+  _       -> toValue False
 
 isFunction :: MonadNix e t f m => NValue t f m -> m (NValue t f m)
 isFunction func = demand func $ \case

--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -145,18 +145,19 @@ builtinsList = sequence
     version <- toValue (5 :: Int)
     pure $ Builtin Normal ("langVersion", version)
 
-  , add0 Normal   "nixPath"          nixPath
   , add  TopLevel "abort"            throw_ -- for now
   , add2 Normal   "add"              add_
   , add2 Normal   "addErrorContext"  addErrorContext
   , add2 Normal   "all"              all_
   , add2 Normal   "any"              any_
+  , add2 Normal   "appendContext"    appendContext
   , add  Normal   "attrNames"        attrNames
   , add  Normal   "attrValues"       attrValues
   , add  TopLevel "baseNameOf"       baseNameOf
   , add2 Normal   "bitAnd"           bitAnd
   , add2 Normal   "bitOr"            bitOr
   , add2 Normal   "bitXor"           bitXor
+  , add0 Normal   "builtins"         builtinsBuiltin
   , add2 Normal   "catAttrs"         catAttrs
   , add2 Normal   "compareVersions"  compareVersions_
   , add  Normal   "concatLists"      concatLists
@@ -235,6 +236,7 @@ builtinsList = sequence
   , add2 TopLevel "map"              map_
   , add2 TopLevel "mapAttrs"         mapAttrs_
   , add2 Normal   "match"            match_
+  , add0 Normal   "nixPath"          nixPath
   , add2 Normal   "mul"              mul_
   , add0 Normal   "null"             (pure $ nvConstant NNull)
   , add  Normal   "parseDrvName"     parseDrvName
@@ -244,6 +246,16 @@ builtinsList = sequence
   , add  Normal   "readDir"          readDir_
   , add  Normal   "readFile"         readFile_
   , add2 Normal   "findFile"         findFile_
+  {-
+  , add  Normal   "fetchGit"         fetchGit
+  , add  Normal   "fetchMercurial"   fetchMercurial
+  , add  Normal   "filterSource"     filterSource
+  , add  Normal   "fromTOML"         fromTOML
+  -}
+  , add  Normal   "getContext"       getContext
+  {-
+  , add  Normal   "path"             path
+  -}
   , add2 TopLevel "removeAttrs"      removeAttrs
   , add3 Normal   "replaceStrings"   replaceStrings
   , add2 TopLevel "scopedImport"     scopedImport
@@ -252,6 +264,9 @@ builtinsList = sequence
   , add2 Normal   "split"            split_
   , add  Normal   "splitVersion"     splitVersion_
   , add0 Normal   "storeDir"         (pure $ nvStr $ principledMakeNixStringWithoutContext "/nix/store")
+  {-
+  , add  Normal   "storePath"        storePath
+  -}
   , add' Normal   "stringLength"     (arity1 $ Text.length . principledStringIgnoreContext)
   , add' Normal   "sub"              (arity2 ((-) @Integer))
   , add' Normal   "substring"        (substring @e @t @f @m)
@@ -266,12 +281,13 @@ builtinsList = sequence
   , add2 TopLevel "trace"            trace_
   , add  Normal   "tryEval"          tryEval
   , add  Normal   "typeOf"           typeOf
+  , add2 Normal   "unsafeGetAttrPos"              unsafeGetAttrPos
+  , add  Normal   "unsafeDiscardStringContext"    unsafeDiscardStringContext
+  {-
+  , add0 Normal   "unsafeDiscardOutputDependency" unsafeDiscardOutputDependency
+  -}
   , add  Normal   "valueSize"        getRecursiveSize
-  , add  Normal   "getContext"                 getContext
-  , add2 Normal   "appendContext"              appendContext
 
-  , add2 Normal   "unsafeGetAttrPos"           unsafeGetAttrPos
-  , add  Normal   "unsafeDiscardStringContext" unsafeDiscardStringContext
   ]
  where
   wrap :: BuiltinType -> Text -> v -> Builtin v
@@ -765,6 +781,12 @@ bitXor
   -> m (NValue t f m)
 bitXor x y = fromValue @Integer x
   >>= \a -> fromValue @Integer y >>= \b -> toValue (a `xor` b)
+
+builtinsBuiltin
+  :: forall e t f m
+   . MonadNix e t f m
+  => m (NValue t f m)
+builtinsBuiltin = (throwError $ ErrorCall "HNix does not provide builtins.builtins at the moment. Using builtins directly should be preferred")
 
 dirOf :: MonadNix e t f m => NValue t f m -> m (NValue t f m)
 dirOf x = demand x $ \case

--- a/src/Nix/Convert.hs
+++ b/src/Nix/Convert.hs
@@ -151,7 +151,7 @@ instance ( Convertible e t f m
     NVStr' ns -> pure $ Just ns
     NVPath' p ->
       Just
-        .   hackyMakeNixStringWithoutContext
+        .   (\s -> principledMakeNixStringWithSingletonContext s (StringContext s DirectPath))
         .   Text.pack
         .   unStorePath
         <$> addPath p

--- a/src/Nix/Effects.hs
+++ b/src/Nix/Effects.hs
@@ -145,7 +145,7 @@ instance MonadInstantiate IO where
           ++ err
 
 pathExists :: MonadFile m => FilePath -> m Bool
-pathExists = doesFileExist
+pathExists = doesPathExist
 
 class Monad m => MonadEnv m where
     getEnvVar :: String -> m (Maybe String)

--- a/src/Nix/Effects.hs
+++ b/src/Nix/Effects.hs
@@ -242,47 +242,36 @@ type StorePathName = Text
 type FilePathFilter m = FilePath -> m Bool
 type StorePathSet = HS.HashSet StorePath
 
-class Monad m => MonadStore m where
+class MonadIO m => MonadStore m where
 
     -- | Add a path to the store, with bells and whistles
-    addToStore :: StorePathName -> FilePath -> RecursiveFlag -> RepairFlag -> m (Either ErrorCall StorePath)
-    default addToStore :: (MonadTrans t, MonadStore m', m ~ t m') => StorePathName -> FilePath -> RecursiveFlag -> RepairFlag -> m (Either ErrorCall StorePath)
+    addToStore :: StorePathName -> FilePath -> RecursiveFlag -> RepairFlag -> m StorePath
+    default addToStore :: (MonadTrans t, MonadStore m', m ~ t m') => StorePathName -> FilePath -> RecursiveFlag -> RepairFlag -> m StorePath
     addToStore a b c d = lift $ addToStore a b c d
 
-    -- | Add a nar (action) to the store
-    -- addToStore' :: StorePathName -> IO Nar -> RecursiveFlag -> RepairFlag -> m (Either ErrorCall StorePath)
+    addTextToStore :: StorePathName -> Text -> Store.StorePathSet -> RepairFlag -> m StorePath
+    default addTextToStore :: (MonadTrans t, MonadStore m', m ~ t m') => StorePathName -> Text -> Store.StorePathSet -> RepairFlag -> m StorePath
+    addTextToStore a b c d = lift $ addTextToStore a b c d
 
-    addTextToStore' :: StorePathName -> Text -> Store.StorePathSet -> RepairFlag -> m (Either ErrorCall StorePath)
-    default addTextToStore' :: (MonadTrans t, MonadStore m', m ~ t m') => StorePathName -> Text -> Store.StorePathSet -> RepairFlag -> m (Either ErrorCall StorePath)
-    addTextToStore' a b c d = lift $ addTextToStore' a b c d
 
-parseStoreResult :: Monad m => String -> (Either String a, [Store.Logger]) -> m (Either ErrorCall a)
-parseStoreResult name res = case res of
-  (Left msg, logs) -> return $ Left $ ErrorCall $ "Failed to execute '" ++ name ++ "': " ++ msg ++ "\n" ++ show logs
-  (Right result, _) -> return $ Right result
+-- relying on show is not ideal, but way more concise.
+-- Bound to disappear anyway if we unify StorePath representation across hnix* projects
+convertStorePath :: Store.StorePath -> StorePath
+convertStorePath = StorePath . show
 
-instance MonadStore IO where
+instance MonadIO m => MonadStore (Store.MonadStoreT m) where
 
-  addToStore name path recursive repair = case Store.makeStorePathName name of
-    Left err -> return $ Left $ ErrorCall $ "String '" ++ show name ++ "' is not a valid path name: " ++ err
-    Right pathName -> do
-      -- TODO: redesign the filter parameter
-      res <- Store.runStore $ Store.addToStore @'Store.SHA256 pathName path recursive (const False) repair
-      parseStoreResult "addToStore" res >>= \case
-        Left err -> return $ Left err
-        Right storePath -> return $ Right $ StorePath $ T.unpack $ T.decodeUtf8 $ Store.storePathToRawFilePath storePath
+  addToStore name path recursive repair = do
+    -- TODO: replace this error call by something smarter. throwE ? throwError ?
+    pathName <- either error return $ Store.makeStorePathName name
+    convertStorePath <$> Store.addToStore @'Store.SHA256 pathName path recursive (const False) repair
 
-  addTextToStore' name text references repair = do
-    res <- Store.runStore $ Store.addTextToStore name text references repair
-    parseStoreResult "addTextToStore" res >>= \case
-      Left err -> return $ Left err
-      Right path -> return $ Right $ StorePath $ T.unpack $ T.decodeUtf8 $ Store.storePathToRawFilePath path
+  addTextToStore name text references repair =
+    convertStorePath <$> Store.addTextToStore name text references repair
 
-addTextToStore :: (Framed e m, MonadStore m) => StorePathName -> Text -> Store.StorePathSet -> RepairFlag -> m StorePath
-addTextToStore a b c d = either throwError return =<< addTextToStore' a b c d
 
-addPath :: (Framed e m, MonadStore m) => FilePath -> m StorePath
-addPath p = either throwError return =<< addToStore (T.pack $ takeFileName p) p True False
-
-toFile_ :: (Framed e m, MonadStore m) => FilePath -> String -> m StorePath
+toFile_ :: MonadStore m => FilePath -> String -> m StorePath
 toFile_ p contents = addTextToStore (T.pack p) (T.pack contents) HS.empty False
+
+addPath :: (MonadStore m) => FilePath -> m StorePath
+addPath p = addToStore (T.pack $ takeFileName p) p True False

--- a/src/Nix/Effects/Basic.hs
+++ b/src/Nix/Effects/Basic.hs
@@ -8,10 +8,6 @@
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE ViewPatterns #-}
 
-{-# OPTIONS_GHC -Wno-missing-signatures #-}
-{-# OPTIONS_GHC -Wno-orphans #-}
-{-# OPTIONS_GHC -fno-warn-name-shadowing #-}
-
 module Nix.Effects.Basic where
 
 import           Control.Monad
@@ -20,30 +16,24 @@ import           Data.HashMap.Lazy              ( HashMap )
 import qualified Data.HashMap.Lazy             as M
 import           Data.List
 import           Data.List.Split
-import           Data.Maybe                     ( maybeToList )
 import           Data.Text                      ( Text )
 import qualified Data.Text                     as Text
-import           Nix.Atoms
+import           Data.Text.Prettyprint.Doc
 import           Nix.Convert
 import           Nix.Effects
 import           Nix.Exec                       ( MonadNix
-                                                , callFunc
                                                 , evalExprLoc
                                                 , nixInstantiateExpr
                                                 )
 import           Nix.Expr
 import           Nix.Frames
-import           Nix.Normal
 import           Nix.Parser
-import           Nix.Pretty
 import           Nix.Render
 import           Nix.Scope
 import           Nix.String
-import           Nix.String.Coerce
 import           Nix.Utils
 import           Nix.Value
 import           Nix.Value.Monad
-import           Prettyprinter
 import           System.FilePath
 
 #ifdef MIN_VERSION_ghc_datasize
@@ -126,8 +116,8 @@ findPathBy
   -> [NValue t f m]
   -> FilePath
   -> m FilePath
-findPathBy finder l name = do
-  mpath <- foldM go Nothing l
+findPathBy finder ls name = do
+  mpath <- foldM go Nothing ls
   case mpath of
     Nothing ->
       throwError
@@ -263,39 +253,6 @@ pathToDefaultNixFile :: MonadFile m => FilePath -> m FilePath
 pathToDefaultNixFile p = do
   isDir <- doesDirectoryExist p
   pure $ if isDir then p </> "default.nix" else p
-
-defaultDerivationStrict
-  :: forall e t f m . MonadNix e t f m => NValue t f m -> m (NValue t f m)
-defaultDerivationStrict = fromValue @(AttrSet (NValue t f m)) >=> \s -> do
-  nn <- maybe (pure False) (demand ?? fromValue) (M.lookup "__ignoreNulls" s)
-  s' <- M.fromList <$> mapMaybeM (handleEntry nn) (M.toList s)
-  v' <- normalForm =<< toValue @(AttrSet (NValue t f m)) @_ @(NValue t f m) s'
-  nixInstantiateExpr $ "derivationStrict " ++ show (prettyNValue v')
- where
-  mapMaybeM :: (a -> m (Maybe b)) -> [a] -> m [b]
-  mapMaybeM op = foldr f (pure [])
-    where f x xs = op x >>= (<$> xs) . (++) . maybeToList
-
-  handleEntry :: Bool -> (Text, NValue t f m) -> m (Maybe (Text, NValue t f m))
-  handleEntry ignoreNulls (k, v) = fmap (k, ) <$> case k of
-      -- The `args' attribute is special: it supplies the command-line
-      -- arguments to the builder.
-      -- TODO This use of coerceToString is probably not right and may
-      -- not have the right arguments.
-    "args"          -> demand v $ fmap Just . coerceNixList
-    "__ignoreNulls" -> pure Nothing
-    _               -> demand v $ \case
-      NVConstant NNull | ignoreNulls -> pure Nothing
-      v'                             -> Just <$> coerceNix v'
-   where
-    coerceNix :: NValue t f m -> m (NValue t f m)
-    coerceNix = toValue <=< coerceToString callFunc CopyToStore CoerceAny
-
-    coerceNixList :: NValue t f m -> m (NValue t f m)
-    coerceNixList v = do
-      xs <- fromValue @[NValue t f m] v
-      ys <- traverse (`demand` coerceNix) xs
-      toValue @[NValue t f m] ys
 
 defaultTraceEffect :: MonadPutStr m => String -> m ()
 defaultTraceEffect = Nix.Effects.putStrLn

--- a/src/Nix/Effects/Basic.hs
+++ b/src/Nix/Effects/Basic.hs
@@ -225,13 +225,13 @@ findPathM = findPathBy existingPath
     pure $ if exists then Just apath else Nothing
 
 defaultImportPath
-  :: (MonadNix e t f m, MonadState (HashMap FilePath NExprLoc) m)
+  :: (MonadNix e t f m, MonadState (HashMap FilePath NExprLoc, b) m)
   => FilePath
   -> m (NValue t f m)
 defaultImportPath path = do
   traceM $ "Importing file " ++ path
   withFrame Info (ErrorCall $ "While importing file " ++ show path) $ do
-    imports <- get
+    imports <- gets fst
     evalExprLoc =<< case M.lookup path imports of
       Just expr -> pure expr
       Nothing   -> do
@@ -242,7 +242,7 @@ defaultImportPath path = do
               $ ErrorCall
               . show $ fillSep ["Parse during import failed:", err]
           Success expr -> do
-            modify (M.insert path expr)
+            modify (\(a, b) -> (M.insert path expr a, b))
             pure expr
 
 defaultPathToDefaultNix :: MonadNix e t f m => FilePath -> m FilePath

--- a/src/Nix/Effects/Derivation.hs
+++ b/src/Nix/Effects/Derivation.hs
@@ -1,0 +1,389 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TupleSections #-}
+{-# LANGUAGE TypeApplications #-}
+ 
+
+module Nix.Effects.Derivation ( defaultDerivationStrict ) where
+
+import           Prelude                 hiding ( readFile )
+
+import           Control.Arrow                  ( first, second )
+import           Control.Monad                  ( (>=>), forM, when )
+import           Control.Monad.Writer           ( join, lift )
+
+import           Data.Char                      ( isAscii, isAlphaNum )
+import qualified Data.HashMap.Lazy             as M
+import qualified Data.HashSet                  as S
+import           Data.List
+import qualified Data.Map.Strict               as Map
+import           Data.Map.Strict                ( Map )
+import qualified Data.Set                      as Set
+import           Data.Set                       ( Set )
+import           Data.Text                      ( Text )
+import qualified Data.Text                     as Text
+import qualified Data.Text.Encoding            as Text
+
+import           Nix.Atoms
+import           Nix.Convert
+import           Nix.Effects
+import           Nix.Exec                       ( MonadNix , callFunc)
+import           Nix.Frames
+import           Nix.Json                       ( nvalueToJSONNixString )
+import           Nix.Parser
+import           Nix.Render
+import           Nix.String
+import           Nix.String.Coerce
+import           Nix.Utils               hiding ( readFile )
+import           Nix.Value
+import           Nix.Value.Monad
+
+import qualified System.Nix.ReadonlyStore      as Store
+import qualified System.Nix.Hash               as Store
+import qualified System.Nix.StorePath          as Store
+
+import           Text.Megaparsec
+import           Text.Megaparsec.Char
+
+
+data Derivation = Derivation
+  { name :: Text
+  , outputs :: Map Text Text
+  , inputs :: (Set Text, Map Text [Text])
+  , platform :: Text
+  , builder :: Text -- should be typed as a store path
+  , args :: [ Text ]
+  , env :: Map Text Text
+  , mFixed :: Maybe Store.SomeNamedDigest
+  , hashMode :: HashMode
+  , useJson :: Bool
+  }
+  deriving Show
+
+defaultDerivation :: Derivation
+defaultDerivation = Derivation
+  { name        = undefined
+  , outputs     = Map.empty
+  , inputs      = (Set.empty, Map.empty)
+  , platform    = undefined
+  , builder     = undefined
+  , args        = []
+  , env         = Map.empty
+  , mFixed      = Nothing
+  , hashMode    = Flat
+  , useJson     = False
+  }
+
+data HashMode = Flat | Recursive
+  deriving (Show, Eq)
+
+makeStorePathName :: (Framed e m) => Text -> m Store.StorePathName
+makeStorePathName name = case Store.makeStorePathName name of
+  Left err -> throwError $ ErrorCall $ "Invalid name '" ++ show name ++ "' for use in a store path: " ++ err
+  Right spname -> return spname
+
+parsePath :: (Framed e m) => Text -> m Store.StorePath
+parsePath p = case Store.parsePath "/nix/store" (Text.encodeUtf8 p) of
+  Left err -> throwError $ ErrorCall $ "Cannot parse store path " ++ show p ++ ":\n" ++ show err
+  Right path -> return path
+
+writeDerivation :: (Framed e m, MonadStore m) => Derivation -> m Store.StorePath
+writeDerivation (drv@Derivation {inputs, name}) = do
+  let (inputSrcs, inputDrvs) = inputs
+  references <- Set.fromList <$> (mapM parsePath $ Set.toList $ inputSrcs `Set.union` (Set.fromList $ Map.keys inputDrvs))
+  path <- addTextToStore (Text.append name ".drv") (unparseDrv drv) (S.fromList $ Set.toList references) False
+  parsePath $ Text.pack $ unStorePath path
+
+-- | Traverse the graph of inputDrvs to replace fixed output derivations with their fixed output hash.
+-- this avoids propagating changes to their .drv when the output hash stays the same.
+hashDerivationModulo :: (Framed e m, MonadFile m) => Derivation -> m (Store.Digest 'Store.SHA256)
+hashDerivationModulo (Derivation {
+    mFixed = Just (Store.SomeDigest (digest :: Store.Digest hashType)),
+    outputs,
+    hashMode
+  }) = case Map.toList outputs of
+    [("out", path)] -> return $ Store.hash @'Store.SHA256 $ Text.encodeUtf8
+      $  "fixed:out"
+      <> (if hashMode == Recursive then ":r" else "")
+      <> ":" <> (Store.algoName @hashType)
+      <> ":" <> (Store.encodeBase16 digest)
+      <> ":" <> path
+    outputsList -> throwError $ ErrorCall $ "This is weird. A fixed output drv should only have one output named 'out'. Got " ++ show outputsList
+hashDerivationModulo drv@(Derivation {inputs = (inputSrcs, inputDrvs)}) = do
+  inputsModulo <- Map.fromList <$> forM (Map.toList inputDrvs) (\(path, outs) -> do
+    drv' <- readDerivation $ Text.unpack path
+    hash <- Store.encodeBase16 <$> hashDerivationModulo drv'
+    return (hash, outs)
+    )
+  return $ Store.hash @'Store.SHA256 $ Text.encodeUtf8 $ unparseDrv (drv {inputs = (inputSrcs, inputsModulo)})
+
+unparseDrv :: Derivation -> Text
+unparseDrv (Derivation {..}) = Text.append "Derive" $ parens
+    [ -- outputs: [("out", "/nix/store/.....-out", "", ""), ...]
+      list $ flip map (Map.toList outputs) (\(outputName, outputPath) ->
+        let prefix = if hashMode == Recursive then "r:" else "" in
+        case mFixed of
+          Nothing -> parens [s outputName, s outputPath, s "", s ""]
+          Just (Store.SomeDigest (digest :: Store.Digest hashType)) ->
+            parens [s outputName, s outputPath, s $ prefix <> Store.algoName @hashType, s $ Store.encodeBase16 digest]
+        )
+    , -- inputDrvs
+      list $ flip map (Map.toList $ snd inputs) (\(path, outs) ->
+        parens [s path, list $ map s $ sort outs])
+    , -- inputSrcs
+      list (map s $ Set.toList $ fst inputs)
+    , s platform
+    , s builder
+    , -- run script args
+      list $ map s args
+    , -- env (key value pairs)
+      list $ flip map (Map.toList env) (\(k, v) ->
+        parens [s k, s v])
+    ]
+  where
+    parens :: [Text] -> Text
+    parens ts = Text.concat ["(", Text.intercalate "," ts, ")"]
+    list   :: [Text] -> Text
+    list   ls = Text.concat ["[", Text.intercalate "," ls, "]"]
+    s = (Text.cons '\"') . (flip Text.snoc '\"') . Text.concatMap escape
+    escape :: Char -> Text
+    escape '\\' = "\\\\"
+    escape '\"' = "\\\""
+    escape '\n' = "\\n"
+    escape '\r' = "\\r"
+    escape '\t' = "\\t"
+    escape c = Text.singleton c
+
+readDerivation :: (Framed e m, MonadFile m) => FilePath -> m Derivation
+readDerivation path = do
+  content <- Text.decodeUtf8 <$> readFile path
+  case parse derivationParser path content of
+    Left err -> throwError $ ErrorCall $ "Failed to parse " ++ show path ++ ":\n" ++ show err
+    Right drv -> return drv
+
+derivationParser :: Parser Derivation
+derivationParser = do
+  _ <- "Derive("
+  fullOutputs <- list $
+    fmap (\[n, p, ht, h] -> (n, p, ht, h)) $ parens s
+  _ <- ","
+  inputDrvs   <- fmap Map.fromList $ list $
+    fmap (,) ("(" *> s <* ",") <*> (list s <* ")")
+  _ <- ","
+  inputSrcs   <- fmap Set.fromList $ list s
+  _ <- ","
+  platform    <- s
+  _ <- ","
+  builder     <- s
+  _ <- ","
+  args        <- list s
+  _ <- ","
+  env         <- fmap Map.fromList $ list $ fmap (\[a, b] -> (a, b)) $ parens s
+  _ <- ")"
+  eof
+
+  let outputs = Map.fromList $ map (\(a, b, _, _) -> (a, b)) fullOutputs
+  let (mFixed, hashMode) = parseFixed fullOutputs
+  let name = "" -- FIXME (extract from file path ?)
+  let useJson = ["__json"] == Map.keys env
+
+  return $ Derivation {inputs = (inputSrcs, inputDrvs), ..}
+ where
+  s :: Parser Text
+  s = fmap Text.pack $ string "\"" *> manyTill (escaped <|> regular) (string "\"")
+  escaped = char '\\' *>
+    (   '\n' <$ string "n"
+    <|> '\r' <$ string "r"
+    <|> '\t' <$ string "t"
+    <|> anySingle
+    )
+  regular = noneOf ['\\', '"']
+
+  parens :: Parser a -> Parser [a]
+  parens p = (string "(") *> sepBy p (string ",") <* (string ")")
+  list   p = (string "[") *> sepBy p (string ",") <* (string "]")
+
+  parseFixed :: [(Text, Text, Text, Text)] -> (Maybe Store.SomeNamedDigest, HashMode)
+  parseFixed fullOutputs = case fullOutputs of
+    [("out", _path, rht, hash)] | rht /= "" && hash /= "" ->
+      let (hashType, hashMode) = case Text.splitOn ":" rht of
+            ["r", ht] -> (ht, Recursive)
+            [ht] ->      (ht, Flat)
+            _ -> undefined -- What ?! -- TODO: Throw a proper error
+      in case Store.mkNamedDigest hashType hash of
+        Right digest -> (Just digest, hashMode)
+        Left _err -> undefined -- TODO: Raise a proper parse error.
+    _ -> (Nothing, Flat)
+
+
+defaultDerivationStrict :: forall e t f m . MonadNix e t f m => NValue t f m -> m (NValue t f m)
+defaultDerivationStrict = fromValue @(AttrSet (NValue t f m)) >=> \s -> do
+    (drv, ctx) <- runWithStringContextT' $ buildDerivationWithContext s
+    drvName <- makeStorePathName $ name drv
+    let inputs = toStorePaths ctx
+
+    -- Compute the output paths, and add them to the environment if needed.
+    -- Also add the inputs, just computed from the strings contexts.
+    drv' <- case mFixed drv of
+      Just (Store.SomeDigest digest) -> do
+        let out = pathToText $ Store.makeFixedOutputPath "/nix/store" (hashMode drv == Recursive) digest drvName
+        let env' = if useJson drv then env drv else Map.insert "out" out (env drv)
+        return $ drv { inputs, env = env', outputs = Map.singleton "out" out }
+
+      Nothing -> do
+        hash <- hashDerivationModulo $ drv
+          { inputs
+        --, outputs = Map.map (const "") (outputs drv)  -- not needed, this is already the case
+          , env = if useJson drv then env drv
+                  else foldl' (\m k -> Map.insert k "" m) (env drv) (Map.keys $ outputs drv)
+          }
+        outputs' <- sequence $ Map.mapWithKey (\o _ -> makeOutputPath o hash drvName) (outputs drv)
+        return $ drv
+          { inputs
+          , outputs = outputs'
+          , env = if useJson drv then env drv else Map.union outputs' (env drv)
+          }
+
+    drvPath <- writeDerivation drv'
+
+    -- TODO: memoize this result here.
+    -- _ <- hashDerivationModulo drv'
+
+    let outputsWithContext = Map.mapWithKey (\out path -> principledMakeNixStringWithSingletonContext path (StringContext (pathToText drvPath) (DerivationOutput out))) (outputs drv')
+        drvPathWithContext = principledMakeNixStringWithSingletonContext (pathToText drvPath) (StringContext (pathToText drvPath) AllOutputs)
+        attrSet = M.map nvStr $ M.fromList $ ("drvPath", drvPathWithContext): Map.toList outputsWithContext
+    -- TODO: Add location information for all the entries.
+    --              here --v
+    return $ nvSet attrSet M.empty
+
+  where
+
+    pathToText = Text.decodeUtf8 . Store.storePathToRawFilePath
+
+    makeOutputPath o h n = do
+      name <- makeStorePathName (Store.unStorePathName n <> if o == "out" then "" else "-" <> o)
+      return $ pathToText $ Store.makeStorePath "/nix/store" ("output:" <> Text.encodeUtf8 o) h name
+
+    toStorePaths ctx = foldl (flip addToInputs) (Set.empty, Map.empty) ctx
+    addToInputs (StringContext path kind) = case kind of
+      DirectPath -> first (Set.insert path)
+      DerivationOutput o -> second (Map.insertWith (++) path [o])
+      AllOutputs ->
+        -- TODO: recursive lookup. See prim_derivationStrict
+        -- XXX: When is this really used ?
+        undefined
+
+
+-- | Build a derivation in a context collecting string contexts.
+-- This is complex from a typing standpoint, but it allows to perform the
+-- full computation without worrying too much about all the string's contexts.
+buildDerivationWithContext :: forall e t f m. (MonadNix e t f m) => AttrSet (NValue t f m) -> WithStringContextT m Derivation
+buildDerivationWithContext drvAttrs = do
+    -- Parse name first, so we can add an informative frame
+    drvName     <- getAttr   "name"                      $ extractNixString >=> assertDrvStoreName
+    withFrame' Info (ErrorCall $ "While evaluating derivation " ++ show drvName) $ do
+
+      useJson     <- getAttrOr "__structuredAttrs" False   $ return
+      ignoreNulls <- getAttrOr "__ignoreNulls"     False   $ return
+
+      args        <- getAttrOr "args"              []      $ mapM (fromValue' >=> extractNixString)
+      builder     <- getAttr   "builder"                   $ extractNixString
+      platform    <- getAttr   "system"                    $ extractNoCtx >=> assertNonNull
+      mHash       <- getAttrOr "outputHash"        Nothing $ extractNoCtx >=> (return . Just)
+      hashMode    <- getAttrOr "outputHashMode"    Flat    $ extractNoCtx >=> parseHashMode
+      outputs     <- getAttrOr "outputs"           ["out"] $ mapM (fromValue' >=> extractNoCtx)
+
+      mFixedOutput <- case mHash of
+        Nothing -> return Nothing
+        Just hash -> do
+          when (outputs /= ["out"]) $ lift $ throwError $ ErrorCall $ "Multiple outputs are not supported for fixed-output derivations"
+          hashType <- getAttr "outputHashAlgo" $ extractNoCtx
+          digest <- lift $ either (throwError . ErrorCall) return $ Store.mkNamedDigest hashType hash
+          return $ Just digest
+
+      -- filter out null values if needed.
+      attrs <- if not ignoreNulls
+        then return drvAttrs
+        else M.mapMaybe id <$> forM drvAttrs (demand' ?? (\case
+            NVConstant NNull -> return Nothing
+            value -> return $ Just value
+          ))
+
+      env <- if useJson
+        then do
+          jsonString :: NixString <- lift $ nvalueToJSONNixString $ flip nvSet M.empty $
+            deleteKeys [ "args", "__ignoreNulls", "__structuredAttrs" ] attrs
+          rawString :: Text <- extractNixString jsonString
+          return $ Map.singleton "__json" rawString
+        else
+          mapM (lift . coerceToString callFunc CopyToStore CoerceAny >=> extractNixString) $
+            Map.fromList $ M.toList $ deleteKeys [ "args", "__ignoreNulls" ] attrs
+
+      return $ defaultDerivation { platform, builder, args, env,  hashMode, useJson
+        , name = drvName
+        , outputs = Map.fromList $ map (\o -> (o, "")) outputs
+        , mFixed = mFixedOutput
+        }
+  where
+    -- common functions, lifted to WithStringContextT
+
+    demand' :: NValue t f m -> (NValue t f m -> WithStringContextT m a) -> WithStringContextT m a
+    demand' v f = join $ lift $ demand v (return . f)
+
+    fromValue' :: (FromValue a m (NValue' t f m (NValue t f m)), MonadNix e t f m) => NValue t f m -> WithStringContextT m a
+    fromValue' = lift . fromValue
+
+    withFrame' :: (Framed e m, Exception s) => NixLevel -> s -> WithStringContextT m a -> WithStringContextT m a
+    withFrame' level f = join . lift . withFrame level f . return
+
+    -- shortcuts to get the (forced) value of an AttrSet field
+
+    getAttrOr' :: forall v a. (MonadNix e t f m, FromValue v m (NValue' t f m (NValue t f m)))
+      => Text -> m a -> (v -> WithStringContextT m a) -> WithStringContextT m a
+    getAttrOr' n d f = case M.lookup n drvAttrs of
+      Nothing -> lift d
+      Just v  -> withFrame' Info (ErrorCall $ "While evaluating attribute '" ++ show n ++ "'") $
+                   fromValue' v >>= f
+
+    getAttrOr n d f = getAttrOr' n (return d) f
+
+    getAttr n = getAttrOr' n (throwError $ ErrorCall $ "Required attribute '" ++ show n ++ "' not found.")
+
+    -- Test validity for fields
+
+    assertDrvStoreName :: MonadNix e t f m => Text -> WithStringContextT m Text
+    assertDrvStoreName name = lift $ do
+      let invalid c = not $ isAscii c && (isAlphaNum c || c `elem` ("+-._?=" :: String)) -- isAlphaNum allows non-ascii chars.
+      let failWith reason = throwError $ ErrorCall $ "Store name " ++ show name ++ " " ++ reason
+      when ("." `Text.isPrefixOf` name)    $ failWith "cannot start with a period"
+      when (Text.length name > 211)        $ failWith "must be no longer than 211 characters"
+      when (Text.any invalid name)         $ failWith "contains some invalid character"
+      when (".drv" `Text.isSuffixOf` name) $ failWith "is not allowed to end in '.drv'"
+      return name
+
+    extractNoCtx :: MonadNix e t f m => NixString -> WithStringContextT m Text
+    extractNoCtx ns = case principledGetStringNoContext ns of
+      Nothing -> lift $ throwError $ ErrorCall $ "The string " ++ show ns ++ " is not allowed to have a context."
+      Just v -> return v
+
+    assertNonNull :: MonadNix e t f m => Text -> WithStringContextT m Text
+    assertNonNull t = do
+      when (Text.null t) $ lift $ throwError $ ErrorCall "Value must not be empty"
+      return t
+
+    parseHashMode :: MonadNix e t f m => Text -> WithStringContextT m HashMode
+    parseHashMode = \case
+      "flat" ->      return Flat
+      "recursive" -> return Recursive
+      other -> lift $ throwError $ ErrorCall $ "Hash mode " ++ show other ++ " is not valid. It must be either 'flat' or 'recursive'"
+
+    -- Other helpers
+
+    deleteKeys :: [Text] -> AttrSet a -> AttrSet a
+    deleteKeys keys attrSet = foldl' (flip M.delete) attrSet keys
+

--- a/src/Nix/Effects/Derivation.hs
+++ b/src/Nix/Effects/Derivation.hs
@@ -16,9 +16,11 @@ import           Prelude                 hiding ( readFile )
 import           Control.Arrow                  ( first, second )
 import           Control.Monad                  ( (>=>), forM, when )
 import           Control.Monad.Writer           ( join, lift )
+import           Control.Monad.State            ( MonadState, gets, modify )
 
 import           Data.Char                      ( isAscii, isAlphaNum )
 import qualified Data.HashMap.Lazy             as M
+import qualified Data.HashMap.Strict           as MS
 import qualified Data.HashSet                  as S
 import           Data.List
 import qualified Data.Map.Strict               as Map
@@ -101,7 +103,7 @@ writeDerivation (drv@Derivation {inputs, name}) = do
 
 -- | Traverse the graph of inputDrvs to replace fixed output derivations with their fixed output hash.
 -- this avoids propagating changes to their .drv when the output hash stays the same.
-hashDerivationModulo :: (Framed e m, MonadFile m) => Derivation -> m (Store.Digest 'Store.SHA256)
+hashDerivationModulo :: (MonadNix e t f m, MonadState (b, MS.HashMap Text Text) m) => Derivation -> m (Store.Digest 'Store.SHA256)
 hashDerivationModulo (Derivation {
     mFixed = Just (Store.SomeDigest (digest :: Store.Digest hashType)),
     outputs,
@@ -115,10 +117,14 @@ hashDerivationModulo (Derivation {
       <> ":" <> path
     outputsList -> throwError $ ErrorCall $ "This is weird. A fixed output drv should only have one output named 'out'. Got " ++ show outputsList
 hashDerivationModulo drv@(Derivation {inputs = (inputSrcs, inputDrvs)}) = do
-  inputsModulo <- Map.fromList <$> forM (Map.toList inputDrvs) (\(path, outs) -> do
-    drv' <- readDerivation $ Text.unpack path
-    hash <- Store.encodeBase16 <$> hashDerivationModulo drv'
-    return (hash, outs)
+  cache <- gets snd
+  inputsModulo <- Map.fromList <$> forM (Map.toList inputDrvs) (\(path, outs) ->
+    case MS.lookup path cache of
+      Just hash -> return (hash, outs)
+      Nothing -> do
+        drv' <- readDerivation $ Text.unpack path
+        hash <- Store.encodeBase16 <$> hashDerivationModulo drv'
+        return (hash, outs)
     )
   return $ Store.hash @'Store.SHA256 $ Text.encodeUtf8 $ unparseDrv (drv {inputs = (inputSrcs, inputsModulo)})
 
@@ -221,7 +227,7 @@ derivationParser = do
     _ -> (Nothing, Flat)
 
 
-defaultDerivationStrict :: forall e t f m . MonadNix e t f m => NValue t f m -> m (NValue t f m)
+defaultDerivationStrict :: forall e t f m b. (MonadNix e t f m, MonadState (b, MS.HashMap Text Text) m) => NValue t f m -> m (NValue t f m)
 defaultDerivationStrict = fromValue @(AttrSet (NValue t f m)) >=> \s -> do
     (drv, ctx) <- runWithStringContextT' $ buildDerivationWithContext s
     drvName <- makeStorePathName $ name drv
@@ -249,13 +255,14 @@ defaultDerivationStrict = fromValue @(AttrSet (NValue t f m)) >=> \s -> do
           , env = if useJson drv then env drv else Map.union outputs' (env drv)
           }
 
-    drvPath <- writeDerivation drv'
+    drvPath <- pathToText <$> writeDerivation drv'
 
-    -- TODO: memoize this result here.
-    -- _ <- hashDerivationModulo drv'
+    -- Memoize here, as it may be our last chance in case of readonly stores.
+    drvHash <- Store.encodeBase16 <$> hashDerivationModulo drv'
+    modify (\(a, b) -> (a, MS.insert drvPath drvHash b))
 
-    let outputsWithContext = Map.mapWithKey (\out path -> principledMakeNixStringWithSingletonContext path (StringContext (pathToText drvPath) (DerivationOutput out))) (outputs drv')
-        drvPathWithContext = principledMakeNixStringWithSingletonContext (pathToText drvPath) (StringContext (pathToText drvPath) AllOutputs)
+    let outputsWithContext = Map.mapWithKey (\out path -> principledMakeNixStringWithSingletonContext path (StringContext drvPath (DerivationOutput out))) (outputs drv')
+        drvPathWithContext = principledMakeNixStringWithSingletonContext drvPath (StringContext drvPath AllOutputs)
         attrSet = M.map nvStr $ M.fromList $ ("drvPath", drvPathWithContext): Map.toList outputsWithContext
     -- TODO: Add location information for all the entries.
     --              here --v

--- a/src/Nix/Exec.hs
+++ b/src/Nix/Exec.hs
@@ -478,7 +478,7 @@ execBinaryOpForced scope span op lval rval = case op of
 fromStringNoContext :: Framed e m => NixString -> m Text
 fromStringNoContext ns = case principledGetStringNoContext ns of
   Just str -> pure str
-  Nothing  -> throwError $ ErrorCall "expected string with no context"
+  Nothing  -> throwError $ ErrorCall $ "expected string with no context, but got " ++ show ns
 
 addTracing
   :: (MonadNix e t f m, Has e Options, MonadReader Int n, Alternative n)

--- a/src/Nix/Exec.hs
+++ b/src/Nix/Exec.hs
@@ -298,13 +298,11 @@ callFunc fun arg = demand fun $ \fun' -> do
     "Function call stack exhausted"
   case fun' of
     NVClosure params f -> do
-      traceM $ "callFunc:NVFunction taking " ++ show params
       f arg
     NVBuiltin name f -> do
       span <- currentPos
       withFrame Info (Calling @m @t name span) (f arg)
     s@(NVSet m _) | Just f <- M.lookup "__functor" m -> do
-      traceM "callFunc:__functor"
       demand f $ (`callFunc` s) >=> (`callFunc` arg)
     x -> throwError $ ErrorCall $ "Attempt to call non-function: " ++ show x
 
@@ -316,7 +314,6 @@ execUnaryOp
   -> NValue t f m
   -> m (NValue t f m)
 execUnaryOp scope span op arg = do
-  traceM "NUnary"
   case arg of
     NVConstant c -> case (op, c) of
       (NNeg, NInt i  ) -> unaryOp $ NInt (-i)

--- a/src/Nix/Fresh/Basic.hs
+++ b/src/Nix/Fresh/Basic.hs
@@ -22,9 +22,7 @@ type StdIdT = FreshIdT Int
 
 instance (MonadFail m, MonadFile m) => MonadFile (StdIdT m)
 instance MonadIntrospect m => MonadIntrospect (StdIdT m)
-instance MonadStore m => MonadStore (StdIdT m) where
-  addPath' = lift . addPath'
-  toFile_' = (lift .) . toFile_'
+instance MonadStore m => MonadStore (StdIdT m)
 instance MonadPutStr m => MonadPutStr (StdIdT m)
 instance MonadHttp m => MonadHttp (StdIdT m)
 instance MonadEnv m => MonadEnv (StdIdT m)

--- a/src/Nix/Fresh/Basic.hs
+++ b/src/Nix/Fresh/Basic.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
@@ -13,7 +14,9 @@ module Nix.Fresh.Basic where
 import           Control.Monad.Fail ( MonadFail )
 #endif
 import           Control.Monad.Reader
+import           Control.Monad.Except
 import           Nix.Effects
+import           System.Nix.Store.Remote.Types (MonadRemoteStore)
 import           Nix.Render
 import           Nix.Fresh
 import           Nix.Value
@@ -22,13 +25,15 @@ type StdIdT = FreshIdT Int
 
 instance (MonadFail m, MonadFile m) => MonadFile (StdIdT m)
 instance MonadIntrospect m => MonadIntrospect (StdIdT m)
-instance MonadStore m => MonadStore (StdIdT m)
 instance MonadPutStr m => MonadPutStr (StdIdT m)
 instance MonadHttp m => MonadHttp (StdIdT m)
 instance MonadEnv m => MonadEnv (StdIdT m)
 instance MonadPaths m => MonadPaths (StdIdT m)
 instance MonadInstantiate m => MonadInstantiate (StdIdT m)
 instance MonadExec m => MonadExec (StdIdT m)
+instance MonadError String m => MonadError String (StdIdT m)
+instance MonadRemoteStore m => MonadRemoteStore (StdIdT m)
+instance (MonadIO m, MonadRemoteStore m) => MonadStore (StdIdT m)
 
 instance (MonadEffects t f m, MonadDataContext f m)
   => MonadEffects t f (StdIdT m) where

--- a/src/Nix/Parser.hs
+++ b/src/Nix/Parser.hs
@@ -264,7 +264,7 @@ nixIf = annotateLocation1
 nixAssert :: Parser NExprLoc
 nixAssert = annotateLocation1
   (   NAssert
-  <$> (reserved "assert" *> nixExpr)
+  <$> (reserved "assert" *> nixToplevelForm)
   <*> (semi *> nixToplevelForm)
   <?> "assert"
   )

--- a/src/Nix/Render.hs
+++ b/src/Nix/Render.hs
@@ -77,6 +77,9 @@ posAndMsg (SourcePos _ lineNo _) msg = FancyError
 
 renderLocation :: MonadFile m => SrcSpan -> Doc a -> m (Doc a)
 renderLocation (SrcSpan (SourcePos file begLine begCol) (SourcePos file' endLine endCol)) msg
+  | file == file' && file == "<string>" && begLine == endLine
+  = pure $ "In raw input string at position " <> pretty (unPos begCol)
+
   | file /= "<string>" && file == file'
   = do
     exist <- doesFileExist file

--- a/src/Nix/Render/Frame.hs
+++ b/src/Nix/Render/Frame.hs
@@ -90,7 +90,8 @@ renderFrame (NixFrame level f)
   | Just (e :: ExecFrame t f m) <- fromException f = renderExecFrame level e
   | Just (e :: ErrorCall) <- fromException f = pure [pretty (show e)]
   | Just (e :: SynHoleInfo m v) <- fromException f = pure [pretty (show e)]
-  | otherwise = error $ "Unrecognized frame: " ++ show f
+renderFrame (NixFrame level (SomeException e)) =
+  pure [ pretty $ "Unrecognized frame: " ++ show e ++ " of type " ++ show (typeOf e) ]
 
 wrapExpr :: NExprF r -> NExpr
 wrapExpr x = Fix (Fix (NSym "<?>") <$ x)

--- a/src/Nix/Standard.hs
+++ b/src/Nix/Standard.hs
@@ -37,6 +37,7 @@ import           Nix.Cited.Basic
 import           Nix.Context
 import           Nix.Effects
 import           Nix.Effects.Basic
+import           Nix.Effects.Derivation
 import           Nix.Expr.Types.Annotated
 import           Nix.Fresh
 import           Nix.Fresh.Basic
@@ -82,8 +83,8 @@ instance (MonadFix1T t m, MonadAtomicRef m) => MonadAtomicRef (Fix1T t m) where
 instance (MonadFix1T t m, MonadFail (Fix1T t m), MonadFile m) => MonadFile (Fix1T t m)
 
 instance (MonadFix1T t m, MonadStore m) => MonadStore (Fix1T t m) where
-  addPath' = lift . addPath'
-  toFile_' n = lift . toFile_' n
+  addToStore a b c d = lift $ addToStore a b c d
+  addTextToStore' a b c d = lift $ addTextToStore' a b c d
 
 {------------------------------------------------------------------------}
 

--- a/src/Nix/String.hs
+++ b/src/Nix/String.hs
@@ -32,7 +32,9 @@ module Nix.String
   , addStringContext
   , addSingletonStringContext
   , runWithStringContextT
+  , runWithStringContextT'
   , runWithStringContext
+  , runWithStringContext'
   )
 where
 
@@ -231,6 +233,16 @@ runWithStringContextT :: Monad m => WithStringContextT m Text -> m NixString
 runWithStringContextT (WithStringContextT m) =
   uncurry NixString <$> runWriterT m
 
+-- | Run an action that manipulates nix strings, and collect the contexts encountered.
+-- Warning: this may be unsafe, depending on how you handle the resulting context list.
+runWithStringContextT' :: Monad m => WithStringContextT m a -> m (a, S.HashSet StringContext)
+runWithStringContextT' (WithStringContextT m) = runWriterT m
+
 -- | Run an action producing a string with a context and put those into a 'NixString'.
 runWithStringContext :: WithStringContextT Identity Text -> NixString
 runWithStringContext = runIdentity . runWithStringContextT
+
+-- | Run an action that manipulates nix strings, and collect the contexts encountered.
+-- Warning: this may be unsafe, depending on how you handle the resulting context list.
+runWithStringContext' :: WithStringContextT Identity a -> (a, S.HashSet StringContext)
+runWithStringContext' = runIdentity . runWithStringContextT'

--- a/src/Nix/Thunk/Basic.hs
+++ b/src/Nix/Thunk/Basic.hs
@@ -15,7 +15,6 @@ import           Control.Exception       hiding ( catch )
 import           Control.Monad.Catch
 
 import           Nix.Thunk
-import           Nix.Utils
 import           Nix.Var
 
 data Deferred m v = Deferred (m v) | Computed v
@@ -75,7 +74,6 @@ forceThunk (Thunk n active ref) k = do
       if nowActive
         then throwM $ ThunkLoop $ show n
         else do
-          traceM $ "Forcing " ++ show n
           v <- catch action $ \(e :: SomeException) -> do
             _ <- atomicModifyVar active (False, )
             throwM e

--- a/tests/EvalTests.hs
+++ b/tests/EvalTests.hs
@@ -494,7 +494,9 @@ freeVarsEqual a xs = do
 
 maskedFiles :: [FilePath]
 maskedFiles =
-  [ "builtins.fetchurl-01.nix" ]
+  [ "builtins.fetchurl-01.nix"
+  , "builtins.nix" -- FIXME (layus) nix conditionally enables exec & co.
+  ]
 
 testDir :: FilePath
 testDir = "tests/eval-compare"

--- a/tests/NixLanguageTests.hs
+++ b/tests/NixLanguageTests.hs
@@ -69,7 +69,6 @@ newFailingTests :: Set String
 newFailingTests = Set.fromList
   [ "eval-okay-hash"
   , "eval-okay-hashfile"
-  , "eval-okay-path"
   , "eval-okay-fromTOML"
   , "eval-okay-context-introspection"
   ]

--- a/tests/NixLanguageTests.hs
+++ b/tests/NixLanguageTests.hs
@@ -70,7 +70,6 @@ newFailingTests = Set.fromList
   [ "eval-okay-hash"
   , "eval-okay-hashfile"
   , "eval-okay-path"
-  , "eval-okay-types"
   , "eval-okay-fromTOML"
   , "eval-okay-context-introspection"
   ]


### PR DESCRIPTION
This refactors the store to make it composable with arbitrary mtl monad stacks, with the added constraint that `addToStore` takes a filtering fucntion `FilePath -> PathFilter -> m Bool` which is not MonadBaseControl compatible, and cannot be lifted (the monad is in a negative/contravariant position).

The solution involves a RemoteStoreT transformer, a MonadRemoteStore monad and still lacks a proper generic MonadStore which I would like to make generic across all the store implementations (in-memeory / read-only / remote daemon / etc.)

Possibly doing something very wrong here, but it works.

based on top of #554


