### PR TITLE
Nix.Builtins: replaceStrings: refactor

### DIFF
--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -961,25 +961,24 @@ replaceStrings tfrom tto ts =
 
         go orig resultAccum ctx = case lookupPrefix orig of
           Nothing ->
-            maybe
-              (finish resultAccum)
-              (\(h, t) -> go t (resultAccum <> Builder.singleton h))
-              (Text.uncons orig)
-              ctx
+            process resultAccum orig ctx
           Just (prefix, replacementNS, rest) ->
-            (if prefix == mempty
+            ( if prefix == mempty
               then
-                maybe
-                  (finish newResultAccum)
-                  (\(h,t) -> go t (newResultAccum <> Builder.singleton h))
-                  (Text.uncons rest)
+                process newResultAccum rest
               else
-                go rest newResultAccum)
-                (ctx <> newCtx)
+                go rest newResultAccum
+            ) (ctx <> newCtx)
            where
             replacement = Builder.fromText $ stringIgnoreContext replacementNS
             newResultAccum = resultAccum <> replacement
             newCtx      = NixString.getContext replacementNS
+         where
+            process r t =
+              maybe
+                (finish r)
+                (\(h, t) -> go t (r <> Builder.singleton h))
+                (Text.uncons t)
       toValue
         $ go (stringIgnoreContext ns) mempty
         $ NixString.getContext ns

--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -959,22 +959,23 @@ replaceStrings tfrom tto ts =
 
         finish = makeNixString . LazyText.toStrict . Builder.toLazyText
 
-        go orig resultAccum ctx = case lookupPrefix orig of
+        go source resultAccum ctx = case lookupPrefix source of
           Nothing ->
-            process resultAccum orig ctx
+            process source resultAccum ctx
           Just (prefix, replacementNS, rest) ->
             ( if prefix == mempty
               then
-                process newResultAccum rest
+                process rest newResultAccum
               else
                 go rest newResultAccum
-            ) (ctx <> newCtx)
+            ) newCtx
            where
-            replacement = Builder.fromText $ stringIgnoreContext replacementNS
+            replacement    = Builder.fromText $ stringIgnoreContext replacementNS
             newResultAccum = resultAccum <> replacement
-            newCtx      = NixString.getContext replacementNS
+            additionalCtx  = NixString.getContext replacementNS
+            newCtx         = ctx <> additionalCtx
          where
-            process r t =
+            process t r =
               maybe
                 (finish r)
                 (\(h, t) -> go t (r <> Builder.singleton h))

--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -957,28 +957,27 @@ replaceStrings tfrom tto ts =
             let rest = Text.drop (Text.length prefix) s
             pure (prefix, replacement, rest)
 
-        finish b =
-          makeNixString (LazyText.toStrict $ Builder.toLazyText b)
+        finish = makeNixString . LazyText.toStrict . Builder.toLazyText
 
         go orig result ctx = case lookupPrefix orig of
           Nothing ->
-            case Text.uncons orig of
+            (case Text.uncons orig of
               Nothing     ->
-                finish result ctx
+                finish result
               Just (h, t) ->
-                go t (result <> Builder.singleton h) ctx
+                go t (result <> Builder.singleton h)) ctx
           Just (prefix, replacementNS, rest) ->
-            case prefix of
+            (case prefix of
               "" ->
                 case Text.uncons rest of
                   Nothing ->
-                    finish (result <> Builder.fromText replacement) (ctx <> newCtx)
+                    finish (result <> Builder.fromText replacement)
                   Just (h, t) ->
                     go t (mconcat [ result
                                   , Builder.fromText replacement
-                                  , Builder.singleton h ]) (ctx <> newCtx)
+                                  , Builder.singleton h ])
               _prefix ->
-                go rest (result <> Builder.fromText replacement) (ctx <> newCtx)
+                go rest (result <> Builder.fromText replacement)) (ctx <> newCtx)
              where
               replacement = stringIgnoreContext replacementNS
               newCtx      = NixString.getContext replacementNS

--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -939,46 +939,46 @@ replaceStrings
   -> NValue t f m
   -> m (NValue t f m)
 -- `ns*` goes for NixString here, which are with context - remember
-replaceStrings tfrom tto ts = fromValue (Deeper tfrom) >>= \(nsFrom :: [NixString]) ->
-  fromValue (Deeper tto) >>= \(nsTo :: [NixString]) ->
-    fromValue ts >>= \(ns :: NixString) -> do
+replaceStrings tfrom tto ts =
+  fromValue (Deeper tfrom) >>= \(nsFrom :: [NixString]) ->
+  fromValue (Deeper tto)   >>= \(nsTo   :: [NixString]) ->
+  fromValue ts             >>= \(ns     ::  NixString ) ->
+    do
       when (length nsFrom /= length nsTo)
         $ throwError $ ErrorCall "builtins.replaceStrings: Arguments `from`&`to` are lists `from` what replace `to` what, so the number of their inhabitanting elements must always match."
       let
 
         from = fmap stringIgnoreContext nsFrom
 
