### PR TITLE
(needs "Chroot store support" #813) Add an integration test for derivationStrict builtin

### DIFF
--- a/tests/eval-compare/nixpkgs.hello.nix
+++ b/tests/eval-compare/nixpkgs.hello.nix
@@ -1,0 +1,22 @@
+/*
+
+FIXME: TODO: This is a bad test because:
+
+1. We may not have access to the network in test environments (e.g. Nix :-))
+2. fetchTarball is not yet implemented in hnix and call the real nix
+3. We want all the tests that rely on nixpkgs to use the same fetched path
+4. We want a single place to update the nixpkgs revision we test.
+5. Currently hnix tests are not sandboxed as the ones in hnix-store-remote,
+   so all the .drv we build en up in the host store.
+
+ XXX: NIXPKGS_TESTS are broken for now. Fix that too when fixing this.
+
+*/
+let 
+  nixpkgs = builtins.fetchTarball {
+    url = "https://github.com/NixOS/nixpkgs/archive/1dc37370c489b610f8b91d7fdd40633163ffbafd.tar.gz";
+  };
+in
+  
+with import nixpkgs {};
+"${pkgs.hello.drvPath}"


### PR DESCRIPTION
The origianal thread: https://github.com/haskell-nix/hnix/pull/554#issuecomment-752843118

Oversimplification: In this chain Nixpkgs code gets launched and Nixpkgs code runs `fetchurl.nix` file where it is not.