### PR TITLE
Switching (hacky->principled) functions for the string context

### DIFF
--- a/benchmarks/ParserBench.hs
+++ b/benchmarks/ParserBench.hs
@@ -2,20 +2,20 @@ module ParserBench (benchmarks) where
 
 import           Nix.Parser
 
-import           Control.Applicative
 import           Criterion
 
 benchFile :: FilePath -> Benchmark
-benchFile = bench <*> whnfIO . parseNixFile . ("data/" ++)
+benchFile = bench <*> whnfIO . parseNixFile . ("data/" <>)
 
 benchmarks :: Benchmark
 benchmarks = bgroup
-  "Parser"
-  [ benchFile "nixpkgs-all-packages.nix"
-  , benchFile "nixpkgs-all-packages-pretty.nix"
-  , benchFile "let-comments.nix"
-  , benchFile "let-comments-multiline.nix"
-  , benchFile "let.nix"
-  , benchFile "simple.nix"
-  , benchFile "simple-pretty.nix"
-  ]
+  "Parser" $
+    fmap benchFile
+      [ "nixpkgs-all-packages.nix"
+      , "nixpkgs-all-packages-pretty.nix"
+      , "let-comments.nix"
+      , "let-comments-multiline.nix"
+      , "let.nix"
+      , "simple.nix"
+      , "simple-pretty.nix"
+      ]

--- a/main/Main.hs
+++ b/main/Main.hs
@@ -143,13 +143,13 @@ main = do
       = liftIO
         .   putStrLn
         .   Text.unpack
-        .   principledStringIgnoreContext
+        .   stringIgnoreContext
         .   toXML
         <=< normalForm
       | json opts
       = liftIO
         .   Text.putStrLn
-        .   principledStringIgnoreContext
+        .   stringIgnoreContext
         <=< nvalueToJSONNixString
       | strict opts
       = liftIO . print . prettyNValue <=< normalForm

--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -104,7 +104,7 @@ withNixContext mpath action = do
   opts :: Options <- asks (view hasLens)
   let i = nvList $ map
         ( nvStr
-        . hackyMakeNixStringWithoutContext
+        . principledMakeNixStringWithoutContext
         . Text.pack
         )
         (include opts)
@@ -341,12 +341,12 @@ nixPath = fmap nvList $ flip foldNixPath [] $ \p mn ty rest ->
           PathEntryPath -> ("path", nvPath p)
           PathEntryURI ->
             ( "uri"
-            , nvStr $ hackyMakeNixStringWithoutContext $ Text.pack p
+            , nvStr $ principledMakeNixStringWithoutContext $ Text.pack p
             )
 
         , ( "prefix"
           , nvStr
-            $ hackyMakeNixStringWithoutContext $ Text.pack $ fromMaybe "" mn
+            $ principledMakeNixStringWithoutContext $ Text.pack $ fromMaybe "" mn
           )
         ]
       )
@@ -657,7 +657,7 @@ splitMatches numDropped (((_, (start, len)) : captures) : mts) haystack =
   caps           = nvList (map f captures)
   f (a, (s, _)) = if s < 0 then nvConstant NNull else thunkStr a
 
-thunkStr s = nvStr (hackyMakeNixStringWithoutContext (decodeUtf8 s))
+thunkStr s = nvStr (principledMakeNixStringWithoutContext (decodeUtf8 s))
 
 substring :: forall e t f m. MonadNix e t f m => Int -> Int -> NixString -> Prim m NixString
 substring start len str = Prim $
@@ -1321,7 +1321,7 @@ fromJSON arg = demand arg $ fromValue >=> fromStringNoContext >=> \encoded ->
   jsonToNValue = \case
     A.Object m -> flip nvSet M.empty <$> traverse jsonToNValue m
     A.Array  l -> nvList <$> traverse jsonToNValue (V.toList l)
-    A.String s -> pure $ nvStr $ hackyMakeNixStringWithoutContext s
+    A.String s -> pure $ nvStr $ principledMakeNixStringWithoutContext s
     A.Number n -> pure $ nvConstant $ case floatingOrInteger n of
       Left  r -> NFloat r
       Right i -> NInt i

--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -1015,9 +1015,6 @@ toFile
 toFile name s = do
   name' <- fromStringNoContext =<< fromValue name
   s'    <- fromValue s