-        lookupPrefix s = do  -- monadic context handles Maybe result here, aka if Nothing returned
-          (prefix, replacement) <- find ((`Text.isPrefixOf` s) . fst)
-            $ zip from nsTo
-          let rest = Text.drop (Text.length prefix) s
-          pure (prefix, replacement, rest)
+        lookupPrefix s =
+          do  -- monadic context handles Maybe result here, aka if Nothing returned
+            (prefix, replacement) <- find ((`Text.isPrefixOf` s) . fst)
+              $ zip from nsTo
+            let rest = Text.drop (Text.length prefix) s
+            pure (prefix, replacement, rest)
 
         finish b =
           makeNixString (LazyText.toStrict $ Builder.toLazyText b)
 
         go orig result ctx = case lookupPrefix orig of
-          Nothing -> case Text.uncons orig of
-            Nothing     -> finish result ctx
-            Just (h, t) -> go t (result <> Builder.singleton h) ctx
+          Nothing ->
+            case Text.uncons orig of
+              Nothing     ->
+                finish result ctx
+              Just (h, t) ->
+                go t (result <> Builder.singleton h) ctx
           Just (prefix, replacementNS, rest) ->
             case prefix of
-              "" -> case Text.uncons rest of
-                Nothing -> finish
-                  (result <> Builder.fromText replacement)
-                  (ctx <> newCtx)
-                Just (h, t) -> go
-                  t
-                  (mconcat
-                    [ result
-                    , Builder.fromText replacement
-                    , Builder.singleton h
-                    ]
-                  )
-                  (ctx <> newCtx)
-              _ -> go rest
-                      (result <> Builder.fromText replacement)
-                      (ctx <> newCtx)
+              "" ->
+                case Text.uncons rest of
+                  Nothing ->
+                    finish (result <> Builder.fromText replacement) (ctx <> newCtx)
+                  Just (h, t) ->
+                    go t (mconcat [ result
+                                  , Builder.fromText replacement
+                                  , Builder.singleton h ]) (ctx <> newCtx)
+              _prefix ->
+                go rest (result <> Builder.fromText replacement) (ctx <> newCtx)
              where
               replacement = stringIgnoreContext replacementNS
               newCtx      = NixString.getContext replacementNS

--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -970,16 +970,15 @@ replaceStrings tfrom tto ts =
             (if prefix == mempty
               then
                 maybe
-                  (finish (resultAccum <> Builder.fromText replacement))
-                  (\(h,t) -> go t (mconcat [ resultAccum
-                                            , Builder.fromText replacement
-                                            , Builder.singleton h ]))
+                  (finish newResultAccum)
+                  (\(h,t) -> go t (newResultAccum <> Builder.singleton h))
                   (Text.uncons rest)
               else
-                go rest (resultAccum <> Builder.fromText replacement))
+                go rest newResultAccum)
                 (ctx <> newCtx)
            where
-            replacement = stringIgnoreContext replacementNS
+            replacement = Builder.fromText $ stringIgnoreContext replacementNS
+            newResultAccum = resultAccum <> replacement
             newCtx      = NixString.getContext replacementNS
       toValue
         $ go (stringIgnoreContext ns) mempty

