### PR TITLE
Intern strings

### DIFF
--- a/hnix.cabal
+++ b/hnix.cabal
@@ -417,6 +417,7 @@ library
     , http-client >= 0.5.14 && < 0.6 || >= 0.6.4 && < 0.7
     , http-client-tls >= 0.3.5 && < 0.4
     , http-types >= 0.12.2 && < 0.13
+    , intern
     , lens-family >= 1.2.2 && < 2.2
     , lens-family-core >= 1.2.2 && < 2.2
     , lens-family-th >= 0.5.0 && < 0.6
@@ -484,6 +485,7 @@ executable hnix
     , free
     , haskeline >= 0.8.0.0 && < 0.9
     , hnix
+    , intern
     , mtl
     , optparse-applicative
     , pretty-show
@@ -535,6 +537,7 @@ test-suite hnix-tests
     , filepath
     , hedgehog
     , hnix
+    , intern
     , megaparsec
     , mtl
     , neat-interpolation

--- a/main/Main.hs
+++ b/main/Main.hs
@@ -9,6 +9,7 @@
 
 module Main where
 
+import           Control.Arrow                  ( first )
 import           Control.Comonad                ( extract )
 import qualified Control.DeepSeq               as Deep
 import qualified Control.Exception             as Exc
@@ -17,6 +18,7 @@ import           Control.Monad.Catch
 import           Control.Monad.Free
 import           Control.Monad.IO.Class
 import qualified Data.HashMap.Lazy             as M
+import           Data.Interned                  ( unintern )
 import qualified Data.Map                      as Map
 import           Data.List                      ( sortOn )
 import           Data.Maybe                     ( fromJust )
@@ -164,7 +166,7 @@ main = do
       findAttrs = go ""
        where
         go prefix s = do
-          xs <- forM (sortOn fst (M.toList s)) $ \(k, nv) -> case nv of
+          xs <- forM (sortOn fst (map (first unintern) $ M.toList s)) $ \(k, nv) -> case nv of
             Free v -> pure (k, Just (Free v))
             Pure (StdThunk (extract -> Thunk _ _ ref)) -> do
               let path         = prefix ++ Text.unpack k

--- a/src/Nix.hs
+++ b/src/Nix.hs
@@ -29,10 +29,11 @@ module Nix
 where
 
 import           Control.Applicative
-import           Control.Arrow                  ( second )
+import           Control.Arrow                  ( first, second )
 import           Control.Monad.Reader
 import           Data.Fix
 import qualified Data.HashMap.Lazy             as M
+import           Data.Interned
 import qualified Data.Text                     as Text
 import qualified Data.Text.Read                as Text
 import           Nix.Builtins
@@ -121,7 +122,7 @@ evaluateExpression mpath evaluator handler expr = do
 
   eval' = normalForm <=< nixEvalExpr mpath
 
-  argmap args = nvSet (M.fromList args) mempty
+  argmap args = nvSet (M.fromList $ map (first intern) args) mempty
 
 processResult
   :: forall e t f m a
@@ -148,7 +149,7 @@ processResult h val = do
         ++ "', but got: "
         ++ show v
   go (k : ks) v = demand v $ \case
-    NVSet xs _ -> case M.lookup k xs of
+    NVSet xs _ -> case M.lookup (intern k) xs of
       Nothing ->
         errorWithoutStackTrace
           $  "Set does not contain key '"

