### PR TITLE
Fix rendering of builtin call frames

### DIFF
--- a/src/Nix/Exec.hs
+++ b/src/Nix/Exec.hs
@@ -302,7 +302,7 @@ callFunc fun arg = demand fun $ \fun' -> do
       f arg
     NVBuiltin name f -> do
       span <- currentPos
-      withFrame Info (Calling @m @t name span) (f arg)
+      withFrame Info (Calling @m @(NValue t f m) name span) (f arg)
     s@(NVSet m _) | Just f <- M.lookup "__functor" m -> do
       traceM "callFunc:__functor"
       demand f $ (`callFunc` s) >=> (`callFunc` arg)


### PR DESCRIPTION
As it happens, we have spent a lot of efforts to bypass the typechecker and get types that are both unused and unconstrained, but still need to  align properly in the end (i.e. renderFrame).

Using exceptions we ensured that there is no way to connect the type of the EvalFrame thrown with the type expected by renderFrame, which is expected to guess it right to print it.

Furthermore, we made it sure to include an EvalFrame constructor that has no use for the v parameter, meaning that we may not even have access to a value of the right type when the constructor is called.

As a result, the code is littered with type annotations forged for the sole purpose of matching two parts of the program disconnected by (untyped) Exceptions.

Examples:

https://github.com/haskell-nix/hnix/blob/38c3062d54e3158e0592e1d25e9b55477049002e/main/Main.hs#L97-L99

https://github.com/haskell-nix/hnix/blob/38c3062d54e3158e0592e1d25e9b55477049002e/src/Nix/Exec.hs#L168

At the places where it works properly, the typing is weird, and still not perfect. It works because `(NValue t f m)` is the only `Scoped` instance we declare.

https://github.com/haskell-nix/hnix/blob/38c3062d54e3158e0592e1d25e9b55477049002e/src/Nix/Eval.hs#L426-L432

This is screaming for typed exceptions, but in the meantime this makes it work :-).
