### PR TITLE
rename '<CYCLE>' to direct & understandable '<expr>'

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,7 +285,7 @@ hnix \
   --eval \
   --expr '{ x = true; }'
   
-{ x = "<CYCLE>"; }
+{ x = "<expr>"; }
 ```
 
 To disable laziness add the `--strict` to commands or `:set strict` in the REPL.

--- a/src/Nix/Normal.hs
+++ b/src/Nix/Normal.hs
@@ -124,7 +124,7 @@ removeEffects =
     (fmap Free . sequenceNValue' id)
 
 opaque :: Applicative f => NValue t f m
-opaque = nvStr $ makeNixStringWithoutContext "<CYCLE>"
+opaque = nvStr $ makeNixStringWithoutContext "<expr>"
 
 dethunk
   :: (MonadThunk t m (NValue t f m), MonadDataContext f m)

--- a/src/Nix/Pretty.hs
+++ b/src/Nix/Pretty.hs
@@ -315,7 +315,7 @@ exprFNixDoc = \case
 valueToExpr :: forall t f m . MonadDataContext f m => NValue t f m -> NExpr
 valueToExpr = iterNValue (\_ _ -> thk) phi
  where
-  thk = Fix . NSym . pack $ "<CYCLE>"
+  thk = Fix . NSym . pack $ "<expr>"
 
   phi :: NValue' t f m NExpr -> NExpr
   phi (NVConstant' a ) = Fix $ NConstant a

--- a/src/Nix/XML.hs
+++ b/src/Nix/XML.hs
@@ -18,7 +18,7 @@ import           Text.XML.Light
 toXML :: forall t f m . MonadDataContext f m => NValue t f m -> NixString
 toXML = runWithStringContext . fmap pp . iterNValue (\_ _ -> cyc) phi
  where
-  cyc = pure $ mkElem "string" "value" "<CYCLE>"
+  cyc = pure $ mkElem "string" "value" "<expr>"
 
   pp =
     ("<?xml version='1.0' encoding='utf-8'?>\n" <>)


### PR DESCRIPTION
Semantically `<CYCLE>` was remotely right only in `opaque` `src/Nix/Normal.hs`
which tries to detect cycles, and only partially right, even if just due to non-termination detenction problem (halting problem).

In other cases, where `<CYCLE>` was used - they are no cycles, which people see: https://github.com/haskell-nix/hnix/issues/663#issue-646681651, and felt confused.

In REPL case - they are simply thunks, or as in XML - just mark expressions.

& they are all expressions after all.

Even most of the infinite nonterminating expressions can be WHNF & studied as expression layer by layer.

And since we can say "expr", that also saves users & devs from communicating what in the lazy FP programming "thunk" slang means.

And currently by itself explains the #777 situation