### PR TITLE
cabal: rm cryptohash-sha512 override

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,8 +1,3 @@
 packages:
   ./hnix.cabal
 
-source-repository-package
-    type: git
-    location: https://github.com/Anton-Latukha/cryptohash-sha512
-    tag: 48f827eb09a73ad5ee43dd397a06ebdbf51ab856
-


### PR DESCRIPTION
https://github.com/haskell-hvr/cryptohash-sha512/pull/5#issuecomment-757068529

Nixpkgs is Ok with all this, it does not import these overrides and have own separate mechanics for the overrides. Since cryptohash-sha512 package is essentially in the unmaintained state - I think it is not worth cleaning the Nixpkgs description because soon (on soon arriving 9.0) - it may be needed again in Nixpgs store, and to that time I hope we make a transition.

This cleaning has a nice side-effect that after release HNix would not need to recompile the cryptohash and Store packages every build.