### PR TITLE
CI: GitHub: Nix: dontCheck

### DIFF
--- a/.github/workflows/Optional-Nix-dev-env-macOS.yml
+++ b/.github/workflows/Optional-Nix-dev-env-macOS.yml
@@ -16,6 +16,7 @@ env:
   # rev: "nixos-unstable"         #  2020-09-29: NOTE: HNix default.nix currently pins the rev
   cachixAccount: "hnix"
   CACHIX_SIGNING_KEY: ${{ secrets.CACHIX_SIGNING_KEY }}
+  doCheck: "false"
 
 
 jobs:

--- a/.github/workflows/Optional-Nix-dev-env-main.yml
+++ b/.github/workflows/Optional-Nix-dev-env-main.yml
@@ -27,7 +27,7 @@ env:
   CACHIX_SIGNING_KEY: ${{ secrets.CACHIX_SIGNING_KEY }}
   allowInconsistentDependencies: "false"
   doJailbreak: "false"
-  doCheck: "true"
+  doCheck: "false"
   sdistTarball: "false"
   buildFromSdist: "false"
   buildStrictly: "false"


### PR DESCRIPTION
The Cabal testing on 4 GHC versions & bases is really enough.

After that Nix it is really enough just to check compilation - it is the main trouble we have in it.

But `dontCheck` essentially defies the purpose of the Nix dev env, since tests fall in it.

Maybe form a network test switch and disable those tests when the variable is
set. So we configure that in the CI and in Nixpkgs.

Or detect `IN_NIX_SHELL` or build-related env var and disable them automatically.