### PR TITLE
CI: defer Nix macOS to scheduled; Cabal: add macOS

### DIFF
--- a/.github/workflows/Cabal-macOS.yml
+++ b/.github/workflows/Cabal-macOS.yml
@@ -1,4 +1,4 @@
-name: "Hackage, Cabal, Linux"
+name: "Hackage, Cabal, macOS"
 
 on:
   pull_request:
@@ -6,41 +6,39 @@ on:
     branches:
       - master
   schedule:
-    - cron: "45 02 * * *"
+    - cron: "30 04 * * *"
 
 env:
-  cabalConfig: --enable-tests --enable-benchmarks --disable-optimization --enable-deterministic
+  cabalConfig: --enable-tests --disable-optimization --enable-deterministic
 
 jobs:
 
   build10:
     name: "GHC"
-    runs-on: ubuntu-latest
+    runs-on: macOS-latest
     strategy:
       matrix:
-        ghc: [ "8.10", "8.4" ]
+        # It is dev env, so trying to stick to last GHC.
+        ghc: [ "8.10" ]
     steps:
 
       - name: "Git checkout"
         uses: actions/checkout@v2
         with:
           submodules: recursive
-          
+
       - name: "Haskell env setup"
         id: HaskEnvSetup
         uses: haskell/actions/setup@v1
         with:
           ghc-version: ${{ matrix.ghc }}
 
-      - name: "Install additional system packages"
-        run: sudo apt install libsodium-dev
-
-      #  2020-08-01: NOTE: Nix instantiate still needed for HNix tests
-      - name: "Install Nix"
-        uses: cachix/install-nix-action@v12
-
       - name: "Repository update"
         run: cabal v2-update
+
+      # Still required for Remote and some builtins
+      - name: "Install Nix"
+        uses: cachix/install-nix-action@v12
 
       # NOTE: Freeze is for the caching
       - name: "Configuration freeze"
@@ -52,19 +50,11 @@ jobs:
           path: |
             ${{ steps.HaskEnvSetup.outputs.cabal-store }}
             dist-newstyle
-          key: ${{ runner.os }}-Cabal-${{ matrix.ghc }}-${{ hashFiles('cabal.project.freeze') }}
-          restore-keys: ${{ runner.os }}-Cabal-${{ matrix.ghc }}-
+          key: ${{ runner.os }}-Cabal-${{ hashFiles( 'cabal.project.freeze' ) }}
+          restore-keys: ${{ runner.os }}-Cabal-
 
       - name: "Build"
         run: cabal v2-build $cabalConfig
 
       - name: "Tests"
         run: cabal v2-test $cabalConfig
-
-      - name: "Haddock"
-        if: ${{ matrix.ghc == '8.10' }}
-        run: cabal v2-haddock $cabalConfig
-
-      - name: "Source distribution file"
-        if: ${{ matrix.ghc == '8.10' }}
-        run: cabal v2-sdist

--- a/.github/workflows/Optional-Nix-dev-env-macOS.yml
+++ b/.github/workflows/Optional-Nix-dev-env-macOS.yml
@@ -1,19 +1,12 @@
-name: "(Optional) Nix dev env, macOS"
+name: "(On shedule) Nix dev env, macOS"
   # Due to macOS is a side-build to test the platform, using nixos-unstable for additional long-term stability of it
 on:
-  # On Git changes in PR
-  pull_request:
-  # On Git changes of the master
-  push:
-    branches:
-      - master
   schedule:
-    # Every day at 04:45
-    - cron: "45 01 * * *"
+    # Every Friday 22:45
+    - cron: "45 22 * * 5"
 
 
 env:
-  # rev: "nixos-unstable"         #  2020-09-29: NOTE: HNix default.nix currently pins the rev
   cachixAccount: "hnix"
   CACHIX_SIGNING_KEY: ${{ secrets.CACHIX_SIGNING_KEY }}
   doCheck: "false"
@@ -21,7 +14,7 @@ env:
 
 jobs:
   build10:
-    name: "Default GHC (8.8)"
+    name: "Default GHC"
     runs-on: macos-latest
     continue-on-error: true
     steps:

--- a/.github/workflows/Optional-Nix-dev-env-main.yml
+++ b/.github/workflows/Optional-Nix-dev-env-main.yml
@@ -83,7 +83,7 @@ jobs:
 
 
   build20:
-    name: "GHC 8.10.3, quality build, SDist, Optimizations, Benchmark, Haddock, Completions"
+    name: "GHC 8.10, quality build, SDist, Optimizations, Benchmark, Haddock, Completions"
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:


### PR DESCRIPTION
This currently does not solve the support of macOS.

Just baselines the requirements to keep support right.

Basically, I do not want contributors to be bothering with the checks of macOS Nixpkgs check during their work. Lets do not try to force Nix dev env & Nixpkgs requirements & macOS requirement in the mix, some devs may not even understand the situation of the Nix configuration code/state and what all that means, they do not need to know what is in `default.nix`, what `rev` it currently is, what Apple changes in the platform and how it changes&complicates the Nixpkgs, are the current state and current WIP processes in Nixpkgs with macOS support and how it all comes or grazes in the software pipe into a check result.

Lets do not bother devs in PRs with Nixpkgs macOS compatibility, when we can to just ask/have a pulse of a basic macOS compatibility, and leave the Nix/Nixpkgs macOS stuff to the project & Nixpkgs maintainers and when devs really would become interested in it.