### PR TITLE
Make `->` right assosciative

### DIFF
--- a/src/Nix/Parser.hs
+++ b/src/Nix/Parser.hs
@@ -643,7 +643,7 @@ nixOperators selector =
   , {- 13 -}
     [binaryL "||" NOr]
   , {- 14 -}
-    [binaryN "->" NImpl]
+    [binaryR "->" NImpl]
   ]
 
 data OperatorInfo = OperatorInfo


### PR DESCRIPTION
As per the nix source code https://github.com/haskell-nix/nix/blob/61e816217bfdfffd39c130c7cd24f07e640098fc/src/libexpr/parser.y#L296-L307

The bug was found while parsing firefox https://github.com/NixOS/nixpkgs/blob/5030e5cdc7f4782e895c470e8ea9fa574274b223/pkgs/applications/networking/browsers/firefox/common.nix#L76-L77
