### PR TITLE
Support both epochs of base16-bytestring

### DIFF
--- a/hnix.cabal
+++ b/hnix.cabal
@@ -442,7 +442,7 @@ library
     exposed-modules:
         Nix.Options.Parser
     build-depends:
-        base16-bytestring >= 0.1.1 && < 0.2
+        base16-bytestring >= 0.1.1 && < 1.1
       , pretty-show >= 1.9.5 && < 1.11
       , serialise >= 0.2.1 && < 0.3
   -- if !flag(profiling)


### PR DESCRIPTION
Since it's trivial, allow downstream to stay more casual.