--- a/src/Nix/Convert.hs
+++ b/src/Nix/Convert.hs
@@ -320,7 +320,7 @@ instance ( Convertible e t f m
     f' <- toValue (makeNixStringWithoutContext (Text.pack f))
     l' <- toValue (unPos l)
     c' <- toValue (unPos c)
-    let pos = M.fromList [("file" :: Text, f'), ("line", l'), ("column", c')]
+    let pos = M.fromList [("file", f'), ("line", l'), ("column", c')]
     pure $ nvSet' pos mempty
 
 -- | With 'ToValue', we can always act recursively

--- a/src/Nix/Effects/Basic.hs
+++ b/src/Nix/Effects/Basic.hs
@@ -131,7 +131,7 @@ findPathBy finder ls name = do
   go :: Maybe FilePath -> NValue t f m -> m (Maybe FilePath)
   go p@(Just _) _ = pure p
   go Nothing l =
-    demand l $ fromValue >=> \(s :: HashMap Text (NValue t f m)) -> do
+    demand l $ fromValue >=> \(s :: HashMap VarName (NValue t f m)) -> do
       p <- resolvePath s
       demand p $ fromValue >=> \(Path path) -> case M.lookup "prefix" s of
         Nothing -> tryPath path Nothing

--- a/src/Nix/Expr/Types/Annotated.hs
+++ b/src/Nix/Expr/Types/Annotated.hs
@@ -44,6 +44,7 @@ import           Data.Text                      ( Text
                                                 )
 import           GHC.Generics
 import           Nix.Atoms
+import           Nix.Utils
 import           Nix.Expr.Types
 import           Text.Megaparsec                ( unPos
                                                 , mkPos
@@ -180,7 +181,7 @@ nullSpan = SrcSpan nullPos nullPos
 pattern NSym_ :: SrcSpan -> VarName -> NExprLocF r
 pattern NSym_ ann x = Compose (Ann ann (NSym x))
 
-pattern NSynHole_ :: SrcSpan -> Text -> NExprLocF r
+pattern NSynHole_ :: SrcSpan -> VarName -> NExprLocF r
 pattern NSynHole_ ann x = Compose (Ann ann (NSynHole x))
 
 pattern NConstant_ :: SrcSpan -> NAtom -> NExprLocF r

--- a/src/Nix/Json.hs
+++ b/src/Nix/Json.hs
@@ -4,11 +4,13 @@
 
 module Nix.Json where
 
+import           Control.Arrow                  ( first )
 import           Control.Monad
 import           Control.Monad.Trans
 import qualified Data.Aeson                    as A
 import qualified Data.Aeson.Encoding           as A
 import qualified Data.HashMap.Lazy             as HM
+import           Data.Interned
 import qualified Data.Text                     as Text
 import qualified Data.Text.Lazy                as TL
 import qualified Data.Text.Lazy.Encoding       as TL
@@ -46,7 +48,7 @@ nvalueToJSON = \case
       <$> traverse (join . lift . flip demand (pure . nvalueToJSON)) l
   NVSet m _ -> case HM.lookup "outPath" m of
     Nothing ->
-      A.Object
+      A.Object . HM.fromList . map (first unintern) . HM.toList
         <$> traverse (join . lift . flip demand (pure . nvalueToJSON)) m
     Just outPath -> join $ lift $ demand outPath (pure . nvalueToJSON)
   NVPath p -> do

--- a/src/Nix/Parser.hs
+++ b/src/Nix/Parser.hs
@@ -64,6 +64,7 @@ import           Data.Fix                       ( Fix(..) )
 import           Data.Functor
 import           Data.HashSet                   ( HashSet )
 import qualified Data.HashSet                  as HashSet
+import           Data.Interned
 import           Data.List.NonEmpty             ( NonEmpty(..) )
 import qualified Data.List.NonEmpty            as NE
 import qualified Data.Map                      as Map
@@ -80,6 +81,7 @@ import           GHC.Generics            hiding ( Prefix )
 import           Nix.Expr                hiding ( ($>) )
 import           Nix.Expr.Strings
 import           Nix.Render
+import           Nix.Utils                      ( VarName )
 import           Prettyprinter                  ( Doc
                                                 , pretty
                                                 )
@@ -381,7 +383,7 @@ argExpr = msum [atLeft, onlyname, atRight] <* symbol ":" where
 
   -- Collects the parameters within curly braces. Returns the parameters and
   -- a boolean indicating if the parameters are variadic.
-  getParams :: Parser ([(Text, Maybe NExprLoc)], Bool)
+  getParams :: Parser ([(VarName, Maybe NExprLoc)], Bool)
   getParams = go []   where
     -- Attempt to parse `...`. If this succeeds, stop and return True.
     -- Otherwise, attempt to parse an argument, optionally with a
@@ -495,7 +497,7 @@ identifier = lexeme $ try $ do
     <$> satisfy (\x -> isAlpha x || x == '_')
     <*> takeWhileP Nothing identLetter
   guard (not (ident `HashSet.member` reservedNames))
-  pure ident
+  pure $ intern ident
  where
   identLetter x = isAlpha x || isDigit x || x == '_' || x == '\'' || x == '-'
 

--- a/src/Nix/Pretty.hs
+++ b/src/Nix/Pretty.hs
@@ -16,6 +16,7 @@
 
 module Nix.Pretty where
 
+import           Control.Arrow                  ( first )
 import           Control.Applicative            ( (<|>) )
 import           Control.Monad.Free
 import           Data.Fix                       ( Fix(..), foldFix )
@@ -399,8 +400,8 @@ printNix = iterNValue (\_ _ -> thk) phi
   phi (NVSet' s _) =
     "{ "
       ++ concat
-           [ check (unpack $ unintern k) ++ " = " ++ v ++ "; "
-           | (k, v) <- sort $ toList s
+           [ check (unpack k) ++ " = " ++ v ++ "; "
+           | (k, v) <- sort $ map (first unintern) $ toList s
            ]
       ++ "}"
    where

--- a/src/Nix/Scope.hs
+++ b/src/Nix/Scope.hs
@@ -26,7 +26,7 @@ instance Show (Scope a) where
 newScope :: AttrSet a -> Scope a
 newScope = Scope
 
-scopeLookup :: Text -> [Scope a] -> Maybe a
+scopeLookup :: VarName -> [Scope a] -> Maybe a
 scopeLookup key = foldr go Nothing
   where go (Scope m) rest = M.lookup key m <|> rest
 
@@ -53,7 +53,7 @@ class Scoped a m | m -> a where
   currentScopes :: m (Scopes m a)
   clearScopes :: m r -> m r
   pushScopes :: Scopes m a -> m r -> m r
-  lookupVar :: Text -> m (Maybe a)
+  lookupVar :: VarName -> m (Maybe a)
 
 currentScopesReader
   :: forall m a e . (MonadReader e m, Has e (Scopes m a)) => m (Scopes m a)
@@ -74,7 +74,7 @@ pushScopesReader
 pushScopesReader s = local (over hasLens (s <>))
 
 lookupVarReader
-  :: forall m a e . (MonadReader e m, Has e (Scopes m a)) => Text -> m (Maybe a)
+  :: forall m a e . (MonadReader e m, Has e (Scopes m a)) => VarName -> m (Maybe a)
 lookupVarReader k = do
   mres <- asks (scopeLookup k . lexicalScopes @m . view hasLens)
   case mres of

--- a/src/Nix/TH.hs
+++ b/src/Nix/TH.hs
@@ -16,12 +16,14 @@ import qualified Data.Set                      as Set
 import qualified Data.Text                     as Text
 import           Data.List.NonEmpty             ( NonEmpty(..) )
 import           Data.Maybe                     ( mapMaybe )
+import           Data.Interned                  ( unintern )
 import           Language.Haskell.TH
 import           Language.Haskell.TH.Syntax     ( liftString )
 import           Language.Haskell.TH.Quote
 import           Nix.Atoms
 import           Nix.Expr
 import           Nix.Parser
+import           Nix.Utils                      ( VarName )
 
 quoteExprExp :: String -> ExpQ
 quoteExprExp s = do
@@ -120,12 +122,12 @@ instance ToExpr Float where
 
 metaExp :: Set VarName -> NExprLoc -> Maybe ExpQ
 metaExp fvs (Fix (NSym_ _ x)) | x `Set.member` fvs =
-  Just [| toExpr $(varE (mkName (Text.unpack x))) |]
+  Just [| toExpr $(varE (mkName (Text.unpack $ unintern x))) |]
 metaExp _ _ = Nothing
 
 metaPat :: Set VarName -> NExprLoc -> Maybe PatQ
 metaPat fvs (Fix (NSym_ _ x)) | x `Set.member` fvs =
-  Just (varP (mkName (Text.unpack x)))
+  Just (varP (mkName (Text.unpack $ unintern x)))
 metaPat _ _ = Nothing
 
 nix :: QuasiQuoter

--- a/src/Nix/Type/Infer.hs
+++ b/src/Nix/Type/Infer.hs
@@ -187,7 +187,7 @@ instance ActiveTypeVars a => ActiveTypeVars [a] where
 data TypeError
   = UnificationFail Type Type
   | InfiniteType TVar Type
-  | UnboundVariables [Text]
+  | UnboundVariables [VarName]
   | Ambigious [Constraint]
   | UnificationMismatch [Type] [Type]
   deriving (Eq, Show)
@@ -564,7 +564,7 @@ instance MonadInfer m => ToValue Bool (InferT s m) (Judgment s) where
 infer :: MonadInfer m => NExpr -> InferT s m (Judgment s)
 infer = foldFix Eval.eval
 
-inferTop :: Env -> [(Text, NExpr)] -> Either InferError Env
+inferTop :: Env -> [(VarName, NExpr)] -> Either InferError Env
 inferTop env []                = Right env
 inferTop env ((name, ex) : xs) = case inferExpr env ex of
   Left  err -> Left err

--- a/src/Nix/Type/Type.hs
+++ b/src/Nix/Type/Type.hs
@@ -2,7 +2,7 @@ module Nix.Type.Type where
 
 import qualified Data.HashMap.Lazy             as M
 import           Data.Text                      ( Text )
-import           Nix.Utils                      ( AttrSet )
+import           Nix.Utils                      ( AttrSet, VarName )
 
 -- | Hindrey-Milner type interface
 
@@ -41,4 +41,4 @@ typeString = TCon "string"
 typePath = TCon "path"
 typeNull = TCon "null"
 
-type Name = Text
+type Name = VarName

--- a/tests/EvalTests.hs
+++ b/tests/EvalTests.hs
@@ -22,6 +22,7 @@ import           NeatInterpolation (text)
 import           Nix
 import           Nix.Standard
 import           Nix.TH
+import           Nix.Utils
 import           Nix.Value.Equal
 import qualified System.Directory as D
 import           System.Environment


### PR DESCRIPTION
Some speedup is gained:
avg (5 runs): 21.2s vs 23.4s on evaluating nixpkgs.hello

Nix also caches the strings content. I guess we should just benchmark it. The only downside is that we encounter bigger texts, and compute a hash unnecessarily on some of them.
