### PR TITLE
Bump install-haskell cachix-action and install-nix-action

### DIFF
--- a/.github/workflows/Cabal-Linux.yml
+++ b/.github/workflows/Cabal-Linux.yml
@@ -29,14 +29,14 @@ jobs:
             ~/.cabal/store
             dist-newstyle
           key: ${{ runner.os }}-Cabal-${{ matrix.ghc }}
-      - uses: actions/setup-haskell@v1.1
+      - uses: actions/setup-haskell@v1
         with:
           ghc-version: ${{ matrix.ghc }}
       - name: Install additional system packages
         run: sudo apt install libsodium-dev
       #  2020-08-01: NOTE: Nix instantiate still needed for HNix tests
       - name: Install Nix
-        uses: cachix/install-nix-action@v10
+        uses: cachix/install-nix-action@v12
       - run: cabal v2-configure --disable-optimization --enable-tests --enable-deterministic
       - run: cabal v2-build
       - run: cabal v2-test

--- a/.github/workflows/On-Release-Cabal-Linux.yml
+++ b/.github/workflows/On-Release-Cabal-Linux.yml
@@ -26,14 +26,14 @@ jobs:
             ~/.cabal/store
             dist-newstyle
           key: ${{ runner.os }}-Cabal-${{ matrix.ghc }}
-      - uses: actions/setup-haskell@v1.1
+      - uses: actions/setup-haskell@v1
         with:
           ghc-version: ${{ matrix.ghc }}
       - name: Install additional system packages
         run: sudo apt install libsodium-dev
       #  2020-08-01: NOTE: Nix instantiate still needed for HNix tests
       - name: Install Nix
-        uses: cachix/install-nix-action@v10
+        uses: cachix/install-nix-action@v12
       - run: cabal v2-configure --disable-optimization --enable-tests --enable-deterministic
       - run: cabal v2-build
       - run: cabal v2-test

--- a/.github/workflows/Optional-Nix-dev-env-macOS.yml
+++ b/.github/workflows/Optional-Nix-dev-env-macOS.yml
@@ -29,9 +29,11 @@ jobs:
       with:
         submodules: recursive
     - name: Install Nix
-      uses: cachix/install-nix-action@v10
+      uses: cachix/install-nix-action@v12
+      with:
+        nix_path: nixpkgs=channel:nixos-unstable
     - name: Install Cachix
-      uses: cachix/cachix-action@v6
+      uses: cachix/cachix-action@v7
       with:
         name: ${{ env.cachixAccount }}
         signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'

--- a/.github/workflows/Optional-Nix-dev-env-main.yml
+++ b/.github/workflows/Optional-Nix-dev-env-main.yml
@@ -67,9 +67,11 @@ jobs:
       with:
         submodules: recursive
     - name: Install Nix
-      uses: cachix/install-nix-action@v10
+      uses: cachix/install-nix-action@v12
+      with:
+        nix_path: nixpkgs=channel:nixos-unstable
     - name: Install Cachix
-      uses: cachix/cachix-action@v6
+      uses: cachix/cachix-action@v7
       with:
         name: ${{ env.cachixAccount }}
         signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
@@ -90,9 +92,11 @@ jobs:
       with:
         submodules: recursive
     - name: Install Nix
-      uses: cachix/install-nix-action@v10
+      uses: cachix/install-nix-action@v12
+      with:
+        nix_path: nixpkgs=channel:nixos-unstable
     - name: Install Cachix
-      uses: cachix/cachix-action@v6
+      uses: cachix/cachix-action@v7
       with:
         name: ${{ env.cachixAccount }}
         signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
@@ -120,9 +124,11 @@ jobs:
       with:
         submodules: recursive
     - name: Install Nix
-      uses: cachix/install-nix-action@v10
+      uses: cachix/install-nix-action@v12
+      with:
+        nix_path: nixpkgs=channel:nixos-unstable
     - name: Install Cachix
-      uses: cachix/cachix-action@v6
+      uses: cachix/cachix-action@v7
       with:
         name: ${{ env.cachixAccount }}
         signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'


### PR DESCRIPTION
Closes https://github.com/haskell-nix/hnix/issues/758

install-nix-action requires an explicit `nix_path` now, do not set this
when it is just used to install nix-instantiate for tests

These are nearly impossible to get right via PRs where they're not all tested :shrug: 