-  -- TODO Using hacky here because we still need to turn the context into
-  -- runtime references of the resulting file.
-  -- See prim_toFile in nix/src/libexpr/primops.cc
   mres  <- toFile_ (Text.unpack name')
                    (Text.unpack $ principledStringIgnoreContext s')
   let t  = Text.pack $ unStorePath mres

--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -76,14 +76,15 @@ import           Nix.Options
 import           Nix.Parser              hiding ( nixPath )
 import           Nix.Render
 import           Nix.Scope
-import           Nix.String
+import           Nix.String              hiding (getContext)
+import qualified Nix.String                    as NixString
 import           Nix.String.Coerce
 import           Nix.Utils
 import           Nix.Value
 import           Nix.Value.Equal
 import           Nix.Value.Monad
 import           Nix.XML
-import           System.Nix.Base32              as Base32
+import           System.Nix.Base32             as Base32
 import           System.FilePath
 import           System.Posix.Files             ( isRegularFile
                                                 , isDirectory
@@ -104,7 +105,7 @@ withNixContext mpath action = do
   opts :: Options <- asks (view hasLens)
   let i = nvList $ map
         ( nvStr
-        . principledMakeNixStringWithoutContext
+        . makeNixStringWithoutContext
         . Text.pack
         )
         (include opts)
@@ -140,7 +141,7 @@ data Builtin v = Builtin
 builtinsList :: forall e t f m . MonadNix e t f m => m [Builtin (NValue t f m)]
 builtinsList = sequence
   [ do
-    version <- toValue (principledMakeNixStringWithoutContext "2.3")
+    version <- toValue (makeNixStringWithoutContext "2.3")
     pure $ Builtin Normal ("nixVersion", version)
   , do
     version <- toValue (5 :: Int)
@@ -163,7 +164,7 @@ builtinsList = sequence
   , add2 Normal   "compareVersions"  compareVersions_
   , add  Normal   "concatLists"      concatLists
   , add2 Normal   "concatMap"        concatMap_
-  , add' Normal   "concatStringsSep" (arity2 principledIntercalateNixString)
+  , add' Normal   "concatStringsSep" (arity2 intercalateNixString)
   , add0 Normal   "currentSystem"    currentSystem
   , add0 Normal   "currentTime"      currentTime_
   , add2 Normal   "deepSeq"          deepSeq
@@ -260,9 +261,9 @@ builtinsList = sequence
   , add2 Normal   "sort"             sort_
   , add2 Normal   "split"            split_
   , add  Normal   "splitVersion"     splitVersion_
-  , add0 Normal   "storeDir"         (pure $ nvStr $ principledMakeNixStringWithoutContext "/nix/store")
+  , add0 Normal   "storeDir"         (pure $ nvStr $ makeNixStringWithoutContext "/nix/store")
   --, add  Normal   "storePath"        storePath
-  , add' Normal   "stringLength"     (arity1 $ Text.length . principledStringIgnoreContext)
+  , add' Normal   "stringLength"     (arity1 $ Text.length . stringIgnoreContext)
   , add' Normal   "sub"              (arity2 ((-) @Integer))
   , add' Normal   "substring"        substring
   , add  Normal   "tail"             tail_
@@ -320,7 +321,7 @@ foldNixPath f z = do
   mDataDir <- getEnvVar "NIX_DATA_DIR"
   dataDir <- maybe getDataDir pure mDataDir
   foldrM go z
-    $  map (fromInclude . principledStringIgnoreContext) dirs
+    $  map (fromInclude . stringIgnoreContext) dirs
     ++ case mPath of
          Nothing  -> []
          Just str -> uriAwareSplit (Text.pack str)
@@ -341,12 +342,12 @@ nixPath = fmap nvList $ flip foldNixPath [] $ \p mn ty rest ->
           PathEntryPath -> ("path", nvPath p)
           PathEntryURI ->
             ( "uri"
-            , nvStr $ principledMakeNixStringWithoutContext $ Text.pack p
+            , nvStr $ makeNixStringWithoutContext $ Text.pack p
             )
 
         , ( "prefix"
           , nvStr
-            $ principledMakeNixStringWithoutContext $ Text.pack $ fromMaybe "" mn
+            $ makeNixStringWithoutContext $ Text.pack $ fromMaybe "" mn
           )
         ]
       )
@@ -392,7 +393,7 @@ unsafeGetAttrPos
   -> m (NValue t f m)
 unsafeGetAttrPos x y = demand x $ \x' -> demand y $ \y' -> case (x', y') of
   (NVStr ns, NVSet _ apos) ->
-    case M.lookup (principledStringIgnoreContext ns) apos of
+    case M.lookup (stringIgnoreContext ns) apos of
       Nothing    -> pure $ nvConstant NNull
       Just delta -> toValue delta
   (x, y) ->
@@ -538,7 +539,7 @@ splitVersion_ = fromValue >=> fromStringNoContext >=> \s ->
     $ nvList
     $ flip map (splitVersion s)
     $ nvStr
-    . principledMakeNixStringWithoutContext
+    . makeNixStringWithoutContext
     . versionComponentToString
 
 compareVersions :: Text -> Text -> Ordering
@@ -585,10 +586,10 @@ parseDrvName = fromValue >=> fromStringNoContext >=> \s -> do
   let (name :: Text, version :: Text) = splitDrvName s
   toValue @(AttrSet (NValue t f m)) $ M.fromList
     [ ( "name" :: Text
-      , nvStr $ principledMakeNixStringWithoutContext name
+      , nvStr $ makeNixStringWithoutContext name
       )
     , ( "version"
-      , nvStr $ principledMakeNixStringWithoutContext version
+      , nvStr $ makeNixStringWithoutContext version
       )
     ]
 
@@ -604,13 +605,13 @@ match_ pat str = fromValue pat >>= fromStringNoContext >>= \p ->
         -- context of its second argument. This is probably a bug but we're
         -- going to preserve the behavior here until it is fixed upstream.
         -- Relevant issue: https://github.com/NixOS/nix/issues/2547
-    let s  = principledStringIgnoreContext ns
+    let s  = stringIgnoreContext ns
 
     let re = makeRegex (encodeUtf8 p) :: Regex
     let mkMatch t
           | Text.null t = toValue ()
           | -- Shorthand for Null
-            otherwise   = toValue $ principledMakeNixStringWithoutContext t
+            otherwise   = toValue $ makeNixStringWithoutContext t
     case matchOnceText re (encodeUtf8 s) of
       Just ("", sarr, "") -> do
         let s = map fst (elems sarr)
@@ -630,7 +631,7 @@ split_ pat str = fromValue pat >>= fromStringNoContext >>= \p ->
         -- context of its second argument. This is probably a bug but we're
         -- going to preserve the behavior here until it is fixed upstream.
         -- Relevant issue: https://github.com/NixOS/nix/issues/2547
-    let s = principledStringIgnoreContext ns
+    let s = stringIgnoreContext ns
     let re       = makeRegex (encodeUtf8 p) :: Regex
         haystack = encodeUtf8 s
     pure $ nvList $ splitMatches 0
@@ -657,13 +658,13 @@ splitMatches numDropped (((_, (start, len)) : captures) : mts) haystack =
   caps           = nvList (map f captures)
   f (a, (s, _)) = if s < 0 then nvConstant NNull else thunkStr a
 
-thunkStr s = nvStr (principledMakeNixStringWithoutContext (decodeUtf8 s))
+thunkStr s = nvStr (makeNixStringWithoutContext (decodeUtf8 s))
 
 substring :: forall e t f m. MonadNix e t f m => Int -> Int -> NixString -> Prim m NixString
 substring start len str = Prim $
   if start < 0
   then throwError $ ErrorCall $ "builtins.substring: negative start position: " ++ show start
-  else pure $ principledModifyNixContents (take . Text.drop start) str
+  else pure $ modifyNixContents (take . Text.drop start) str
  where
   --NOTE: negative values of 'len' are OK, and mean "take everything"
   take = if len < 0 then id else Text.take len
@@ -674,7 +675,7 @@ attrNames =
   fromValue @(AttrSet (NValue t f m))
     >=> fmap getDeeper
     .   toValue
-    .   map principledMakeNixStringWithoutContext
+    .   map makeNixStringWithoutContext
     .   sort
     .   M.keys
 
@@ -714,7 +715,7 @@ mapAttrs_ f xs = fromValue @(AttrSet (NValue t f m)) xs >>= \aset -> do
     defer @(NValue t f m)
       $   withFrame Debug (ErrorCall "While applying f in mapAttrs:\n")
       $   callFunc ?? value
-      =<< callFunc f (nvStr (principledMakeNixStringWithoutContext key))
+      =<< callFunc f (nvStr (makeNixStringWithoutContext key))
   toValue . M.fromList . zip (map fst pairs) $ values
 
 filter_
@@ -745,7 +746,7 @@ baseNameOf :: MonadNix e t f m => NValue t f m -> m (NValue t f m)
 baseNameOf x = do
   ns <- coerceToString callFunc DontCopyToStore CoerceStringy x
   pure $ nvStr
-    (principledModifyNixContents (Text.pack . takeFileName . Text.unpack) ns)
+    (modifyNixContents (Text.pack . takeFileName . Text.unpack) ns)
 
 bitAnd
   :: forall e t f m
@@ -783,7 +784,7 @@ builtinsBuiltin = (throwError $ ErrorCall "HNix does not provide builtins.builti
 dirOf :: MonadNix e t f m => NValue t f m -> m (NValue t f m)
 dirOf x = demand x $ \case
   NVStr ns -> pure $ nvStr
-    (principledModifyNixContents (Text.pack . takeDirectory . Text.unpack) ns)
+    (modifyNixContents (Text.pack . takeDirectory . Text.unpack) ns)
   NVPath path -> pure $ nvPath $ takeDirectory path
   v ->
     throwError $ ErrorCall $ "dirOf: expected string or path, got " ++ show v
@@ -793,7 +794,7 @@ unsafeDiscardStringContext
   :: MonadNix e t f m => NValue t f m -> m (NValue t f m)
 unsafeDiscardStringContext mnv = do
   ns <- fromValue mnv
-  toValue $ principledMakeNixStringWithoutContext $ principledStringIgnoreContext
+  toValue $ makeNixStringWithoutContext $ stringIgnoreContext
     ns
 
 seq_
@@ -866,7 +867,7 @@ instance Comonad f => Eq (WValue t f m) where
   WValue (NVConstant (NFloat x)) == WValue (NVConstant (NFloat y)) = x == y
   WValue (NVPath     x         ) == WValue (NVPath     y         ) = x == y
   WValue (NVStr x) == WValue (NVStr y) =
-    principledStringIgnoreContext x == principledStringIgnoreContext y
+    stringIgnoreContext x == stringIgnoreContext y
   _ == _ = False
 
 instance Comonad f => Ord (WValue t f m) where
@@ -878,7 +879,7 @@ instance Comonad f => Ord (WValue t f m) where
   WValue (NVConstant (NFloat x)) <= WValue (NVConstant (NFloat y)) = x <= y
   WValue (NVPath     x         ) <= WValue (NVPath     y         ) = x <= y
   WValue (NVStr x) <= WValue (NVStr y) =
-    principledStringIgnoreContext x <= principledStringIgnoreContext y
+    stringIgnoreContext x <= stringIgnoreContext y
   _ <= _ = False
 
 genericClosure
@@ -929,7 +930,7 @@ replaceStrings
 replaceStrings tfrom tto ts = fromValue (Deeper tfrom) >>= \(nsFrom :: [NixString]) ->
   fromValue (Deeper tto) >>= \(nsTo :: [NixString]) ->
     fromValue ts >>= \(ns :: NixString) -> do
-      let from = map principledStringIgnoreContext nsFrom
+      let from = map stringIgnoreContext nsFrom
       when (length nsFrom /= length nsTo)
         $  throwError
         $  ErrorCall
@@ -942,14 +943,14 @@ replaceStrings tfrom tto ts = fromValue (Deeper tfrom) >>= \(nsFrom :: [NixStrin
           let rest = Text.drop (Text.length prefix) s
           pure (prefix, replacement, rest)
         finish b =
-          principledMakeNixString (LazyText.toStrict $ Builder.toLazyText b)
+          makeNixString (LazyText.toStrict $ Builder.toLazyText b)
         go orig result ctx = case lookupPrefix orig of
           Nothing -> case Text.uncons orig of
             Nothing     -> finish result ctx
             Just (h, t) -> go t (result <> Builder.singleton h) ctx
           Just (prefix, replacementNS, rest) ->
-            let replacement = principledStringIgnoreContext replacementNS
-                newCtx      = principledGetContext replacementNS
+            let replacement = stringIgnoreContext replacementNS
+                newCtx      = NixString.getContext replacementNS
             in  case prefix of
                   "" -> case Text.uncons rest of
                     Nothing -> finish
@@ -968,8 +969,8 @@ replaceStrings tfrom tto ts = fromValue (Deeper tfrom) >>= \(nsFrom :: [NixStrin
                           (result <> Builder.fromText replacement)
                           (ctx <> newCtx)
       toValue
-        $ go (principledStringIgnoreContext ns) mempty
-        $ principledGetContext ns
+        $ go (stringIgnoreContext ns) mempty
+        $ NixString.getContext ns
 
 removeAttrs
   :: forall e t f m
@@ -1016,10 +1017,10 @@ toFile name s = do
   name' <- fromStringNoContext =<< fromValue name
   s'    <- fromValue s
   mres  <- toFile_ (Text.unpack name')
-                   (Text.unpack $ principledStringIgnoreContext s')
+                   (Text.unpack $ stringIgnoreContext s')
   let t  = Text.pack $ unStorePath mres
       sc = StringContext t DirectPath
-  toValue $ principledMakeNixStringWithSingletonContext t sc
+  toValue $ makeNixStringWithSingletonContext t sc
 
 toPath :: MonadNix e t f m => NValue t f m -> m (NValue t f m)
 toPath = fromValue @Path >=> toValue @Path
@@ -1027,7 +1028,7 @@ toPath = fromValue @Path >=> toValue @Path
 pathExists_ :: MonadNix e t f m => NValue t f m -> m (NValue t f m)
 pathExists_ path = demand path $ \case
   NVPath p  -> toValue =<< pathExists p
-  NVStr  ns -> toValue =<< pathExists (Text.unpack (principledStringIgnoreContext ns))
+  NVStr  ns -> toValue =<< pathExists (Text.unpack (stringIgnoreContext ns))
   v ->
     throwError
       $  ErrorCall
@@ -1081,7 +1082,7 @@ isFunction func = demand func $ \case
 throw_ :: MonadNix e t f m => NValue t f m -> m (NValue t f m)
 throw_ mnv = do
   ns <- coerceToString callFunc CopyToStore CoerceStringy mnv
-  throwError . ErrorCall . Text.unpack $ principledStringIgnoreContext ns
+  throwError . ErrorCall . Text.unpack $ stringIgnoreContext ns
 
 import_
   :: forall e t f m . MonadNix e t f m => NValue t f m -> m (NValue t f m)
@@ -1112,7 +1113,7 @@ scopedImport asetArg pathArg = fromValue @(AttrSet (NValue t f m)) asetArg >>= \
 getEnv_ :: MonadNix e t f m => NValue t f m -> m (NValue t f m)
 getEnv_ = fromValue >=> fromStringNoContext >=> \s -> do
   mres <- getEnvVar (Text.unpack s)
-  toValue $ principledMakeNixStringWithoutContext $ maybe "" Text.pack mres
+  toValue $ makeNixStringWithoutContext $ maybe "" Text.pack mres
 
 sort_
   :: MonadNix e t f m
@@ -1153,7 +1154,7 @@ lessThan ta tb = demand ta $ \va -> demand tb $ \vb -> do
       (NFloat a, NFloat b) -> pure $ a < b
       _                    -> badType
     (NVStr a, NVStr b) ->
-      pure $ principledStringIgnoreContext a < principledStringIgnoreContext b
+      pure $ stringIgnoreContext a < stringIgnoreContext b
     _ -> badType
 
 concatLists
@@ -1200,7 +1201,7 @@ hashString
   :: forall e t f m. MonadNix e t f m => NixString -> NixString -> Prim m NixString
 hashString nsAlgo ns = Prim $ do
   algo <- fromStringNoContext nsAlgo
-  let f g = pure $ principledModifyNixContents g ns
+  let f g = pure $ modifyNixContents g ns
   case algo of
     "md5" ->
       f $ \s ->
@@ -1224,11 +1225,11 @@ hashString nsAlgo ns = Prim $ do
 placeHolder :: MonadNix e t f m => NValue t f m -> m (NValue t f m)
 placeHolder = fromValue >=> fromStringNoContext >=> \t -> do
   h <- runPrim
-    (hashString (principledMakeNixStringWithoutContext "sha256")
-                (principledMakeNixStringWithoutContext ("nix-output:" <> t))
+    (hashString (makeNixStringWithoutContext "sha256")
+                (makeNixStringWithoutContext ("nix-output:" <> t))
     )
   toValue
-    $ principledMakeNixStringWithoutContext
+    $ makeNixStringWithoutContext
     $ Text.cons '/'
     $ Base32.encode
     $ case Base16.decode (text h) of -- The result coming out of hashString is base16 encoded
@@ -1240,12 +1241,12 @@ placeHolder = fromValue >=> fromStringNoContext >=> \t -> do
       (_, e) -> error $ "Couldn't Base16 decode the text: '" <> show (text h) <> "'.\nUndecodable remainder: '" <> show e <> "'."
 #endif
    where
-    text h = encodeUtf8 $ principledStringIgnoreContext h
+    text h = encodeUtf8 $ stringIgnoreContext h
 
 absolutePathFromValue :: MonadNix e t f m => NValue t f m -> m FilePath
 absolutePathFromValue = \case
   NVStr ns -> do
-    let path = Text.unpack $ principledStringIgnoreContext ns
+    let path = Text.unpack $ stringIgnoreContext ns
     unless (isAbsolute path)
       $  throwError
       $  ErrorCall
@@ -1269,7 +1270,7 @@ findFile_
 findFile_ aset filePath = demand aset $ \aset' -> demand filePath $ \filePath' ->
   case (aset', filePath') of
     (NVList x, NVStr ns) -> do
-      mres <- findPath @t @f @m x (Text.unpack (principledStringIgnoreContext ns))
+      mres <- findPath @t @f @m x (Text.unpack (stringIgnoreContext ns))
       pure $ nvPath mres
     (NVList _, y) ->
       throwError $ ErrorCall $ "expected a string, got " ++ show y
@@ -1286,7 +1287,7 @@ data FileType
    deriving (Show, Read, Eq, Ord)
 
 instance Convertible e t f m => ToValue FileType m (NValue t f m) where
-  toValue = toValue . principledMakeNixStringWithoutContext . \case
+  toValue = toValue . makeNixStringWithoutContext . \case
     FileTypeRegular   -> "regular" :: Text
     FileTypeDirectory -> "directory"
     FileTypeSymlink   -> "symlink"
@@ -1318,7 +1319,7 @@ fromJSON arg = demand arg $ fromValue >=> fromStringNoContext >=> \encoded ->
   jsonToNValue = \case
     A.Object m -> flip nvSet M.empty <$> traverse jsonToNValue m
     A.Array  l -> nvList <$> traverse jsonToNValue (V.toList l)
-    A.String s -> pure $ nvStr $ principledMakeNixStringWithoutContext s
+    A.String s -> pure $ nvStr $ makeNixStringWithoutContext s
     A.Number n -> pure $ nvConstant $ case floatingOrInteger n of
       Left  r -> NFloat r
       Right i -> NInt i
@@ -1332,7 +1333,7 @@ toXML_ :: MonadNix e t f m => NValue t f m -> m (NValue t f m)
 toXML_ v = demand v $ fmap (nvStr . toXML) . normalForm
 
 typeOf :: MonadNix e t f m => NValue t f m -> m (NValue t f m)
-typeOf v = demand v $ toValue . principledMakeNixStringWithoutContext . \case
+typeOf v = demand v $ toValue . makeNixStringWithoutContext . \case
   NVConstant a -> case a of
     NURI   _ -> "string"
     NInt   _ -> "int"
@@ -1369,7 +1370,7 @@ trace_
 trace_ msg action = do
   traceEffect @t @f @m
     .   Text.unpack
-    .   principledStringIgnoreContext
+    .   stringIgnoreContext
     =<< fromValue msg
   pure action
 
@@ -1390,7 +1391,7 @@ exec_ xs = do
   -- TODO Still need to do something with the context here
   -- See prim_exec in nix/src/libexpr/primops.cc
   -- Requires the implementation of EvalState::realiseContext
-  exec (map (Text.unpack . principledStringIgnoreContext) xs)
+  exec (map (Text.unpack . stringIgnoreContext) xs)
 
 fetchurl
   :: forall e t f m . MonadNix e t f m => NValue t f m -> m (NValue t f m)
@@ -1414,7 +1415,7 @@ fetchurl v = demand v $ \case
         $  "builtins.fetchurl: Expected URI or string, got "
         ++ show v
 
-  noContextAttrs ns = case principledGetStringNoContext ns of
+  noContextAttrs ns = case getStringNoContext ns of
     Nothing ->
       throwError $ ErrorCall $ "builtins.fetchurl: unsupported arguments to url"
     Just t -> pure t
@@ -1437,7 +1438,7 @@ currentSystem :: MonadNix e t f m => m (NValue t f m)
 currentSystem = do
   os   <- getCurrentSystemOS
   arch <- getCurrentSystemArch
-  pure $ nvStr $ principledMakeNixStringWithoutContext (arch <> "-" <> os)
+  pure $ nvStr $ makeNixStringWithoutContext (arch <> "-" <> os)
 
 currentTime_ :: MonadNix e t f m => m (NValue t f m)
 currentTime_ = do
@@ -1455,7 +1456,7 @@ getContext
 getContext x = demand x $ \case
   (NVStr ns) -> do
     let context =
-          getNixLikeContext $ toNixLikeContext $ principledGetContext ns
+          getNixLikeContext $ toNixLikeContext $ NixString.getContext ns
     valued :: M.HashMap Text (NValue t f m) <- sequenceA $ M.map toValue context
     pure $ nvSet valued M.empty
   x ->
@@ -1480,7 +1481,7 @@ appendContext x y = demand x $ \x' -> demand y $ \y' -> case (x', y') of
           Nothing -> pure []
           Just os -> demand os $ \case
             NVList vs ->
-              forM vs $ fmap principledStringIgnoreContext . fromValue
+              forM vs $ fmap stringIgnoreContext . fromValue
             x ->
               throwError
                 $ ErrorCall
@@ -1493,13 +1494,13 @@ appendContext x y = demand x $ \x' -> demand y $ \y' -> case (x', y') of
           $  "Invalid types for context value in builtins.appendContext: "
           ++ show x
     toValue
-      $ principledMakeNixString (principledStringIgnoreContext ns)
+      $ makeNixString (stringIgnoreContext ns)
       $ fromNixLikeContext
       $ NixLikeContext
       $ M.unionWith (<>) newContextValues
       $ getNixLikeContext
       $ toNixLikeContext
-      $ principledGetContext ns
+      $ NixString.getContext ns
   (x, y) ->
     throwError
       $  ErrorCall

--- a/src/Nix/Convert.hs
+++ b/src/Nix/Convert.hs
@@ -151,7 +151,7 @@ instance ( Convertible e t f m
     NVStr' ns -> pure $ Just ns
     NVPath' p ->
       Just
-        .   (\s -> principledMakeNixStringWithSingletonContext s (StringContext s DirectPath))
+        .   (\s -> makeNixStringWithSingletonContext s (StringContext s DirectPath))
         .   Text.pack
         .   unStorePath
         <$> addPath p
@@ -166,7 +166,7 @@ instance ( Convertible e t f m
 instance Convertible e t f m
   => FromValue ByteString m (NValue' t f m (NValue t f m)) where
   fromValueMay = \case
-    NVStr' ns -> pure $ encodeUtf8 <$> principledGetStringNoContext  ns
+    NVStr' ns -> pure $ encodeUtf8 <$> getStringNoContext  ns
     _         -> pure Nothing
   fromValue v = fromValueMay v >>= \case
     Just b -> pure b
@@ -181,7 +181,7 @@ instance ( Convertible e t f m
   => FromValue Path m (NValue' t f m (NValue t f m)) where
   fromValueMay = \case
     NVPath' p  -> pure $ Just (Path p)
-    NVStr'  ns -> pure $ Path . Text.unpack <$> principledGetStringNoContext  ns
+    NVStr'  ns -> pure $ Path . Text.unpack <$> getStringNoContext  ns
     NVSet' s _ -> case M.lookup "outPath" s of
       Nothing -> pure Nothing
       Just p  -> fromValueMay @Path p
@@ -303,7 +303,7 @@ instance Convertible e t f m
 
 instance Convertible e t f m
   => ToValue ByteString m (NValue' t f m (NValue t f m)) where
-  toValue = pure . nvStr' . principledMakeNixStringWithoutContext . decodeUtf8
+  toValue = pure . nvStr' . makeNixStringWithoutContext . decodeUtf8
 
 instance Convertible e t f m
   => ToValue Path m (NValue' t f m (NValue t f m)) where
@@ -317,7 +317,7 @@ instance ( Convertible e t f m
          )
   => ToValue SourcePos m (NValue' t f m (NValue t f m)) where
   toValue (SourcePos f l c) = do
-    f' <- toValue (principledMakeNixStringWithoutContext (Text.pack f))
+    f' <- toValue (makeNixStringWithoutContext (Text.pack f))
     l' <- toValue (unPos l)
     c' <- toValue (unPos c)
     let pos = M.fromList [("file" :: Text, f'), ("line", l'), ("column", c')]
@@ -359,7 +359,7 @@ instance Convertible e t f m
       else pure Nothing
     outputs <- do
       let outputs =
-            principledMakeNixStringWithoutContext <$> nlcvOutputs nlcv
+            makeNixStringWithoutContext <$> nlcvOutputs nlcv
       ts :: [NValue t f m] <- traverse toValue outputs
       case ts of
         [] -> pure Nothing

--- a/src/Nix/Convert.hs
+++ b/src/Nix/Convert.hs
@@ -303,7 +303,7 @@ instance Convertible e t f m
 
 instance Convertible e t f m
   => ToValue ByteString m (NValue' t f m (NValue t f m)) where
-  toValue = pure . nvStr' . hackyMakeNixStringWithoutContext . decodeUtf8
+  toValue = pure . nvStr' . principledMakeNixStringWithoutContext . decodeUtf8
 
 instance Convertible e t f m
   => ToValue Path m (NValue' t f m (NValue t f m)) where

--- a/src/Nix/Convert.hs
+++ b/src/Nix/Convert.hs
@@ -166,7 +166,7 @@ instance ( Convertible e t f m
 instance Convertible e t f m
   => FromValue ByteString m (NValue' t f m (NValue t f m)) where
   fromValueMay = \case
-    NVStr' ns -> pure $ encodeUtf8 <$> hackyGetStringNoContext ns
+    NVStr' ns -> pure $ encodeUtf8 <$> principledGetStringNoContext  ns
     _         -> pure Nothing
   fromValue v = fromValueMay v >>= \case
     Just b -> pure b
@@ -181,7 +181,7 @@ instance ( Convertible e t f m
   => FromValue Path m (NValue' t f m (NValue t f m)) where
   fromValueMay = \case
     NVPath' p  -> pure $ Just (Path p)
-    NVStr'  ns -> pure $ Path . Text.unpack <$> hackyGetStringNoContext ns
+    NVStr'  ns -> pure $ Path . Text.unpack <$> principledGetStringNoContext  ns
     NVSet' s _ -> case M.lookup "outPath" s of
       Nothing -> pure Nothing
       Just p  -> fromValueMay @Path p

--- a/src/Nix/Effects/Basic.hs
+++ b/src/Nix/Effects/Basic.hs
@@ -137,7 +137,7 @@ findPathBy finder ls name = do
         Nothing -> tryPath path Nothing
         Just pf -> demand pf $ fromValueMay >=> \case
           Just (nsPfx :: NixString) ->
-            let pfx = hackyStringIgnoreContext nsPfx
+            let pfx = principledStringIgnoreContext nsPfx
             in  if not (Text.null pfx)
                   then tryPath path (Just (Text.unpack pfx))
                   else tryPath path Nothing
@@ -174,7 +174,7 @@ fetchTarball = flip demand $ \case
  where
   go :: Maybe (NValue t f m) -> NValue t f m -> m (NValue t f m)
   go msha = \case
-    NVStr ns -> fetch (hackyStringIgnoreContext ns) msha
+    NVStr ns -> fetch (principledStringIgnoreContext ns) msha
     v ->
       throwError
         $  ErrorCall
@@ -197,7 +197,7 @@ fetchTarball = flip demand $ \case
   fetch uri Nothing =
     nixInstantiateExpr $ "builtins.fetchTarball \"" ++ Text.unpack uri ++ "\""
   fetch url (Just t) = demand t $ fromValue >=> \nsSha ->
-    let sha = hackyStringIgnoreContext nsSha
+    let sha = principledStringIgnoreContext nsSha
     in  nixInstantiateExpr
           $  "builtins.fetchTarball { "
           ++ "url    = \""

--- a/src/Nix/Effects/Basic.hs
+++ b/src/Nix/Effects/Basic.hs
@@ -137,7 +137,7 @@ findPathBy finder ls name = do
         Nothing -> tryPath path Nothing
         Just pf -> demand pf $ fromValueMay >=> \case
           Just (nsPfx :: NixString) ->
-            let pfx = principledStringIgnoreContext nsPfx
+            let pfx = stringIgnoreContext nsPfx
             in  if not (Text.null pfx)
                   then tryPath path (Just (Text.unpack pfx))
                   else tryPath path Nothing
@@ -174,7 +174,7 @@ fetchTarball = flip demand $ \case
  where
   go :: Maybe (NValue t f m) -> NValue t f m -> m (NValue t f m)
   go msha = \case
-    NVStr ns -> fetch (principledStringIgnoreContext ns) msha
+    NVStr ns -> fetch (stringIgnoreContext ns) msha
     v ->
       throwError
         $  ErrorCall
@@ -197,7 +197,7 @@ fetchTarball = flip demand $ \case
   fetch uri Nothing =
     nixInstantiateExpr $ "builtins.fetchTarball \"" ++ Text.unpack uri ++ "\""
   fetch url (Just t) = demand t $ fromValue >=> \nsSha ->
-    let sha = principledStringIgnoreContext nsSha
+    let sha = stringIgnoreContext nsSha
     in  nixInstantiateExpr
           $  "builtins.fetchTarball { "
           ++ "url    = \""

--- a/src/Nix/Effects/Derivation.hs
+++ b/src/Nix/Effects/Derivation.hs
@@ -260,8 +260,8 @@ defaultDerivationStrict = fromValue @(AttrSet (NValue t f m)) >=> \s -> do
     drvHash <- Store.encodeInBase Store.Base16 <$> hashDerivationModulo drv'
     modify (\(a, b) -> (a, MS.insert drvPath drvHash b))
 
-    let outputsWithContext = Map.mapWithKey (\out path -> principledMakeNixStringWithSingletonContext path (StringContext drvPath (DerivationOutput out))) (outputs drv')
-        drvPathWithContext = principledMakeNixStringWithSingletonContext drvPath (StringContext drvPath AllOutputs)
+    let outputsWithContext = Map.mapWithKey (\out path -> makeNixStringWithSingletonContext path (StringContext drvPath (DerivationOutput out))) (outputs drv')
+        drvPathWithContext = makeNixStringWithSingletonContext drvPath (StringContext drvPath AllOutputs)
         attrSet = M.map nvStr $ M.fromList $ ("drvPath", drvPathWithContext): Map.toList outputsWithContext
     -- TODO: Add location information for all the entries.
     --              here --v
@@ -373,7 +373,7 @@ buildDerivationWithContext drvAttrs = do
       return name
 
     extractNoCtx :: MonadNix e t f m => NixString -> WithStringContextT m Text
-    extractNoCtx ns = case principledGetStringNoContext ns of
+    extractNoCtx ns = case getStringNoContext ns of
       Nothing -> lift $ throwError $ ErrorCall $ "The string " ++ show ns ++ " is not allowed to have a context."
       Just v -> return v
 

--- a/src/Nix/Eval.hs
+++ b/src/Nix/Eval.hs
@@ -355,7 +355,7 @@ evalSetterKeyName = \case
   StaticKey k -> pure (Just k)
   DynamicKey k ->
     runAntiquoted "\n" assembleString (>>= fromValueMay) k <&> \case
-      Just ns -> Just (principledStringIgnoreContext ns)
+      Just ns -> Just (stringIgnoreContext ns)
       _       -> Nothing
 
 assembleString
@@ -367,10 +367,10 @@ assembleString = \case
   Indented _ parts   -> fromParts parts
   DoubleQuoted parts -> fromParts parts
  where
-  fromParts = fmap (fmap principledStringMConcat . sequence) . traverse go
+  fromParts = fmap (fmap stringMConcat . sequence) . traverse go
 
   go = runAntiquoted "\n"
-                     (pure . Just . principledMakeNixStringWithoutContext)
+                     (pure . Just . makeNixStringWithoutContext)
                      (>>= fromValueMay)
 
 buildArgument

--- a/src/Nix/Eval.hs
+++ b/src/Nix/Eval.hs
@@ -355,7 +355,7 @@ evalSetterKeyName = \case
   StaticKey k -> pure (Just k)
   DynamicKey k ->
     runAntiquoted "\n" assembleString (>>= fromValueMay) k <&> \case
-      Just ns -> Just (hackyStringIgnoreContext ns)
+      Just ns -> Just (principledStringIgnoreContext ns)
       _       -> Nothing
 
 assembleString

--- a/src/Nix/Eval.hs
+++ b/src/Nix/Eval.hs
@@ -367,7 +367,7 @@ assembleString = \case
   Indented _ parts   -> fromParts parts
   DoubleQuoted parts -> fromParts parts
  where
-  fromParts = fmap (fmap stringMConcat . sequence) . traverse go
+  fromParts = fmap (fmap mconcat . sequence) . traverse go
 
   go = runAntiquoted "\n"
                      (pure . Just . makeNixStringWithoutContext)

--- a/src/Nix/Exec.hs
+++ b/src/Nix/Exec.hs
@@ -210,7 +210,7 @@ instance MonadNix e t f m => MonadEval (NValue t f m) m where
       pure $ nvStrP
         (Provenance
           scope
-          (NStr_ span (DoubleQuoted [Plain (hackyStringIgnoreContext ns)]))
+          (NStr_ span (DoubleQuoted [Plain (principledStringIgnoreContext ns)]))
         )
         ns
     Nothing -> nverr $ ErrorCall "Failed to assemble string"

--- a/src/Nix/Normal.hs
+++ b/src/Nix/Normal.hs
@@ -124,7 +124,7 @@ removeEffects =
     (fmap Free . sequenceNValue' id)
 
 opaque :: Applicative f => NValue t f m
-opaque = nvStr $ principledMakeNixStringWithoutContext "<CYCLE>"
+opaque = nvStr $ makeNixStringWithoutContext "<CYCLE>"
 
 dethunk
   :: (MonadThunk t m (NValue t f m), MonadDataContext f m)

--- a/src/Nix/Pretty.hs
+++ b/src/Nix/Pretty.hs
@@ -330,7 +330,7 @@ valueToExpr = iterNValue (\_ _ -> thk) phi
   phi (NVBuiltin' name _) = Fix . NSym . pack $ "builtins." ++ name
   phi _                   = error "Pattern synonyms foil completeness check"
 
-  mkStr ns = Fix $ NStr $ DoubleQuoted [Plain (principledStringIgnoreContext ns)]
+  mkStr ns = Fix $ NStr $ DoubleQuoted [Plain (stringIgnoreContext ns)]
 
 prettyNValue
   :: forall t f m ann . MonadDataContext f m => NValue t f m -> Doc ann
@@ -390,7 +390,7 @@ printNix = iterNValue (\_ _ -> thk) phi
 
   phi :: NValue' t f m String -> String
   phi (NVConstant' a ) = unpack $ atomText a
-  phi (NVStr'      ns) = show $ principledStringIgnoreContext ns
+  phi (NVStr'      ns) = show $ stringIgnoreContext ns
   phi (NVList'     l ) = "[ " ++ unwords l ++ " ]"
   phi (NVSet' s _) =
     "{ "

--- a/src/Nix/Pretty.hs
+++ b/src/Nix/Pretty.hs
@@ -330,7 +330,7 @@ valueToExpr = iterNValue (\_ _ -> thk) phi
   phi (NVBuiltin' name _) = Fix . NSym . pack $ "builtins." ++ name
   phi _                   = error "Pattern synonyms foil completeness check"
 
-  mkStr ns = Fix $ NStr $ DoubleQuoted [Plain (hackyStringIgnoreContext ns)]
+  mkStr ns = Fix $ NStr $ DoubleQuoted [Plain (principledStringIgnoreContext ns)]
 
 prettyNValue
   :: forall t f m ann . MonadDataContext f m => NValue t f m -> Doc ann
@@ -390,7 +390,7 @@ printNix = iterNValue (\_ _ -> thk) phi
 
   phi :: NValue' t f m String -> String
   phi (NVConstant' a ) = unpack $ atomText a
-  phi (NVStr'      ns) = show $ hackyStringIgnoreContext ns
+  phi (NVStr'      ns) = show $ principledStringIgnoreContext ns
   phi (NVList'     l ) = "[ " ++ unwords l ++ " ]"
   phi (NVSet' s _) =
     "{ "

--- a/src/Nix/String.hs
+++ b/src/Nix/String.hs
@@ -15,11 +15,8 @@ module Nix.String
   , fromNixLikeContext
   , stringHasContext
   , principledIntercalateNixString
-  , hackyGetStringNoContext
   , principledGetStringNoContext
   , principledStringIgnoreContext
-  , hackyStringIgnoreContext
-  , hackyMakeNixStringWithoutContext
   , principledMakeNixStringWithoutContext
   , principledMakeNixStringWithSingletonContext
   , principledModifyNixContents
@@ -35,6 +32,9 @@ module Nix.String
   , runWithStringContextT'
   , runWithStringContext
   , runWithStringContext'
+  , hackyGetStringNoContext
+  , hackyStringIgnoreContext
+  , hackyMakeNixStringWithoutContext
   )
 where
 
@@ -232,12 +232,11 @@ runWithStringContext' = runIdentity . runWithStringContextT'
 
 -- | Combine two NixStrings using mappend
 hackyStringMappend :: NixString -> NixString -> NixString
-hackyStringMappend (NixString s1 t1) (NixString s2 t2) =
-  NixString (s1 <> s2) (t1 <> t2)
+hackyStringMappend = principledStringMappend
 
 -- | Combine NixStrings using mconcat
 hackyStringMConcat :: [NixString] -> NixString
-hackyStringMConcat = foldr principledStringMappend (NixString mempty mempty)
+hackyStringMConcat = principledStringMConcat
 
 -- | Constructs a NixString without a context
 hackyMakeNixStringWithoutContext :: Text -> NixString

--- a/src/Nix/String.hs
+++ b/src/Nix/String.hs
@@ -47,8 +47,6 @@ import           Data.Text                      ( Text )
 import qualified Data.Text                     as Text
 import           GHC.Generics
 
--- {-# WARNING hackyGetStringNoContext, hackyStringIgnoreContext, hackyMakeNixStringWithoutContext "This NixString function needs to be replaced" #-}
-
 -- | A 'ContextFlavor' describes the sum of possible derivations for string contexts
 data ContextFlavor =
     DirectPath
@@ -132,13 +130,6 @@ principledStringMappend :: NixString -> NixString -> NixString
 principledStringMappend (NixString s1 t1) (NixString s2 t2) =
   NixString (s1 <> s2) (t1 <> t2)
 
---  2021-01-02: NOTE: This function is ERRADICATED from the source code.
--- ERRADICATE it from the API.
--- | Combine two NixStrings using mappend
-hackyStringMappend :: NixString -> NixString -> NixString
-hackyStringMappend (NixString s1 t1) (NixString s2 t2) =
-  NixString (s1 <> s2) (t1 <> t2)
-
 -- | Combine NixStrings with a separator
 principledIntercalateNixString :: NixString -> [NixString] -> NixString
 principledIntercalateNixString _   []   = principledMempty
@@ -147,12 +138,6 @@ principledIntercalateNixString sep nss  = NixString contents ctx
  where
   contents = Text.intercalate (nsContents sep) (map nsContents nss)
   ctx      = S.unions (nsContext sep : map nsContext nss)
-
---  2021-01-02: NOTE: This function is ERRADICATED from the source code.
--- ERRADICATE it from the API.
--- | Combine NixStrings using mconcat
-hackyStringMConcat :: [NixString] -> NixString
-hackyStringMConcat = foldr principledStringMappend (NixString mempty mempty)
 
 -- | Empty string with empty context.
 principledStringMempty :: NixString
@@ -250,3 +235,20 @@ runWithStringContext = runIdentity . runWithStringContextT
 -- Warning: this may be unsafe, depending on how you handle the resulting context list.
 runWithStringContext' :: WithStringContextT Identity a -> (a, S.HashSet StringContext)
 runWithStringContext' = runIdentity . runWithStringContextT'
+
+-- * Deprecated API
+
+-- {-# WARNING hackyGetStringNoContext, hackyStringIgnoreContext, hackyMakeNixStringWithoutContext "This NixString function needs to be replaced" #-}
+
+-- NOTE: These functions are ERRADICATED from the source code.
+-- ERRADICATE them from the API.
+
+-- | Combine two NixStrings using mappend
+hackyStringMappend :: NixString -> NixString -> NixString
+hackyStringMappend (NixString s1 t1) (NixString s2 t2) =
+  NixString (s1 <> s2) (t1 <> t2)
+
+-- | Combine NixStrings using mconcat
+hackyStringMConcat :: [NixString] -> NixString
+hackyStringMConcat = foldr principledStringMappend (NixString mempty mempty)
+

--- a/src/Nix/String.hs
+++ b/src/Nix/String.hs
@@ -178,10 +178,6 @@ stringHasContext :: NixString -> Bool
 stringHasContext (NixString _ c) = not (null c)
 
 -- | Constructs a NixString without a context
-hackyMakeNixStringWithoutContext :: Text -> NixString
-hackyMakeNixStringWithoutContext = flip NixString mempty
-
--- | Constructs a NixString without a context
 principledMakeNixStringWithoutContext :: Text -> NixString
 principledMakeNixStringWithoutContext = flip NixString mempty
 
@@ -251,4 +247,8 @@ hackyStringMappend (NixString s1 t1) (NixString s2 t2) =
 -- | Combine NixStrings using mconcat
 hackyStringMConcat :: [NixString] -> NixString
 hackyStringMConcat = foldr principledStringMappend (NixString mempty mempty)
+
+-- | Constructs a NixString without a context
+hackyMakeNixStringWithoutContext :: Text -> NixString
+hackyMakeNixStringWithoutContext = principledMakeNixStringWithoutContext
 

--- a/src/Nix/String.hs
+++ b/src/Nix/String.hs
@@ -156,11 +156,6 @@ principledStringMConcat =
 --  mappend = (<>)
 
 -- | Extract the string contents from a NixString that has no context
-hackyGetStringNoContext :: NixString -> Maybe Text
-hackyGetStringNoContext (NixString s c) | null c    = Just s
-                                        | otherwise = Nothing
-
--- | Extract the string contents from a NixString that has no context
 principledGetStringNoContext :: NixString -> Maybe Text
 principledGetStringNoContext (NixString s c) | null c    = Just s
                                              | otherwise = Nothing
@@ -251,4 +246,8 @@ hackyMakeNixStringWithoutContext = principledMakeNixStringWithoutContext
 -- | Extract the string contents from a NixString even if the NixString has an associated context
 hackyStringIgnoreContext :: NixString -> Text
 hackyStringIgnoreContext = principledStringIgnoreContext
+
+-- | Extract the string contents from a NixString that has no context
+hackyGetStringNoContext :: NixString -> Maybe Text
+hackyGetStringNoContext = principledGetStringNoContext
 

--- a/src/Nix/String.hs
+++ b/src/Nix/String.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE OverloadedStrings #-}
-{-# OPTIONS_GHC -Wno-unused-top-binds #-}
+
 module Nix.String
   ( NixString
   , getContext

--- a/src/Nix/String.hs
+++ b/src/Nix/String.hs
@@ -28,9 +28,6 @@ module Nix.String
   , runWithStringContextT'
   , runWithStringContext
   , runWithStringContext'
-  , hackyGetStringNoContext
-  , hackyStringIgnoreContext
-  , hackyMakeNixStringWithoutContext
   )
 where
 
@@ -227,32 +224,4 @@ intercalateNixString sep nss  = NixString contents ctx
  where
   contents = Text.intercalate (nsContents sep) (map nsContents nss)
   ctx      = S.unions (nsContext sep : map nsContext nss)
-
-
--- * Deprecated API
-
--- {-# WARNING hackyGetStringNoContext, hackyStringIgnoreContext, hackyMakeNixStringWithoutContext "This NixString function needs to be replaced" #-}
-
--- NOTE: These functions are ERRADICATED from the source code.
--- ERRADICATE them from the API.
-
--- | Combine two NixStrings using mappend
-hackyStringMappend :: NixString -> NixString -> NixString
-hackyStringMappend = mappend
-
--- | Combine NixStrings using mconcat
-hackyStringMConcat :: [NixString] -> NixString
-hackyStringMConcat = mconcat
-
--- | Constructs a NixString without a context
-hackyMakeNixStringWithoutContext :: Text -> NixString
-hackyMakeNixStringWithoutContext = makeNixStringWithoutContext
-
--- | Extract the string contents from a NixString even if the NixString has an associated context
-hackyStringIgnoreContext :: NixString -> Text
-hackyStringIgnoreContext = stringIgnoreContext
-
--- | Extract the string contents from a NixString that has no context
-hackyGetStringNoContext :: NixString -> Maybe Text
-hackyGetStringNoContext = getStringNoContext
 

--- a/src/Nix/String.hs
+++ b/src/Nix/String.hs
@@ -169,10 +169,6 @@ principledGetStringNoContext (NixString s c) | null c    = Just s
 principledStringIgnoreContext :: NixString -> Text
 principledStringIgnoreContext (NixString s _) = s
 
--- | Extract the string contents from a NixString even if the NixString has an associated context
-hackyStringIgnoreContext :: NixString -> Text
-hackyStringIgnoreContext (NixString s _) = s
-
 -- | Returns True if the NixString has an associated context
 stringHasContext :: NixString -> Bool
 stringHasContext (NixString _ c) = not (null c)
@@ -251,4 +247,8 @@ hackyStringMConcat = foldr principledStringMappend (NixString mempty mempty)
 -- | Constructs a NixString without a context
 hackyMakeNixStringWithoutContext :: Text -> NixString
 hackyMakeNixStringWithoutContext = principledMakeNixStringWithoutContext
+
+-- | Extract the string contents from a NixString even if the NixString has an associated context
+hackyStringIgnoreContext :: NixString -> Text
+hackyStringIgnoreContext = principledStringIgnoreContext
 

--- a/src/Nix/String.hs
+++ b/src/Nix/String.hs
@@ -19,7 +19,6 @@ module Nix.String
   , makeNixStringWithoutContext
   , makeNixStringWithSingletonContext
   , modifyNixContents
-  , stringMConcat
   , WithStringContext
   , WithStringContextT(..)
   , extractNixString
@@ -133,11 +132,6 @@ intercalateNixString sep nss  = NixString contents ctx
   contents = Text.intercalate (nsContents sep) (map nsContents nss)
   ctx      = S.unions (nsContext sep : map nsContext nss)
 
--- | Combine NixStrings using mconcat
-stringMConcat :: [NixString] -> NixString
-stringMConcat =
-  foldr mappend (NixString mempty mempty)
-
 -- | Extract the string contents from a NixString that has no context
 getStringNoContext :: NixString -> Maybe Text
 getStringNoContext (NixString s c) | null c    = Just s
@@ -219,7 +213,7 @@ hackyStringMappend = mappend
 
 -- | Combine NixStrings using mconcat
 hackyStringMConcat :: [NixString] -> NixString
-hackyStringMConcat = stringMConcat
+hackyStringMConcat = mconcat
 
 -- | Constructs a NixString without a context
 hackyMakeNixStringWithoutContext :: Text -> NixString

--- a/src/Nix/String/Coerce.hs
+++ b/src/Nix/String/Coerce.hs
@@ -57,18 +57,18 @@ coerceToString call ctsm clevel = go
       |
         -- TODO Return a singleton for "" and "1"
         b && clevel == CoerceAny -> pure
-      $  principledMakeNixStringWithoutContext "1"
-      | clevel == CoerceAny -> pure $ principledMakeNixStringWithoutContext ""
+      $  makeNixStringWithoutContext "1"
+      | clevel == CoerceAny -> pure $ makeNixStringWithoutContext ""
     NVConstant (NInt n) | clevel == CoerceAny ->
-      pure $ principledMakeNixStringWithoutContext $ Text.pack $ show n
+      pure $ makeNixStringWithoutContext $ Text.pack $ show n
     NVConstant (NFloat n) | clevel == CoerceAny ->
-      pure $ principledMakeNixStringWithoutContext $ Text.pack $ show n
+      pure $ makeNixStringWithoutContext $ Text.pack $ show n
     NVConstant NNull | clevel == CoerceAny ->
-      pure $ principledMakeNixStringWithoutContext ""
+      pure $ makeNixStringWithoutContext ""
     NVStr ns -> pure ns
     NVPath p
       | ctsm == CopyToStore -> storePathToNixString <$> addPath p
-      | otherwise -> pure $ principledMakeNixStringWithoutContext $ Text.pack p
+      | otherwise -> pure $ makeNixStringWithoutContext $ Text.pack p
     NVList l | clevel == CoerceAny ->
       nixStringUnwords <$> traverse (`demand` go) l
 
@@ -80,9 +80,9 @@ coerceToString call ctsm clevel = go
     v -> throwError $ ErrorCall $ "Expected a string, but saw: " ++ show v
 
   nixStringUnwords =
-    principledIntercalateNixString (principledMakeNixStringWithoutContext " ")
+    intercalateNixString (makeNixStringWithoutContext " ")
   storePathToNixString :: StorePath -> NixString
-  storePathToNixString sp = principledMakeNixStringWithSingletonContext
+  storePathToNixString sp = makeNixStringWithSingletonContext
     t
     (StringContext t DirectPath)
     where t = Text.pack $ unStorePath sp

--- a/src/Nix/Value.hs
+++ b/src/Nix/Value.hs
@@ -85,7 +85,7 @@ instance Foldable (NValueF p m) where
 instance Show r => Show (NValueF p m r) where
   showsPrec = flip go   where
     go (NVConstantF atom  ) = showsCon1 "NVConstant" atom
-    go (NVStrF      ns    ) = showsCon1 "NVStr" (hackyStringIgnoreContext ns)
+    go (NVStrF      ns    ) = showsCon1 "NVStr" (principledStringIgnoreContext ns)
     go (NVListF     lst   ) = showsCon1 "NVList" lst
     go (NVSetF     attrs _) = showsCon1 "NVSet" attrs
     go (NVClosureF p     _) = showsCon1 "NVClosure" p
@@ -176,7 +176,7 @@ instance Comonad f => Show1 (NValue' t f m) where
   liftShowsPrec sp sl p = \case
     NVConstant' atom  -> showsUnaryWith showsPrec "NVConstantF" p atom
     NVStr' ns ->
-      showsUnaryWith showsPrec "NVStrF" p (hackyStringIgnoreContext ns)
+      showsUnaryWith showsPrec "NVStrF" p (principledStringIgnoreContext ns)
     NVList' lst       -> showsUnaryWith (liftShowsPrec sp sl) "NVListF" p lst
     NVSet' attrs _    -> showsUnaryWith (liftShowsPrec sp sl) "NVSetF" p attrs
     NVPath' path      -> showsUnaryWith showsPrec "NVPathF" p path

--- a/src/Nix/Value.hs
+++ b/src/Nix/Value.hs
@@ -85,7 +85,7 @@ instance Foldable (NValueF p m) where
 instance Show r => Show (NValueF p m r) where
   showsPrec = flip go   where
     go (NVConstantF atom  ) = showsCon1 "NVConstant" atom
-    go (NVStrF      ns    ) = showsCon1 "NVStr" (principledStringIgnoreContext ns)
+    go (NVStrF      ns    ) = showsCon1 "NVStr" (stringIgnoreContext ns)
     go (NVListF     lst   ) = showsCon1 "NVList" lst
     go (NVSetF     attrs _) = showsCon1 "NVSet" attrs
     go (NVClosureF p     _) = showsCon1 "NVClosure" p
@@ -176,7 +176,7 @@ instance Comonad f => Show1 (NValue' t f m) where
   liftShowsPrec sp sl p = \case
     NVConstant' atom  -> showsUnaryWith showsPrec "NVConstantF" p atom
     NVStr' ns ->
-      showsUnaryWith showsPrec "NVStrF" p (principledStringIgnoreContext ns)
+      showsUnaryWith showsPrec "NVStrF" p (stringIgnoreContext ns)
     NVList' lst       -> showsUnaryWith (liftShowsPrec sp sl) "NVListF" p lst
     NVSet' attrs _    -> showsUnaryWith (liftShowsPrec sp sl) "NVSetF" p attrs
     NVPath' path      -> showsUnaryWith showsPrec "NVPathF" p path

--- a/src/Nix/Value/Equal.hs
+++ b/src/Nix/Value/Equal.hs
@@ -86,7 +86,7 @@ isDerivationM f m = case M.lookup "type" m of
     case mres of
         -- We should probably really make sure the context is empty here
         -- but the C++ implementation ignores it.
-      Just s  -> pure $ principledStringIgnoreContext s == "derivation"
+      Just s  -> pure $ stringIgnoreContext s == "derivation"
       Nothing -> pure False
 
 isDerivation :: Monad m => (t -> Maybe NixString) -> AttrSet t -> Bool
@@ -104,7 +104,7 @@ valueFEqM attrsEq eq = curry $ \case
   (NVConstantF (NInt   x), NVConstantF (NFloat y)) -> pure $ fromInteger x == y
   (NVConstantF lc        , NVConstantF rc        ) -> pure $ lc == rc
   (NVStrF ls, NVStrF rs) ->
-    pure $ principledStringIgnoreContext ls == principledStringIgnoreContext rs
+    pure $ stringIgnoreContext ls == stringIgnoreContext rs
   (NVListF ls , NVListF rs ) -> alignEqM eq ls rs
   (NVSetF lm _, NVSetF rm _) -> attrsEq lm rm
   (NVPathF lp , NVPathF rp ) -> pure $ lp == rp

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -59,7 +59,7 @@ ensureNixpkgsCanParse =
           time <- getCurrentTime
           runWithBasicEffectsIO (defaultOptions time) $
             Nix.nixEvalExprLoc Nothing expr
-        let dir = hackyStringIgnoreContext ns
+        let dir = principledStringIgnoreContext ns
         exists <- fileExist (unpack dir)
         unless exists $
           errorWithoutStackTrace $

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -59,7 +59,7 @@ ensureNixpkgsCanParse =
           time <- getCurrentTime
           runWithBasicEffectsIO (defaultOptions time) $
             Nix.nixEvalExprLoc Nothing expr
-        let dir = principledStringIgnoreContext ns
+        let dir = stringIgnoreContext ns
         exists <- fileExist (unpack dir)
         unless exists $
           errorWithoutStackTrace $

--- a/tests/NixLanguageTests.hs
+++ b/tests/NixLanguageTests.hs
@@ -133,7 +133,7 @@ assertLangOk opts file = do
 
 assertLangOkXml :: Options -> FilePath -> Assertion
 assertLangOkXml opts file = do
-  actual <- principledStringIgnoreContext . toXML <$> hnixEvalFile
+  actual <- stringIgnoreContext . toXML <$> hnixEvalFile
     opts
     (file ++ ".nix")
   expected <- Text.readFile $ file ++ ".exp.xml"


### PR DESCRIPTION
* Closes: #383 #384 #385

* Reduced prefixes from functions.

* Code now treats the NixString as a monoid.