### PR TITLE
ReadMe: HNix

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -6,7 +6,7 @@
 [![Repology page](https://img.shields.io/badge/Repology-page-%23005500)](https://repology.org/project/haskell:hnix/versions)
 
 
-# hnix
+# HNix
 
 Parser, evaluator and type checker for the Nix language written in Haskell.
 


### PR DESCRIPTION
I strongly felt that it is time to do a daring thing updating the name of the project. For style and properness.

Proper noun should be written from the capital letter.

The CLI tool names of course have the strong convention of lower case, but HNix is not only and not just is and not only used as a CLI tool to call it lowercase. Of course, CLI tool is written `hnix`.

Haskell is a proper noun for the language, so it is written from the capital letter. Emacs is a CLI tool (at least was only for it for a long time, something like 30 years, its GUI is really a pseudoterminal for Emacs) but a strong proper known of a big project.

I think HNix also should be a project that deserves an "I can refer to it by name" proper noun.

Writing Hnix - does a disservice to the Nix. Nix* is a mothership for all we have here, and Nix* is in itself what we should be thankful for this project existence, and Nix is a much stronger well-known proper noun in itself, all that means it would and is a great disservice calling it "nix".

And HNix is a stylization that respects a hacker history and legacy of hacker naming stylization phenomena in linguistics [link](https://en.wikipedia.org/wiki/List_of_debuggers). For direct example, we have a lot of NValue's & NExpr's flying around in the project, they are named so because they are Value/Expr implementation in the context of Nix language, HNix is a direct continuation logic of that naming, it is Nix implementation in a context of Haskell language.

I simply want HNix to be a project which name is a hacker-written proper noun.