--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -943,10 +943,7 @@ replaceStrings tfrom tto ts = fromValue (Deeper tfrom) >>= \(nsFrom :: [NixStrin
   fromValue (Deeper tto) >>= \(nsTo :: [NixString]) ->
     fromValue ts >>= \(ns :: NixString) -> do
       when (length nsFrom /= length nsTo)
-        $  throwError
-        $  ErrorCall
-        $  "'from' and 'to' arguments to 'replaceStrings'"
-        <> " have different lengths"
+        $ throwError $ ErrorCall "builtins.replaceStrings: Arguments `from`&`to` are lists `from` what replace `to` what, so the number of their inhabitanting elements must always match."
       let
 
         from = fmap stringIgnoreContext nsFrom

--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -959,25 +959,24 @@ replaceStrings tfrom tto ts =
 
         finish = makeNixString . LazyText.toStrict . Builder.toLazyText
 
-        go source resultAccum ctx = case lookupPrefix source of
-          Nothing ->
-            process source resultAccum ctx
-          Just (prefix, replacementNS, rest) ->
-            ( if prefix == mempty
-              then process
-              else go
-            ) rest newResultAccum newCtx
-           where
-            replacement    = Builder.fromText $ stringIgnoreContext replacementNS
-            newResultAccum = resultAccum <> replacement
-            additionalCtx  = NixString.getContext replacementNS
-            newCtx         = ctx <> additionalCtx
+        go source resultAccum ctx =
+          case lookupPrefix source of
+            Nothing ->
+              process source resultAccum ctx
+            Just (prefix, replacementNS, rest) ->
+              (if prefix == mempty then process else go) rest newResultAccum newCtx
+             where
+              replacement    = Builder.fromText $ stringIgnoreContext replacementNS
+              newResultAccum = resultAccum <> replacement
+              additionalCtx  = NixString.getContext replacementNS
+              newCtx         = ctx <> additionalCtx
          where
-            process t r =
-              maybe
-                (finish r)
-                (\(h, t) -> go t (r <> Builder.singleton h))
-                (Text.uncons t)
+          process text result =
+            maybe
+              (finish result)
+              (\(h, t) -> go t (result <> Builder.singleton h))
+              (Text.uncons text)
+
       toValue
         $ go (stringIgnoreContext ns) mempty
         $ NixString.getContext ns

--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -964,11 +964,9 @@ replaceStrings tfrom tto ts =
             process source resultAccum ctx
           Just (prefix, replacementNS, rest) ->
             ( if prefix == mempty
-              then
-                process rest newResultAccum
-              else
-                go rest newResultAccum
-            ) newCtx
+              then process
+              else go
+            ) rest newResultAccum newCtx
            where
             replacement    = Builder.fromText $ stringIgnoreContext replacementNS
             newResultAccum = resultAccum <> replacement

--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -961,21 +961,20 @@ replaceStrings tfrom tto ts =
 
         go orig result ctx = case lookupPrefix orig of
           Nothing ->
-            (case Text.uncons orig of
-              Nothing     ->
-                finish result
-              Just (h, t) ->
-                go t (result <> Builder.singleton h)) ctx
+            maybe
+              (finish result)
+              (\(h, t) -> go t (result <> Builder.singleton h))
+              (Text.uncons orig)
+              ctx
           Just (prefix, replacementNS, rest) ->
             (case prefix of
               "" ->
-                case Text.uncons rest of
-                  Nothing ->
-                    finish (result <> Builder.fromText replacement)
-                  Just (h, t) ->
-                    go t (mconcat [ result
-                                  , Builder.fromText replacement
-                                  , Builder.singleton h ])
+                maybe
+                  (finish (result <> Builder.fromText replacement))
+                  (\(h,t) -> go t (mconcat [ result
+                                           , Builder.fromText replacement
+                                           , Builder.singleton h ]))
+                  (Text.uncons rest)
               _prefix ->
                 go rest (result <> Builder.fromText replacement)) (ctx <> newCtx)
              where

--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -979,7 +979,7 @@ replaceStrings tfrom tto ts =
         --  Maybe `text-builder`, `text-show`?
         finish ctx output = makeNixString (LazyText.toStrict $ Builder.toLazyText output) ctx
 
-        replace (matched, replacementNS, unprocessedInput) = replaceWithNixBug unprocessedInput updatedOutput
+        replace (key, replacementNS, unprocessedInput) = replaceWithNixBug unprocessedInput updatedOutput
 
          where
           replaceWithNixBug =
@@ -992,15 +992,16 @@ replaceStrings tfrom tto ts =
               -- " H e l l o   w o r l d "
               -- repl> builtins.replaceStrings ["ll" ""] [" " "i"] "Hello world"
               -- "iHie ioi iwioirilidi"
+              --  2021-02-18: NOTE: There is no tests for this
               bugPassOneChar  -- augmented recursion
               isNixBugCase
 
-          isNixBugCase = matched == mempty
+          isNixBugCase = key == mempty
 
           updatedOutput  = output <> replacement
-          replacement    = Builder.fromText $ stringIgnoreContext replacementNS
-
           updatedCtx     = ctx <> replacementCtx
+
+          replacement    = Builder.fromText $ stringIgnoreContext replacementNS
           replacementCtx = NixString.getContext replacementNS
 
           -- The bug modifies the content => bug demands `pass` to be a real function =>

--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -923,6 +923,15 @@ genericClosure = fromValue @(AttrSet (NValue t f m)) >=> \s ->
             WValue j : _ -> checkComparable k' j
           fmap (t :) <$> go op (ts <> ys) (S.insert (WValue k') ks)
 
+-- | Takes:
+-- 1. List of expressions to replace.
+-- (finds the occurances of them)
+-- 2. List of expressions to replace corresponding occurance. (arg 1 & 2 lists matched by index)
+-- 3. Expression to process
+-- -> returns the expression with requested replacements.
+-- 
+-- Example:
+-- builtins.replaceStrings ["ll" "e"] [" " "i"] "Hello world" == "Hi o world".
 replaceStrings
   :: MonadNix e t f m
   => NValue t f m


### PR DESCRIPTION
After closing the https://github.com/haskell-nix/hnix/issues/210 decided to refactor it.

This is a good example of why, after the project created, a huge volume of such refactors are needed. If before this the code was: https://github.com/haskell-nix/hnix/pull/405/files#r240045660, after refactor - reading the result becomes easy.

And there is seen further refactor possible. And it seen the go is the case of a bit of mutual recursion between `go` and `process`, and looks like they are the same thing.