### PR TITLE
CI: GitHub: *Cabal-Linux: migrate to official action

### DIFF
--- a/.github/workflows/Cabal-Linux.yml
+++ b/.github/workflows/Cabal-Linux.yml
@@ -29,7 +29,7 @@ jobs:
             ~/.cabal/store
             dist-newstyle
           key: ${{ runner.os }}-Cabal-${{ matrix.ghc }}
-      - uses: actions/setup-haskell@v1
+      - uses: haskell/actions/setup@v1
         with:
           ghc-version: ${{ matrix.ghc }}
       - name: "Install additional system packages"

--- a/.github/workflows/On-Release-Cabal-Linux.yml
+++ b/.github/workflows/On-Release-Cabal-Linux.yml
@@ -26,7 +26,7 @@ jobs:
             ~/.cabal/store
             dist-newstyle
           key: ${{ runner.os }}-Cabal-${{ matrix.ghc }}
-      - uses: actions/setup-haskell@v1
+      - uses: haskell/actions/setup@v1
         with:
           ghc-version: ${{ matrix.ghc }}
       - name: "Install additional system packages"


### PR DESCRIPTION
Old GH one become unmaintained (yesterday - officially), and the official
successor fork is in `haskell` group.