### PR TITLE
Clean-up refactor

### DIFF
--- a/main/Main.hs
+++ b/main/Main.hs
@@ -55,9 +55,9 @@ main = do
     Nothing -> case expression opts of
       Just s  -> handleResult opts Nothing (parseNixTextLoc s)
       Nothing -> case fromFile opts of
-        Just "-" -> mapM_ (processFile opts) =<< (lines <$> liftIO getContents)
+        Just "-" -> mapM_ (processFile opts) . lines =<< liftIO getContents
         Just path ->
-          mapM_ (processFile opts) =<< (lines <$> liftIO (readFile path))
+          mapM_ (processFile opts) . lines =<< liftIO (readFile path)
         Nothing -> case filePaths opts of
           [] -> withNixContext Nothing Repl.main
           ["-"] ->

--- a/main/Repl.hs
+++ b/main/Repl.hs
@@ -348,7 +348,7 @@ completeFunc reversedPrev word
   -- Commands
   | reversedPrev == ":"
   = pure . listCompletion
-      $ map helpOptionName (helpOptions :: HelpOptions e t f m)
+      $ fmap helpOptionName (helpOptions :: HelpOptions e t f m)
 
   -- Files
   | any (`Data.List.isPrefixOf` word) [ "/", "./", "../", "~/" ]
@@ -364,7 +364,7 @@ completeFunc reversedPrev word
       Just binding -> do
         candidates <- lift $ algebraicComplete subFields binding
         pure
-          $ map notFinished
+          $ fmap notFinished
           $ listCompletion (Data.Text.unpack . (var <>) <$> candidates)
 
   -- Builtins, context variables
@@ -381,7 +381,7 @@ completeFunc reversedPrev word
       ++ (Data.Text.unpack <$> shortBuiltins)
 
   where
-    listCompletion = map simpleCompletion . filter (word `Data.List.isPrefixOf`)
+    listCompletion = fmap simpleCompletion . filter (word `Data.List.isPrefixOf`)
 
     notFinished x = x { isFinished = False }
 
@@ -508,7 +508,7 @@ renderSetOptions :: [HelpSetOption] -> Doc ()
 renderSetOptions so =
   Prettyprinter.indent 4
     $ Prettyprinter.vsep
-    $ flip map so
+    $ flip fmap so
     $ \h ->
              Prettyprinter.pretty (helpSetOptionName h)
          <+> helpSetOptionSyntax h

--- a/main/Repl.hs
+++ b/main/Repl.hs
@@ -363,9 +363,7 @@ completeFunc reversedPrev word
       Nothing -> pure []
       Just binding -> do
         candidates <- lift $ algebraicComplete subFields binding
-        pure
-          $ fmap notFinished
-          $ listCompletion (Data.Text.unpack . (var <>) <$> candidates)
+        pure $ notFinished <$> listCompletion (Data.Text.unpack . (var <>) <$> candidates)
 
   -- Builtins, context variables
   | otherwise
@@ -377,8 +375,8 @@ completeFunc reversedPrev word
 
     pure $ listCompletion
       $ ["__includes"]
-      ++ (Data.Text.unpack <$> contextKeys)
-      ++ (Data.Text.unpack <$> shortBuiltins)
+      <> (Data.Text.unpack <$> contextKeys)
+      <> (Data.Text.unpack <$> shortBuiltins)
 
   where
     listCompletion = fmap simpleCompletion . filter (word `Data.List.isPrefixOf`)
@@ -401,7 +399,7 @@ completeFunc reversedPrev word
                   Nothing -> pure []
                   Just e ->
                     demand e
-                    (\e' -> fmap (("." <> f) <>) <$> algebraicComplete fs e')
+                      (\e' -> (fmap . fmap) (("." <> f) <>) $ algebraicComplete fs e')
 
       in case val of
         NVSet xs _ -> withMap xs

--- a/src/Nix.hs
+++ b/src/Nix.hs
@@ -107,7 +107,7 @@ evaluateExpression
   -> m a
 evaluateExpression mpath evaluator handler expr = do
   opts :: Options <- asks (view hasLens)
-  args <- traverse (traverse eval') $ map (second parseArg) (arg opts) ++ map
+  args <- traverse (traverse eval') $ fmap (second parseArg) (arg opts) ++ fmap
     (second mkStr)
     (argstr opts)
   evaluator mpath expr >>= \f -> demand f $ \f' ->

--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -636,7 +636,7 @@ split_ pat str = fromValue pat >>= fromStringNoContext >>= \p ->
     let re       = makeRegex (encodeUtf8 p) :: Regex
         haystack = encodeUtf8 s
     pure $ nvList $ splitMatches 0
-                                   (map elems $ matchAllText re haystack)
+                                   (fmap elems $ matchAllText re haystack)
                                    haystack
 
 splitMatches
@@ -656,7 +656,7 @@ splitMatches numDropped (((_, (start, len)) : captures) : mts) haystack =
  where
   relStart       = max 0 start - numDropped
   (before, rest) = B.splitAt relStart haystack
-  caps           = nvList (map f captures)
+  caps           = nvList (fmap f captures)
   f (a, (s, _)) = if s < 0 then nvConstant NNull else thunkStr a
 
 thunkStr :: Applicative f => ByteString -> NValue t f m
@@ -718,7 +718,7 @@ mapAttrs_ f xs = fromValue @(AttrSet (NValue t f m)) xs >>= \aset -> do
       $   withFrame Debug (ErrorCall "While applying f in mapAttrs:\n")
       $   callFunc ?? value
       =<< callFunc f (nvStr (makeNixStringWithoutContext key))
-  toValue . M.fromList . zip (map fst pairs) $ values
+  toValue . M.fromList . zip (fmap fst pairs) $ values
 
 filter_
   :: forall e t f m
@@ -1393,7 +1393,7 @@ exec_ xs = do
   -- TODO Still need to do something with the context here
   -- See prim_exec in nix/src/libexpr/primops.cc
   -- Requires the implementation of EvalState::realiseContext
-  exec (map (Text.unpack . stringIgnoreContext) xs)
+  exec (fmap (Text.unpack . stringIgnoreContext) xs)
 
 fetchurl
   :: forall e t f m . MonadNix e t f m => NValue t f m -> m (NValue t f m)

--- a/src/Nix/Cache.hs
+++ b/src/Nix/Cache.hs
@@ -23,13 +23,13 @@ readCache path = do
 #if USE_COMPACT
     eres <- C.unsafeReadCompact path
     case eres of
-        Left err -> error $ "Error reading cache file: " ++ err
+        Left err -> error $ "Error reading cache file: " <> err
         Right expr -> return $ C.getCompact expr
 #else
 #ifdef MIN_VERSION_serialise
   eres <- S.deserialiseOrFail <$> BS.readFile path
   case eres of
-    Left  err  -> error $ "Error reading cache file: " ++ show err
+    Left  err  -> error $ "Error reading cache file: " <> show err
     Right expr -> return expr
 #else
     error "readCache not implemented for this platform"

--- a/src/Nix/Effects/Basic.hs
+++ b/src/Nix/Effects/Basic.hs
@@ -58,14 +58,14 @@ defaultMakeAbsolutePath origPath = do
               throwError
                 $  ErrorCall
                 $  "when resolving relative path,"
-                ++ " __cur_file is in scope,"
-                ++ " but is not a path; it is: "
-                ++ show val
+                <> " __cur_file is in scope,"
+                <> " but is not a path; it is: "
+                <> show val
       pure $ cwd <///> origPathExpanded
   removeDotDotIndirections <$> canonicalizePath absPath
 
 expandHomePath :: MonadFile m => FilePath -> m FilePath
-expandHomePath ('~' : xs) = flip (++) xs <$> getHomeDirectory
+expandHomePath ('~' : xs) = flip (<>) xs <$> getHomeDirectory
 expandHomePath p          = pure p
 
 -- | Incorrectly normalize paths by rewriting patterns like @a/b/..@ to @a@.
@@ -86,7 +86,7 @@ x <///> y | isAbsolute y || "." `isPrefixOf` y = x </> y
  where
   joinByLargestOverlap (splitDirectories -> xs) (splitDirectories -> ys) =
     joinPath $ head
-      [ xs ++ drop (length tx) ys | tx <- tails xs, tx `elem` inits ys ]
+      [ xs <> drop (length tx) ys | tx <- tails xs, tx `elem` inits ys ]
 
 defaultFindEnvPath :: MonadNix e t f m => String -> m FilePath
 defaultFindEnvPath = findEnvPathM
@@ -123,9 +123,9 @@ findPathBy finder ls name = do
       throwError
         $  ErrorCall
         $  "file '"
-        ++ name
-        ++ "' was not found in the Nix search path"
-        ++ " (add it's using $NIX_PATH or -I)"
+        <> name
+        <> "' was not found in the Nix search path"
+        <> " (add it's using $NIX_PATH or -I)"
     Just path -> pure path
  where
   go :: Maybe FilePath -> NValue t f m -> m (Maybe FilePath)
@@ -155,8 +155,8 @@ findPathBy finder ls name = do
         throwError
           $  ErrorCall
           $  "__nixPath must be a list of attr sets"
-          ++ " with 'path' elements, but received: "
-          ++ show s
+          <> " with 'path' elements, but received: "
+          <> show s
 
 fetchTarball
   :: forall e t f m . MonadNix e t f m => NValue t f m -> m (NValue t f m)
@@ -170,7 +170,7 @@ fetchTarball = flip demand $ \case
     throwError
       $  ErrorCall
       $  "builtins.fetchTarball: Expected URI or set, got "
-      ++ show v
+      <> show v
  where
   go :: Maybe (NValue t f m) -> NValue t f m -> m (NValue t f m)
   go msha = \case
@@ -179,7 +179,7 @@ fetchTarball = flip demand $ \case
       throwError
         $  ErrorCall
         $  "builtins.fetchTarball: Expected URI or string, got "
-        ++ show v
+        <> show v
 
 {- jww (2018-04-11): This should be written using pipes in another module
     fetch :: Text -> Maybe (NThunk m) -> m (NValue t f m)
@@ -190,22 +190,22 @@ fetchTarball = flip demand $ \case
         ".xz"  -> undefined
         ".tar" -> undefined
         ext -> throwError $ ErrorCall $ "builtins.fetchTarball: Unsupported extension '"
-                  ++ ext ++ "'"
+                  <> ext <> "'"
 -}
 
   fetch :: Text -> Maybe (NValue t f m) -> m (NValue t f m)
   fetch uri Nothing =
-    nixInstantiateExpr $ "builtins.fetchTarball \"" ++ Text.unpack uri ++ "\""
+    nixInstantiateExpr $ "builtins.fetchTarball \"" <> Text.unpack uri <> "\""
   fetch url (Just t) = demand t $ fromValue >=> \nsSha ->
     let sha = stringIgnoreContext nsSha
     in  nixInstantiateExpr
           $  "builtins.fetchTarball { "
-          ++ "url    = \""
-          ++ Text.unpack url
-          ++ "\"; "
-          ++ "sha256 = \""
-          ++ Text.unpack sha
-          ++ "\"; }"
+          <> "url    = \""
+          <> Text.unpack url
+          <> "\"; "
+          <> "sha256 = \""
+          <> Text.unpack sha
+          <> "\"; }"
 
 defaultFindPath :: MonadNix e t f m => [NValue t f m] -> FilePath -> m FilePath
 defaultFindPath = findPathM
@@ -229,8 +229,8 @@ defaultImportPath
   => FilePath
   -> m (NValue t f m)
 defaultImportPath path = do
-  traceM $ "Importing file " ++ path
-  withFrame Info (ErrorCall $ "While importing file " ++ show path) $ do
+  traceM $ "Importing file " <> path
+  withFrame Info (ErrorCall $ "While importing file " <> show path) $ do
     imports <- gets fst
     evalExprLoc =<< case M.lookup path imports of
       Just expr -> pure expr

--- a/src/Nix/Effects/Derivation.hs
+++ b/src/Nix/Effects/Derivation.hs
@@ -141,7 +141,7 @@ unparseDrv (Derivation {..}) = Text.append "Derive" $ parens
       list $ flip fmap (Map.toList $ snd inputs) (\(path, outs) ->
         parens [s path, list $ fmap s $ sort outs])
     , -- inputSrcs
-      list (map s $ Set.toList $ fst inputs)
+      list (fmap s $ Set.toList $ fst inputs)
     , s platform
     , s builder
     , -- run script args

--- a/src/Nix/Effects/Derivation.hs
+++ b/src/Nix/Effects/Derivation.hs
@@ -130,7 +130,7 @@ hashDerivationModulo drv@(Derivation {inputs = (inputSrcs, inputDrvs)}) = do
 unparseDrv :: Derivation -> Text
 unparseDrv (Derivation {..}) = Text.append "Derive" $ parens
     [ -- outputs: [("out", "/nix/store/.....-out", "", ""), ...]
-      list $ flip map (Map.toList outputs) (\(outputName, outputPath) ->
+      list $ flip fmap (Map.toList outputs) (\(outputName, outputPath) ->
         let prefix = if hashMode == Recursive then "r:" else "" in
         case mFixed of
           Nothing -> parens [s outputName, s outputPath, s "", s ""]
@@ -138,16 +138,16 @@ unparseDrv (Derivation {..}) = Text.append "Derive" $ parens
             parens [s outputName, s outputPath, s $ prefix <> Store.algoName @hashType, s $ Store.encodeInBase Store.Base16 digest]
         )
     , -- inputDrvs
-      list $ flip map (Map.toList $ snd inputs) (\(path, outs) ->
-        parens [s path, list $ map s $ sort outs])
+      list $ flip fmap (Map.toList $ snd inputs) (\(path, outs) ->
+        parens [s path, list $ fmap s $ sort outs])
     , -- inputSrcs
       list (map s $ Set.toList $ fst inputs)
     , s platform
     , s builder
     , -- run script args
-      list $ map s args
+      list $ fmap s args
     , -- env (key value pairs)
-      list $ flip map (Map.toList env) (\(k, v) ->
+      list $ flip fmap (Map.toList env) (\(k, v) ->
         parens [s k, s v])
     ]
   where
@@ -192,7 +192,7 @@ derivationParser = do
   _ <- ")"
   eof
 
-  let outputs = Map.fromList $ map (\(a, b, _, _) -> (a, b)) fullOutputs
+  let outputs = Map.fromList $ fmap (\(a, b, _, _) -> (a, b)) fullOutputs
   let (mFixed, hashMode) = parseFixed fullOutputs
   let name = "" -- FIXME (extract from file path ?)
   let useJson = ["__json"] == Map.keys env
@@ -332,7 +332,7 @@ buildDerivationWithContext drvAttrs = do
 
       return $ defaultDerivation { platform, builder, args, env,  hashMode, useJson
         , name = drvName
-        , outputs = Map.fromList $ map (\o -> (o, "")) outputs
+        , outputs = Map.fromList $ fmap (\o -> (o, "")) outputs
         , mFixed = mFixedOutput
         }
   where

--- a/src/Nix/Eval.hs
+++ b/src/Nix/Eval.hs
@@ -257,7 +257,7 @@ evalBinds recursive binds = do
   go _ (NamedVar (StaticKey "__overrides" :| []) finalValue pos) =
     finalValue >>= fromValue >>= \(o', p') ->
           -- jww (2018-05-09): What to do with the key position here?
-                                              pure $ map
+                                              pure $ fmap
       (\(k, v) -> ([k], fromMaybe pos (M.lookup k p'), demand v pure))
       (M.toList o')
 

--- a/src/Nix/Eval.hs
+++ b/src/Nix/Eval.hs
@@ -234,7 +234,7 @@ desugarBinds embed binds = evalState (mapM (go <=< collect) binds) M.empty
   go (Left  x) = do
     maybeValue <- gets (M.lookup x)
     case maybeValue of
-      Nothing     -> error ("No binding " ++ show x)
+      Nothing     -> error ("No binding " <> show x)
       Just (p, v) -> pure $ NamedVar (StaticKey x :| []) (embed v) p
 
 evalBinds
@@ -247,7 +247,7 @@ evalBinds recursive binds = do
   scope <- currentScopes :: m (Scopes m v)
   buildResult scope . concat =<< mapM (go scope) (moveOverridesLast binds)
  where
-  moveOverridesLast = uncurry (++) . partition
+  moveOverridesLast = uncurry (<>) . partition
     (\case
       NamedVar (StaticKey "__overrides" :| []) _ _pos -> False
       _ -> True
@@ -403,7 +403,7 @@ buildArgument params arg = do
         $  evalError @v
         $  ErrorCall
         $  "Missing value for parameter: "
-        ++ show k
+        <> show k
     That (Just f) ->
       Just $ \args -> defer $ withScopes scope $ pushScope args f
     This _
@@ -415,7 +415,7 @@ buildArgument params arg = do
         $  evalError @v
         $  ErrorCall
         $  "Unexpected parameter: "
-        ++ show k
+        <> show k
     These x _ -> Just (const (pure x))
 
 addSourcePositions

--- a/src/Nix/Exec.hs
+++ b/src/Nix/Exec.hs
@@ -158,8 +158,8 @@ instance MonadNix e t f m => MonadEval (NValue t f m) m where
     nverr @e @t @f
       $  ErrorCall
       $  "Undefined variable '"
-      ++ Text.unpack var
-      ++ "'"
+      <> Text.unpack var
+      <> "'"
 
   synHole name = do
     span  <- currentPos
@@ -173,15 +173,15 @@ instance MonadNix e t f m => MonadEval (NValue t f m) m where
     evalError @(NValue t f m)
       $  ErrorCall
       $  "Inheriting unknown attribute: "
-      ++ intercalate "." (map Text.unpack (NE.toList ks))
+      <> intercalate "." (map Text.unpack (NE.toList ks))
 
   attrMissing ks (Just s) =
     evalError @(NValue t f m)
       $  ErrorCall
       $  "Could not look up attribute "
-      ++ intercalate "." (map Text.unpack (NE.toList ks))
-      ++ " in "
-      ++ show (prettyNValue s)
+      <> intercalate "." (map Text.unpack (NE.toList ks))
+      <> " in "
+      <> show (prettyNValue s)
 
   evalCurPos = do
     scope                  <- currentScopes
@@ -303,7 +303,7 @@ callFunc fun arg = demand fun $ \fun' -> do
       withFrame Info (Calling @m @(NValue t f m) name span) (f arg)
     s@(NVSet m _) | Just f <- M.lookup "__functor" m -> do
       demand f $ (`callFunc` s) >=> (`callFunc` arg)
-    x -> throwError $ ErrorCall $ "Attempt to call non-function: " ++ show x
+    x -> throwError $ ErrorCall $ "Attempt to call non-function: " <> show x
 
 execUnaryOp
   :: (Framed e m, MonadCited t f m, Show t)
@@ -322,13 +322,13 @@ execUnaryOp scope span op arg = do
         throwError
           $  ErrorCall
           $  "unsupported argument type for unary operator "
-          ++ show op
+          <> show op
     x ->
       throwError
         $  ErrorCall
         $  "argument to unary operator"
-        ++ " must evaluate to an atomic type: "
-        ++ show x
+        <> " must evaluate to an atomic type: "
+        <> show x
  where
   unaryOp = pure . nvConstantP (Provenance scope (NUnary_ span op (Just arg)))
 
@@ -387,7 +387,7 @@ execBinaryOpForced scope span op lval rval = case op of
   NMult  -> numBinOp (*)
   NDiv   -> numBinOp' div (/)
   NConcat -> case (lval, rval) of
-    (NVList ls, NVList rs) -> pure $ nvListP prov $ ls ++ rs
+    (NVList ls, NVList rs) -> pure $ nvListP prov $ ls <> rs
     _ -> unsupportedTypes
 
   NUpdate -> case (lval, rval) of
@@ -408,7 +408,7 @@ execBinaryOpForced scope span op lval rval = case op of
       Nothing -> throwError $ ErrorCall $
         -- data/nix/src/libexpr/eval.cc:1412
         "A string that refers to a store path cannot be appended to a path."
-    (NVPath ls, NVPath rs) -> nvPathP prov <$> makeAbsolutePath @t @f (ls ++ rs)
+    (NVPath ls, NVPath rs) -> nvPathP prov <$> makeAbsolutePath @t @f (ls <> rs)
 
     (ls@NVSet{}, NVStr rs) ->
       (\ls2 -> nvStrP prov (ls2 `mappend` rs))
@@ -458,23 +458,23 @@ execBinaryOpForced scope span op lval rval = case op of
 
   unsupportedTypes = throwError $ ErrorCall $
     "Unsupported argument types for binary operator "
-      ++ show op
-      ++ ": "
-      ++ show lval
-      ++ ", "
-      ++ show rval
+      <> show op
+      <> ": "
+      <> show lval
+      <> ", "
+      <> show rval
 
   alreadyHandled = throwError $ ErrorCall $
     "This cannot happen: operator "
-      ++ show op
-      ++ " should have been handled in execBinaryOp."
+      <> show op
+      <> " should have been handled in execBinaryOp."
 
 -- This function is here, rather than in 'Nix.String', because of the need to
 -- use 'throwError'.
 fromStringNoContext :: Framed e m => NixString -> m Text
 fromStringNoContext ns = case getStringNoContext ns of
   Just str -> pure str
-  Nothing  -> throwError $ ErrorCall $ "expected string with no context, but got " ++ show ns
+  Nothing  -> throwError $ ErrorCall $ "expected string with no context, but got " <> show ns
 
 addTracing
   :: (MonadNix e t f m, Has e Options, MonadReader Int n, Alternative n)
@@ -494,7 +494,7 @@ addTracing k v = do
             then pretty $ show (void x)
 #endif
             else prettyNix (Fix (Fix (NSym "?") <$ x))
-          msg x = pretty ("eval: " ++ replicate depth ' ') <> x
+          msg x = pretty ("eval: " <> replicate depth ' ') <> x
       loc <- renderLocation span (msg rendered <> " ...\n")
       putStr $ show loc
       res <- k v'

--- a/src/Nix/Exec.hs
+++ b/src/Nix/Exec.hs
@@ -173,13 +173,13 @@ instance MonadNix e t f m => MonadEval (NValue t f m) m where
     evalError @(NValue t f m)
       $  ErrorCall
       $  "Inheriting unknown attribute: "
-      <> intercalate "." (map Text.unpack (NE.toList ks))
+      <> intercalate "." (fmap Text.unpack (NE.toList ks))
 
   attrMissing ks (Just s) =
     evalError @(NValue t f m)
       $  ErrorCall
       $  "Could not look up attribute "
-      <> intercalate "." (map Text.unpack (NE.toList ks))
+      <> intercalate "." (fmap Text.unpack (NE.toList ks))
       <> " in "
       <> show (prettyNValue s)
 

--- a/src/Nix/Expr/Shorthands.hs
+++ b/src/Nix/Expr/Shorthands.hs
@@ -135,7 +135,7 @@ mkDots e [] = e
 mkDots (Fix (NSelect e keys' x)) keys =
   -- Special case: if the expression in the first argument is already
   -- a dotted expression, just extend it.
-  Fix (NSelect e (keys' <> map (StaticKey ?? Nothing) keys) x)
+  Fix (NSelect e (keys' <> fmap (StaticKey ?? Nothing) keys) x)
 mkDots e keys = Fix $ NSelect e (map (StaticKey ?? Nothing) keys) Nothing
 -}
 

--- a/src/Nix/Expr/Shorthands.hs
+++ b/src/Nix/Expr/Shorthands.hs
@@ -136,7 +136,7 @@ mkDots (Fix (NSelect e keys' x)) keys =
   -- Special case: if the expression in the first argument is already
   -- a dotted expression, just extend it.
   Fix (NSelect e (keys' <> fmap (StaticKey ?? Nothing) keys) x)
-mkDots e keys = Fix $ NSelect e (map (StaticKey ?? Nothing) keys) Nothing
+mkDots e keys = Fix $ NSelect e (fmap (StaticKey ?? Nothing) keys) Nothing
 -}
 
 -- | An `inherit` clause without an expression to pull from.
@@ -174,7 +174,7 @@ modifyFunctionBody f (Fix e) = case e of
 
 -- | A let statement with multiple assignments.
 letsE :: [(Text, NExpr)] -> NExpr -> NExpr
-letsE pairs = Fix . NLet (map (uncurry bindTo) pairs)
+letsE pairs = Fix . NLet (fmap (uncurry bindTo) pairs)
 
 -- | Wrapper for a single-variable @let@.
 letE :: Text -> NExpr -> NExpr -> NExpr
@@ -182,11 +182,11 @@ letE varName varExpr = letsE [(varName, varExpr)]
 
 -- | Make an attribute set (non-recursive).
 attrsE :: [(Text, NExpr)] -> NExpr
-attrsE pairs = Fix $ NSet NNonRecursive (map (uncurry bindTo) pairs)
+attrsE pairs = Fix $ NSet NNonRecursive (fmap (uncurry bindTo) pairs)
 
 -- | Make an attribute set (recursive).
 recAttrsE :: [(Text, NExpr)] -> NExpr
-recAttrsE pairs = Fix $ NSet NRecursive (map (uncurry bindTo) pairs)
+recAttrsE pairs = Fix $ NSet NRecursive (fmap (uncurry bindTo) pairs)
 
 -- | Logical negation.
 mkNot :: NExpr -> NExpr

--- a/src/Nix/Expr/Strings.hs
+++ b/src/Nix/Expr/Strings.hs
@@ -62,7 +62,7 @@ stripIndent xs =
   Indented minIndent
     . removePlainEmpty
     . mergePlain
-    . map snd
+    . fmap snd
     . dropWhileEnd cleanup
     . (\ys -> zip
         (map
@@ -78,11 +78,11 @@ stripIndent xs =
     $ ls'
  where
   ls        = stripEmptyOpening $ splitLines xs
-  ls'       = map (dropSpaces minIndent) ls
+  ls'       = fmap (dropSpaces minIndent) ls
 
   minIndent = case stripEmptyLines ls of
     []         -> 0
-    nonEmptyLs -> minimum $ map (countSpaces . mergePlain) nonEmptyLs
+    nonEmptyLs -> minimum $ fmap (countSpaces . mergePlain) nonEmptyLs
 
   stripEmptyLines = filter $ \case
     [Plain t] -> not $ T.null $ T.strip t
@@ -109,7 +109,7 @@ escapeCodes =
   [('\n', 'n'), ('\r', 'r'), ('\t', 't'), ('\\', '\\'), ('$', '$'), ('"', '"')]
 
 fromEscapeCode :: Char -> Maybe Char
-fromEscapeCode = (`lookup` map swap escapeCodes)
+fromEscapeCode = (`lookup` fmap swap escapeCodes)
 
 toEscapeCode :: Char -> Maybe Char
 toEscapeCode = (`lookup` escapeCodes)

--- a/src/Nix/Expr/Strings.hs
+++ b/src/Nix/Expr/Strings.hs
@@ -31,7 +31,7 @@ removePlainEmpty = filter f where
   -- trimEnd xs
   --     | null xs = xs
   --     | otherwise = case last xs of
-  --           Plain x -> init xs ++ [Plain (T.dropWhileEnd (== ' ') x)]
+  --           Plain x -> init xs <> [Plain (T.dropWhileEnd (== ' ') x)]
   --           _ -> xs
 
 -- | Equivalent to case splitting on 'Antiquoted' strings.

--- a/src/Nix/Expr/Types.hs
+++ b/src/Nix/Expr/Types.hs
@@ -609,8 +609,8 @@ ekey _ _ f e = fromMaybe e <$> f Nothing
 stripPositionInfo :: NExpr -> NExpr
 stripPositionInfo = transport phi
  where
-  phi (NSet recur binds) = NSet recur (map go binds)
-  phi (NLet binds body) = NLet (map go binds) body
+  phi (NSet recur binds) = NSet recur (fmap go binds)
+  phi (NLet binds body) = NLet (fmap go binds) body
   phi x                 = x
 
   go (NamedVar path r     _pos) = NamedVar path r nullPos

--- a/src/Nix/Frames.hs
+++ b/src/Nix/Frames.hs
@@ -36,7 +36,7 @@ data NixFrame = NixFrame
 
 instance Show NixFrame where
   show (NixFrame level f) =
-    "Nix frame at level " ++ show level ++ ": " ++ show f
+    "Nix frame at level " <> show level <> ": " <> show f
 
 type Frames = [NixFrame]
 

--- a/src/Nix/Fresh/Basic.hs
+++ b/src/Nix/Fresh/Basic.hs
@@ -36,7 +36,7 @@ instance (MonadEffects t f m, MonadDataContext f m)
   findEnvPath      = lift . findEnvPath @t @f @m
   findPath vs path = do
     i <- FreshIdT ask
-    let vs' = map (unliftNValue (runFreshIdT i)) vs
+    let vs' = fmap (unliftNValue (runFreshIdT i)) vs
     lift $ findPath @t @f @m vs' path
   importPath path = do
     i <- FreshIdT ask

--- a/src/Nix/Lint.hs
+++ b/src/Nix/Lint.hs
@@ -276,13 +276,13 @@ instance MonadLint e m => MonadEval (Symbolic m) m where
     evalError @(Symbolic m)
       $  ErrorCall
       $  "Inheriting unknown attribute: "
-      <> intercalate "." (map Text.unpack (NE.toList ks))
+      <> intercalate "." (fmap Text.unpack (NE.toList ks))
 
   attrMissing ks (Just s) =
     evalError @(Symbolic m)
       $  ErrorCall
       $  "Could not look up attribute "
-      <> intercalate "." (map Text.unpack (NE.toList ks))
+      <> intercalate "." (fmap Text.unpack (NE.toList ks))
       <> " in "
       <> show s
 

--- a/src/Nix/Lint.hs
+++ b/src/Nix/Lint.hs
@@ -139,18 +139,18 @@ renderSymbolic = unpackSymbolic >=> \case
     TStr    -> pure "string"
     TList r -> do
       x <- demand r renderSymbolic
-      pure $ "[" ++ x ++ "]"
+      pure $ "[" <> x <> "]"
     TSet Nothing  -> pure "<any set>"
     TSet (Just s) -> do
       x <- traverse (`demand` renderSymbolic) s
-      pure $ "{" ++ show x ++ "}"
+      pure $ "{" <> show x <> "}"
     f@(TClosure p) -> do
       (args, sym) <- do
         f' <- mkSymbolic [f]
         lintApp (NAbs (void p) ()) f' everyPossible
       args' <- traverse renderSymbolic args
       sym'  <- renderSymbolic sym
-      pure $ "(" ++ show args' ++ " -> " ++ sym' ++ ")"
+      pure $ "(" <> show args' <> " -> " <> sym' <> ")"
     TPath          -> pure "path"
     TBuiltin _n _f -> pure "<builtin function>"
 
@@ -242,8 +242,8 @@ unify context (SV x) (SV y) = do
               -- x' <- renderSymbolic (Symbolic x)
               -- y' <- renderSymbolic (Symbolic y)
           throwError $ ErrorCall "Cannot unify "
-                  -- ++ show x' ++ " with " ++ show y'
-                  --  ++ " in context: " ++ show context
+                  -- <> show x' <> " with " <> show y'
+                  --  <> " in context: " <> show context
         else do
           writeVar x (NMany m)
           writeVar y (NMany m)
@@ -270,21 +270,21 @@ instance (MonadThunkId m, MonadAtomicRef m, MonadCatch m)
   demand (SV v) f = f (SV v)
 
 instance MonadLint e m => MonadEval (Symbolic m) m where
-  freeVariable var = symerr $ "Undefined variable '" ++ Text.unpack var ++ "'"
+  freeVariable var = symerr $ "Undefined variable '" <> Text.unpack var <> "'"
 
   attrMissing ks Nothing =
     evalError @(Symbolic m)
       $  ErrorCall
       $  "Inheriting unknown attribute: "
-      ++ intercalate "." (map Text.unpack (NE.toList ks))
+      <> intercalate "." (map Text.unpack (NE.toList ks))
 
   attrMissing ks (Just s) =
     evalError @(Symbolic m)
       $  ErrorCall
       $  "Could not look up attribute "
-      ++ intercalate "." (map Text.unpack (NE.toList ks))
-      ++ " in "
-      ++ show s
+      <> intercalate "." (map Text.unpack (NE.toList ks))
+      <> " in "
+      <> show s
 
   evalCurPos = do
     f <- mkSymbolic [TPath]

--- a/src/Nix/Parser.hs
+++ b/src/Nix/Parser.hs
@@ -67,8 +67,7 @@ import qualified Data.HashSet                  as HashSet
 import           Data.List.NonEmpty             ( NonEmpty(..) )
 import qualified Data.List.NonEmpty            as NE
 import qualified Data.Map                      as Map
-import           Data.Text               hiding ( map
-                                                , foldr1
+import           Data.Text               hiding ( foldr1
                                                 , concat
                                                 , concatMap
                                                 , zipWith
@@ -94,7 +93,7 @@ infixl 3 <+>
 ---------------------------------------------------------------------------------
 
 nixExpr :: Parser NExprLoc
-nixExpr = makeExprParser nixTerm $ map (map snd) (nixOperators nixSelector)
+nixExpr = makeExprParser nixTerm $ fmap (fmap snd) (nixOperators nixSelector)
 
 antiStart :: Parser Text
 antiStart = symbol "${" <?> show ("${" :: String)

--- a/src/Nix/Parser.hs
+++ b/src/Nix/Parser.hs
@@ -162,14 +162,14 @@ nixTerm = do
     _ ->
       msum
         $  [ nixSelect nixSet | c == 'r' ]
-        ++ [ nixPath | pathChar c ]
-        ++ if isDigit c
+        <> [ nixPath | pathChar c ]
+        <> if isDigit c
              then [nixFloat, nixInt]
              else
                [ nixUri | isAlpha c ]
-               ++ [ nixBool | c == 't' || c == 'f' ]
-               ++ [ nixNull | c == 'n' ]
-               ++ [nixSelect nixSym]
+               <> [ nixBool | c == 't' || c == 'f' ]
+               <> [ nixNull | c == 'n' ]
+               <> [nixSelect nixSym]
 
 nixToplevelForm :: Parser NExprLoc
 nixToplevelForm = keywords <+> nixLambda <+> nixExpr
@@ -239,7 +239,7 @@ nixSearchPath = annotateLocation1
 
 pathStr :: Parser FilePath
 pathStr = lexeme $ liftM2
-  (++)
+  (<>)
   (many (satisfy pathChar))
   (Prelude.concat <$> some (liftM2 (:) slash (some (satisfy pathChar))))
 
@@ -393,7 +393,7 @@ argExpr = msum [atLeft, onlyname, atRight] <* symbol ":" where
         -- Get an argument name and an optional default.
       pair <- liftM2 (,) identifier (optional $ question *> nixToplevelForm)
       -- Either return this, or attempt to get a comma and restart.
-      option (acc ++ [pair], False) $ comma >> go (acc ++ [pair])
+      option (acc <> [pair], False) $ comma >> go (acc <> [pair])
 
 nixBinders :: Parser [Binding NExprLoc]
 nixBinders = (inherit <+> namedVar) `endBy` semi where

--- a/src/Nix/Pretty.hs
+++ b/src/Nix/Pretty.hs
@@ -116,7 +116,7 @@ wrapPath op sub = if wasPath sub
   else wrapParens op sub
 
 prettyString :: NString (NixDoc ann) -> Doc ann
-prettyString (DoubleQuoted parts) = dquotes . hcat . map prettyPart $ parts
+prettyString (DoubleQuoted parts) = dquotes . hcat . fmap prettyPart $ parts
  where
   prettyPart (Plain t)      = pretty . concatMap escape . unpack $ t
   prettyPart EscapedNewline = "''\\n"
@@ -127,11 +127,11 @@ prettyString (Indented _ parts) = group $ nest 2 $ vcat
   [dsquote, content, dsquote]
  where
   dsquote = squote <> squote
-  content = vsep . map prettyLine . stripLastIfEmpty . splitLines $ parts
+  content = vsep . fmap prettyLine . stripLastIfEmpty . splitLines $ parts
   stripLastIfEmpty = reverse . f . reverse   where
     f ([Plain t] : xs) | Text.null (strip t) = xs
     f xs = xs
-  prettyLine = hcat . map prettyPart
+  prettyLine = hcat . fmap prettyPart
   prettyPart (Plain t) =
     pretty . unpack . replace "${" "''${" . replace "''" "'''" $ t
   prettyPart EscapedNewline = "\\n"
@@ -176,7 +176,7 @@ prettyKeyName (DynamicKey key) = runAntiquoted
   key
 
 prettySelector :: NAttrPath (NixDoc ann) -> Doc ann
-prettySelector = hcat . punctuate dot . map prettyKeyName . NE.toList
+prettySelector = hcat . punctuate dot . fmap prettyKeyName . NE.toList
 
 prettyAtom :: NAtom -> NixDoc ann
 prettyAtom atom = simpleExpr $ pretty $ unpack $ atomText atom
@@ -225,7 +225,7 @@ exprFNixDoc = \case
       $ nest 2
       $ vsep
       $ concat
-      $ [[lbracket], map (wrapParens appOpNonAssoc) xs, [rbracket]]
+      $ [[lbracket], fmap (wrapParens appOpNonAssoc) xs, [rbracket]]
   NSet NNonRecursive [] -> simpleExpr $ lbrace <> rbrace
   NSet NNonRecursive xs ->
     simpleExpr
@@ -233,7 +233,7 @@ exprFNixDoc = \case
       $ nest 2
       $ vsep
       $ concat
-      $ [[lbrace], map prettyBind xs, [rbrace]]
+      $ [[lbrace], fmap prettyBind xs, [rbrace]]
   NSet NRecursive [] -> simpleExpr $ recPrefix <> lbrace <> rbrace
   NSet NRecursive xs ->
     simpleExpr
@@ -241,7 +241,7 @@ exprFNixDoc = \case
       $ nest 2
       $ vsep
       $ concat
-      $ [[recPrefix <> lbrace], map prettyBind xs, [rbrace]]
+      $ [[recPrefix <> lbrace], fmap prettyBind xs, [rbrace]]
   NAbs args body ->
     leastPrecedence
       $ nest 2
@@ -357,7 +357,7 @@ prettyNValueProv v = do
         $ parens
         $ mconcat
         $ "from: "
-        : map (prettyOriginExpr . _originExpr) ps
+        : fmap (prettyOriginExpr . _originExpr) ps
         ]
 
 prettyNThunk
@@ -379,7 +379,7 @@ prettyNThunk t = do
       $ parens
       $ mconcat
       $ "thunk from: "
-      : map (prettyOriginExpr . _originExpr) ps
+      : fmap (prettyOriginExpr . _originExpr) ps
       ]
 
 -- | This function is used only by the testing code.

--- a/src/Nix/Pretty.hs
+++ b/src/Nix/Pretty.hs
@@ -149,7 +149,7 @@ prettyParamSet args var = encloseSep
   (lbrace <> space)
   (align (space <> rbrace))
   sep
-  (map prettySetArg args ++ prettyVariadic)
+  (map prettySetArg args <> prettyVariadic)
  where
   prettySetArg (n, maybeDef) = case maybeDef of
     Nothing -> pretty (unpack n)
@@ -273,7 +273,7 @@ exprFNixDoc = \case
     ordoc = maybe mempty (((space <> "or") <+>) . wrapParens appOpNonAssoc) o
   NHasAttr r attr ->
     mkNixDoc (wrapParens hasAttrOp r <+> "?" <+> prettySelector attr) hasAttrOp
-  NEnvPath     p -> simpleExpr $ pretty ("<" ++ p ++ ">")
+  NEnvPath     p -> simpleExpr $ pretty ("<" <> p <> ">")
   NLiteralPath p -> pathExpr $ pretty $ case p of
     "./"  -> "./."
     "../" -> "../."
@@ -282,7 +282,7 @@ exprFNixDoc = \case
         | "~/" `isPrefixOf` txt  -> txt
         | "./" `isPrefixOf` txt  -> txt
         | "../" `isPrefixOf` txt -> txt
-        | otherwise              -> "./" ++ txt
+        | otherwise              -> "./" <> txt
   NSym name -> simpleExpr $ pretty (unpack name)
   NLet binds body ->
     leastPrecedence
@@ -327,7 +327,7 @@ valueToExpr = iterNValue (\_ _ -> thk) phi
     ]
   phi (NVClosure' _ _   ) = Fix . NSym . pack $ "<closure>"
   phi (NVPath' p        ) = Fix $ NLiteralPath p
-  phi (NVBuiltin' name _) = Fix . NSym . pack $ "builtins." ++ name
+  phi (NVBuiltin' name _) = Fix . NSym . pack $ "builtins." <> name
   phi _                   = error "Pattern synonyms foil completeness check"
 
   mkStr ns = Fix $ NStr $ DoubleQuoted [Plain (stringIgnoreContext ns)]
@@ -391,22 +391,22 @@ printNix = iterNValue (\_ _ -> thk) phi
   phi :: NValue' t f m String -> String
   phi (NVConstant' a ) = unpack $ atomText a
   phi (NVStr'      ns) = show $ stringIgnoreContext ns
-  phi (NVList'     l ) = "[ " ++ unwords l ++ " ]"
+  phi (NVList'     l ) = "[ " <> unwords l <> " ]"
   phi (NVSet' s _) =
     "{ "
-      ++ concat
-           [ check (unpack k) ++ " = " ++ v ++ "; "
+      <> concat
+           [ check (unpack k) <> " = " <> v <> "; "
            | (k, v) <- sort $ toList s
            ]
-      ++ "}"
+      <> "}"
    where
     check v = fromMaybe
       v
       (   fmap (surround . show) (readMaybe v :: Maybe Int)
       <|> fmap (surround . show) (readMaybe v :: Maybe Float)
       )
-      where surround s = "\"" ++ s ++ "\""
+      where surround s = "\"" <> s <> "\""
   phi NVClosure'{}        = "<<lambda>>"
   phi (NVPath' fp       ) = fp
-  phi (NVBuiltin' name _) = "<<builtin " ++ name ++ ">>"
+  phi (NVBuiltin' name _) = "<<builtin " <> name <> ">>"
   phi _                   = error "Pattern synonyms foil completeness check"

--- a/src/Nix/Pretty.hs
+++ b/src/Nix/Pretty.hs
@@ -149,7 +149,7 @@ prettyParamSet args var = encloseSep
   (lbrace <> space)
   (align (space <> rbrace))
   sep
-  (map prettySetArg args <> prettyVariadic)
+  (fmap prettySetArg args <> prettyVariadic)
  where
   prettySetArg (n, maybeDef) = case maybeDef of
     Nothing -> pretty (unpack n)
@@ -161,7 +161,7 @@ prettyBind :: Binding (NixDoc ann) -> Doc ann
 prettyBind (NamedVar n v _p) =
   prettySelector n <+> equals <+> withoutParens v <> semi
 prettyBind (Inherit s ns _p) =
-  "inherit" <+> scope <> align (fillSep (map prettyKeyName ns)) <> semi
+  "inherit" <+> scope <> align (fillSep (fmap prettyKeyName ns)) <> semi
   where scope = maybe mempty ((<> space) . parens . withoutParens) s
 
 prettyKeyName :: NKeyName (NixDoc ann) -> Doc ann
@@ -289,7 +289,7 @@ exprFNixDoc = \case
       $ group
       $ vsep
       $ [ "let"
-        , indent 2 (vsep (map prettyBind binds))
+        , indent 2 (vsep (fmap prettyBind binds))
         , "in" <+> withoutParens body
         ]
   NIf cond trueBody falseBody ->

--- a/src/Nix/Reduce.hs
+++ b/src/Nix/Reduce.hs
@@ -96,11 +96,11 @@ staticImport pann path = do
     Nothing   -> go path'
  where
   go path = do
-    liftIO $ putStrLn $ "Importing file " ++ path
+    liftIO $ putStrLn $ "Importing file " <> path
 
     eres <- liftIO $ parseNixFileLoc path
     case eres of
-      Failure err -> error $ "Parse failed: " ++ show err
+      Failure err -> error $ "Parse failed: " <> show err
       Success x   -> do
         let
           pos  = SourcePos "Reduce.hs" (mkPos 1) (mkPos 1)

--- a/src/Nix/Reduce.hs
+++ b/src/Nix/Reduce.hs
@@ -313,10 +313,10 @@ pruneTree opts = foldFixM $ \(FlaggedF (b, Compose x)) -> do
     NAbs params (Just body) -> Just $ NAbs (pruneParams params) body
 
     NList l | reduceLists opts -> Just $ NList (catMaybes l)
-            | otherwise        -> Just $ NList (map (fromMaybe nNull) l)
+            | otherwise        -> Just $ NList (fmap (fromMaybe nNull) l)
     NSet recur binds
       | reduceSets opts -> Just $ NSet recur (mapMaybe sequence binds)
-      | otherwise -> Just $ NSet recur (map (fmap (fromMaybe nNull)) binds)
+      | otherwise -> Just $ NSet recur (fmap (fmap (fromMaybe nNull)) binds)
 
     NLet binds (Just body@(Fix (Compose (Ann _ x)))) ->
       Just $ case mapMaybe pruneBinding binds of
@@ -386,10 +386,10 @@ pruneTree opts = foldFixM $ \(FlaggedF (b, Compose x)) -> do
   pruneParams (Param n) = Param n
   pruneParams (ParamSet xs b n)
     | reduceSets opts = ParamSet
-      (map (second (maybe (Just nNull) (Just . fromMaybe nNull))) xs)
+      (fmap (second (maybe (Just nNull) (Just . fromMaybe nNull))) xs)
       b
       n
-    | otherwise = ParamSet (map (second (fmap (fromMaybe nNull))) xs) b n
+    | otherwise = ParamSet (fmap (second (fmap (fromMaybe nNull))) xs) b n
 
   pruneBinding :: Binding (Maybe NExprLoc) -> Maybe (Binding NExprLoc)
   pruneBinding (NamedVar _ Nothing _) = Nothing
@@ -398,7 +398,7 @@ pruneTree opts = foldFixM $ \(FlaggedF (b, Compose x)) -> do
   pruneBinding (Inherit _                 [] _) = Nothing
   pruneBinding (Inherit (join -> Nothing) _  _) = Nothing
   pruneBinding (Inherit (join -> m) xs pos) =
-    Just (Inherit m (map pruneKeyName xs) pos)
+    Just (Inherit m (fmap pruneKeyName xs) pos)
 
 reducingEvalExpr
   :: (Framed e m, Has e Options, Exception r, MonadCatch m, MonadIO m)

--- a/src/Nix/Reduce.hs
+++ b/src/Nix/Reduce.hs
@@ -278,7 +278,7 @@ reduce (NAbs_ ann params body) = do
   let args = case params' of
         Param name -> M.singleton name (Fix (NSym_ ann name))
         ParamSet pset _ _ ->
-          M.fromList $ map (\(k, _) -> (k, Fix (NSym_ ann k))) pset
+          M.fromList $ fmap (\(k, _) -> (k, Fix (NSym_ ann k))) pset
   Fix . NAbs_ ann params' <$> pushScope args body
 
 reduce v = Fix <$> sequence v

--- a/src/Nix/Render.hs
+++ b/src/Nix/Render.hs
@@ -114,7 +114,7 @@ sourceContext path (unPos -> begLine) (unPos -> _begCol) (unPos -> endLine) (unP
     let beg' = max 1 (min begLine (begLine - 3))
         end' = max endLine (endLine + 3)
     ls <-
-      map pretty
+      fmap pretty
       .   take (end' - beg')
       .   drop (pred beg')
       .   T.lines
@@ -123,7 +123,7 @@ sourceContext path (unPos -> begLine) (unPos -> _begCol) (unPos -> endLine) (unP
     let
       nums    = zipWith (curry (show . fst)) [beg' ..] ls
       longest = maximum (map length nums)
-      nums'   = flip map nums $ \n -> replicate (longest - length n) ' ' ++ n
+      nums'   = flip fmap nums $ \n -> replicate (longest - length n) ' ' ++ n
       pad n | read n == begLine = "==> " ++ n
             | otherwise         = "    " ++ n
       ls' = zipWith (<+>)

--- a/src/Nix/Render.hs
+++ b/src/Nix/Render.hs
@@ -127,6 +127,6 @@ sourceContext path (unPos -> begLine) (unPos -> _begCol) (unPos -> endLine) (unP
       pad n | read n == begLine = "==> " <> n
             | otherwise         = "    " <> n
       ls' = zipWith (<+>)
-                    (map (pretty . pad) nums')
-                    (map ("| " <+>) ls)
+                    (fmap (pretty . pad) nums')
+                    (fmap ("| " <+>) ls)
     pure $ vsep $ ls' <> [msg]

--- a/src/Nix/Render.hs
+++ b/src/Nix/Render.hs
@@ -97,11 +97,11 @@ renderLocation (SrcSpan (SourcePos file begLine begCol) (SourcePos file' endLine
 renderLocation (SrcSpan beg end) msg =
   fail
     $  "Don't know how to render range from "
-    ++ show beg
-    ++ " to "
-    ++ show end
-    ++ " for error: "
-    ++ show msg
+    <> show beg
+    <> " to "
+    <> show end
+    <> " for error: "
+    <> show msg
 
 errorContext :: FilePath -> Pos -> Pos -> Pos -> Pos -> Doc a
 errorContext path bl bc _el _ec =
@@ -122,11 +122,11 @@ sourceContext path (unPos -> begLine) (unPos -> _begCol) (unPos -> endLine) (unP
       <$> readFile path
     let
       nums    = zipWith (curry (show . fst)) [beg' ..] ls
-      longest = maximum (map length nums)
-      nums'   = flip fmap nums $ \n -> replicate (longest - length n) ' ' ++ n
-      pad n | read n == begLine = "==> " ++ n
-            | otherwise         = "    " ++ n
+      longest = maximum (fmap length nums)
+      nums'   = flip fmap nums $ \n -> replicate (longest - length n) ' ' <> n
+      pad n | read n == begLine = "==> " <> n
+            | otherwise         = "    " <> n
       ls' = zipWith (<+>)
                     (map (pretty . pad) nums')
                     (map ("| " <+>) ls)
-    pure $ vsep $ ls' ++ [msg]
+    pure $ vsep $ ls' <> [msg]

--- a/src/Nix/Render/Frame.hs
+++ b/src/Nix/Render/Frame.hs
@@ -51,7 +51,7 @@ renderFrames (x : xs) = do
     | verbose opts <= ErrorsOnly -> renderFrame @v @t @f x
     | verbose opts <= Informational -> do
       f <- renderFrame @v @t @f x
-      pure $ concatMap go (reverse xs) ++ f
+      pure $ concatMap go (reverse xs) <> f
     | otherwise -> concat <$> mapM (renderFrame @v @t @f) (reverse (x : xs))
   pure $ case frames of
     [] -> mempty
@@ -92,7 +92,7 @@ renderFrame (NixFrame level f)
   | Just (e :: ExecFrame t f m) <- fromException f = renderExecFrame level e
   | Just (e :: ErrorCall) <- fromException f = pure [pretty (show e)]
   | Just (e :: SynHoleInfo m v) <- fromException f = pure [pretty (show e)]
-  | otherwise = error $ "Unrecognized frame: " ++ show f
+  | otherwise = error $ "Unrecognized frame: " <> show f
 
 wrapExpr :: NExprF r -> NExpr
 wrapExpr x = Fix (Fix (NSym "<?>") <$ x)
@@ -108,7 +108,7 @@ renderEvalFrame level f = do
     EvaluatingExpr scope e@(Fix (Compose (Ann ann _))) -> do
       let scopeInfo | showScopes opts = [pretty $ show scope]
                     | otherwise   = []
-      fmap (\x -> scopeInfo ++ [x])
+      fmap (\x -> scopeInfo <> [x])
         $   renderLocation ann
         =<< renderExpr level "While evaluating" "Expression" e
 
@@ -154,7 +154,7 @@ renderExpr _level longLabel shortLabel e@(Fix (Compose (Ann _ x))) = do
           | otherwise = prettyNix (Fix (Fix (NSym "<?>") <$ x))
   pure $ if verbose opts >= Chatty
     then
-      vsep [pretty (longLabel ++ ":\n>>>>>>>>"), indent 2 rendered, "<<<<<<<<"]
+      vsep [pretty (longLabel <> ":\n>>>>>>>>"), indent 2 rendered, "<<<<<<<<"]
     else pretty shortLabel <> fillSep [": ", rendered]
 
 renderValueFrame
@@ -218,7 +218,7 @@ renderThunkLoop
   -> ThunkLoop
   -> m [Doc ann]
 renderThunkLoop _level = pure . (: []) . \case
-  ThunkLoop n -> pretty $ "Infinite recursion in thunk " ++ n
+  ThunkLoop n -> pretty $ "Infinite recursion in thunk " <> n
 
 renderNormalLoop
   :: (MonadReader e m, Has e Options, MonadFile m, MonadCitedThunks t f m)

--- a/src/Nix/Scope.hs
+++ b/src/Nix/Scope.hs
@@ -37,7 +37,7 @@ data Scopes m a = Scopes
 
 instance Show (Scopes m a) where
   show (Scopes m a) =
-    "Scopes: " ++ show m ++ ", and " ++ show (length a) ++ " with-scopes"
+    "Scopes: " <> show m <> ", and " <> show (length a) <> " with-scopes"
 
 instance Semigroup (Scopes m a) where
   Scopes ls lw <> Scopes rs rw = Scopes (ls <> rs) (lw <> rw)

--- a/src/Nix/String.hs
+++ b/src/Nix/String.hs
@@ -221,6 +221,6 @@ intercalateNixString _   []   = mempty
 intercalateNixString _   [ns] = ns
 intercalateNixString sep nss  = NixString contents ctx
  where
-  contents = Text.intercalate (nsContents sep) (map nsContents nss)
+  contents = Text.intercalate (nsContents sep) (fmap nsContents nss)
   ctx      = S.unions (nsContext sep : fmap nsContext nss)
 

--- a/src/Nix/String.hs
+++ b/src/Nix/String.hs
@@ -30,21 +30,24 @@ module Nix.String
   )
 where
 
-import           Control.Monad.Writer
-import           Data.Functor.Identity
+
+
+
+import           Control.Monad.Writer           ( WriterT(..), MonadWriter(tell), MonadTrans, (<=<))
+import           Data.Functor.Identity          ( Identity(runIdentity) )
 import qualified Data.HashMap.Lazy             as M
 import qualified Data.HashSet                  as S
-import           Data.Hashable
+import           Data.Hashable                  ( Hashable )
 import           Data.Text                      ( Text )
 import qualified Data.Text                     as Text
-import           GHC.Generics
+import           GHC.Generics                   ( Generic )
 
 
 -- * Types
 
 -- ** Context
 
--- | A 'StringContext' ...
+-- | A Nix 'StringContext' ...
 data StringContext =
   StringContext { scPath :: !Text
                 , scFlavor :: !ContextFlavor
@@ -139,7 +142,7 @@ getContext = nsContext
 
 fromNixLikeContext :: NixLikeContext -> S.HashSet StringContext
 fromNixLikeContext =
-  S.fromList . join . fmap toStringContexts . M.toList . getNixLikeContext
+  S.fromList . (toStringContexts <=< (M.toList . getNixLikeContext))
 
 -- | Extract the string contents from a NixString that has no context
 getStringNoContext :: NixString -> Maybe Text

--- a/src/Nix/String.hs
+++ b/src/Nix/String.hs
@@ -139,7 +139,7 @@ getContext = nsContext
 
 fromNixLikeContext :: NixLikeContext -> S.HashSet StringContext
 fromNixLikeContext =
-  S.fromList . join . map toStringContexts . M.toList . getNixLikeContext
+  S.fromList . join . fmap toStringContexts . M.toList . getNixLikeContext
 
 -- | Extract the string contents from a NixString that has no context
 getStringNoContext :: NixString -> Maybe Text
@@ -164,7 +164,7 @@ toStringContexts (path, nlcv) = case nlcv of
   NixLikeContextValue _ True _ -> StringContext path AllOutputs
     : toStringContexts (path, nlcv { nlcvAllOutputs = False })
   NixLikeContextValue _ _ ls | not (null ls) ->
-    map (StringContext path . DerivationOutput) ls
+    fmap (StringContext path . DerivationOutput) ls
   _ -> []
 
 toNixLikeContextValue :: StringContext -> (Text, NixLikeContextValue)
@@ -222,5 +222,5 @@ intercalateNixString _   [ns] = ns
 intercalateNixString sep nss  = NixString contents ctx
  where
   contents = Text.intercalate (nsContents sep) (map nsContents nss)
-  ctx      = S.unions (nsContext sep : map nsContext nss)
+  ctx      = S.unions (nsContext sep : fmap nsContext nss)
 

--- a/src/Nix/String/Coerce.hs
+++ b/src/Nix/String/Coerce.hs
@@ -77,7 +77,7 @@ coerceToString call ctsm clevel = go
 
     NVSet s _ | Just p <- M.lookup "outPath" s -> demand p go
 
-    v -> throwError $ ErrorCall $ "Expected a string, but saw: " ++ show v
+    v -> throwError $ ErrorCall $ "Expected a string, but saw: " <> show v
 
   nixStringUnwords =
     intercalateNixString (makeNixStringWithoutContext " ")

--- a/src/Nix/TH.hs
+++ b/src/Nix/TH.hs
@@ -66,7 +66,7 @@ freeVars e = case unFix e of
       `Set.union` Set.unions (mapMaybe (fmap freeVars . snd) set)
     -- But remove the argument name if existing, and all arguments in the parameter set
       \\          maybe Set.empty Set.singleton varname
-      \\          Set.fromList (map fst set)
+      \\          Set.fromList (fmap fst set)
   (NLet bindings expr) ->
     freeVars expr
       `Set.union` foldMap bindFree bindings

--- a/src/Nix/Thunk.hs
+++ b/src/Nix/Thunk.hs
@@ -60,6 +60,6 @@ newtype ThunkLoop = ThunkLoop String -- contains rendering of ThunkId
   deriving Typeable
 
 instance Show ThunkLoop where
-  show (ThunkLoop i) = "ThunkLoop " ++ i
+  show (ThunkLoop i) = "ThunkLoop " <> i
 
 instance Exception ThunkLoop

--- a/src/Nix/Thunk/Basic.hs
+++ b/src/Nix/Thunk/Basic.hs
@@ -28,7 +28,7 @@ instance (Eq v, Eq (ThunkId m)) => Eq (NThunkF m v) where
   Thunk x _ _ == Thunk y _ _ = x == y
 
 instance Show v => Show (NThunkF m v) where
-  show (Thunk _ _ _) = "<thunk>"
+  show Thunk{} = "<thunk>"
 
 type MonadBasicThunk m = (MonadThunkId m, MonadVar m)
 

--- a/src/Nix/Type/Assumption.hs
+++ b/src/Nix/Type/Assumption.hs
@@ -30,7 +30,7 @@ remove :: Assumption -> Name -> Assumption
 remove (Assumption a) var = Assumption (filter (\(n, _) -> n /= var) a)
 
 lookup :: Name -> Assumption -> [Type]
-lookup key (Assumption a) = map snd (filter (\(n, _) -> n == key) a)
+lookup key (Assumption a) = fmap snd (filter (\(n, _) -> n == key) a)
 
 merge :: Assumption -> Assumption -> Assumption
 merge (Assumption a) (Assumption b) = Assumption (a ++ b)
@@ -42,4 +42,4 @@ singleton :: Name -> Type -> Assumption
 singleton x y = Assumption [(x, y)]
 
 keys :: Assumption -> [Name]
-keys (Assumption a) = map fst a
+keys (Assumption a) = fmap fst a

--- a/src/Nix/Type/Assumption.hs
+++ b/src/Nix/Type/Assumption.hs
@@ -33,7 +33,7 @@ lookup :: Name -> Assumption -> [Type]
 lookup key (Assumption a) = fmap snd (filter (\(n, _) -> n == key) a)
 
 merge :: Assumption -> Assumption -> Assumption
-merge (Assumption a) (Assumption b) = Assumption (a ++ b)
+merge (Assumption a) (Assumption b) = Assumption (a <> b)
 
 mergeAssumptions :: [Assumption] -> Assumption
 mergeAssumptions = foldl' merge empty

--- a/src/Nix/Type/Infer.hs
+++ b/src/Nix/Type/Infer.hs
@@ -142,7 +142,7 @@ instance Substitutable Constraint where
     ImpInstConst (apply s t1) (apply s ms) (apply s t2)
 
 instance Substitutable a => Substitutable [a] where
-  apply = map . apply
+  apply = fmap . apply
 
 instance (Ord a, Substitutable a) => Substitutable (Set.Set a) where
   apply = Set.map . apply
@@ -253,7 +253,7 @@ inferType env ex = do
 inferExpr :: Env -> NExpr -> Either InferError [Scheme]
 inferExpr env ex = case runInfer (inferType env ex) of
   Left  err -> Left err
-  Right xs  -> Right $ map (\(subst, ty) -> closeOver (subst `apply` ty)) xs
+  Right xs  -> Right $ fmap (\(subst, ty) -> closeOver (subst `apply` ty)) xs
 
 -- | Canonicalize and return the polymorphic toplevel type.
 closeOver :: Type -> Scheme
@@ -505,7 +505,7 @@ instance MonadInfer m => MonadEval (Judgment s) (InferT s m) where
             (as1 `As.merge` As.singleton k t, M.insert k t t1)
         arg   = pure $ Judgment env [] (TSet True tys)
         call  = k arg $ \args b -> (args, ) <$> b
-        names = map fst js
+        names = fmap fst js
 
     (args, Judgment as cs t) <- foldr (\(_, TVar a) -> extendMSet a) call js
 

--- a/src/Nix/Utils.hs
+++ b/src/Nix/Utils.hs
@@ -48,7 +48,7 @@ traceM :: Monad m => String -> m ()
 traceM = const (pure ())
 #endif
 
-$(makeLensesBy (\n -> Just ("_" ++ n)) ''Fix)
+$(makeLensesBy (\n -> Just ("_" <> n)) ''Fix)
 
 type DList a = Endo [a]
 

--- a/src/Nix/Value.hs
+++ b/src/Nix/Value.hs
@@ -94,7 +94,7 @@ instance Show r => Show (NValueF p m r) where
 
     showsCon1 :: Show a => String -> a -> Int -> String -> String
     showsCon1 con a d =
-      showParen (d > 10) $ showString (con ++ " ") . showsPrec 11 a
+      showParen (d > 10) $ showString (con <> " ") . showsPrec 11 a
 
 lmapNValueF :: Functor m => (b -> a) -> NValueF a m r -> NValueF b m r
 lmapNValueF f = \case

--- a/src/Nix/XML.hs
+++ b/src/Nix/XML.hs
@@ -74,4 +74,4 @@ paramsXML (ParamSet s b mname) =
   nattr = maybe [] ((: []) . Attr (unqual "name") . Text.unpack) mname
 
 paramSetXML :: ParamSet r -> [Content]
-paramSetXML = map (\(k, _) -> Elem $ mkElem "attr" "name" (Text.unpack k))
+paramSetXML = fmap (\(k, _) -> Elem $ mkElem "attr" "name" (Text.unpack k))

--- a/tests/EvalTests.hs
+++ b/tests/EvalTests.hs
@@ -444,7 +444,7 @@ genEvalCompareTests = do
     let unmaskedFiles = filter ((==".nix") . takeExtension) td
     let files = unmaskedFiles \\ maskedFiles
 
-    pure $ testGroup "Eval comparison tests" $ map (mkTestCase testDir) files
+    pure $ testGroup "Eval comparison tests" $ fmap (mkTestCase testDir) files
   where
     mkTestCase td f = testCase f $ assertEvalFileMatchesNix (td </> f)
 

--- a/tests/NixLanguageTests.hs
+++ b/tests/NixLanguageTests.hs
@@ -60,7 +60,7 @@ From (git://nix)/tests/lang.sh we see that
 -}
 
 groupBy :: Ord k => (v -> k) -> [v] -> Map k [v]
-groupBy key = Map.fromListWith (++) . map (key &&& pure)
+groupBy key = Map.fromListWith (++) . fmap (key &&& pure)
 
 -- | New tests, which have never yet passed.  Once any of these is passing,
 -- please remove it from this list.  Do not add tests to this list if they have
@@ -85,14 +85,14 @@ genTests = do
     <$> globDir1 (compile "*-*-*.*") "data/nix/tests/lang"
   let testsByName = groupBy (takeFileName . dropExtensions) testFiles
   let testsByType = groupBy testType (Map.toList testsByName)
-  let testGroups  = map mkTestGroup (Map.toList testsByType)
+  let testGroups  = fmap mkTestGroup (Map.toList testsByType)
   pure $ localOption (mkTimeout 2000000) $ testGroup
     "Nix (upstream) language tests"
     testGroups
  where
   testType (fullpath, _files) = take 2 $ splitOn "-" $ takeFileName fullpath
   mkTestGroup (kind, tests) =
-    testGroup (unwords kind) $ map (mkTestCase kind) tests
+    testGroup (unwords kind) $ fmap (mkTestCase kind) tests
   mkTestCase kind (basename, files) = testCase (takeFileName basename) $ do
     time <- liftIO getCurrentTime
     let opts = defaultOptions time
@@ -143,7 +143,7 @@ assertEval :: Options -> [FilePath] -> Assertion
 assertEval _opts files = do
   time <- liftIO getCurrentTime
   let opts = defaultOptions time
-  case delete ".nix" $ sort $ map takeExtensions files of
+  case delete ".nix" $ sort $ fmap takeExtensions files of
     []                 -> () <$ hnixEvalFile opts (name ++ ".nix")
     [".exp"         ]  -> assertLangOk opts name
     [".exp.xml"     ]  -> assertLangOkXml opts name

--- a/tests/PrettyParseTests.hs
+++ b/tests/PrettyParseTests.hs
@@ -165,7 +165,7 @@ normalize = foldFix $ \case
     :: Antiquoted (NString NExpr) NExpr -> Antiquoted (NString NExpr) NExpr
   normAntiquotedString (Plain (DoubleQuoted [EscapedNewline])) = EscapedNewline
   normAntiquotedString (Plain (DoubleQuoted strs)) =
-    let strs' = map normAntiquotedText strs
+    let strs' = fmap normAntiquotedText strs
     in  if strs == strs'
           then Plain (DoubleQuoted strs)
           else normAntiquotedString (Plain (DoubleQuoted strs'))
@@ -216,7 +216,7 @@ prop_prettyparse p = do
  where
   parse     = parseNixText
 
-  normalise = unlines . map (reverse . dropWhile isSpace . reverse) . lines
+  normalise = unlines . fmap (reverse . dropWhile isSpace . reverse) . lines
 
   ldiff :: String -> String -> [Diff [String]]
   ldiff s1 s2 = getDiff (map (: []) (lines s1)) (map (: []) (lines s2))


### PR DESCRIPTION
I've checked the performance.

The compilation feels a bit slower, but did not measure that literally so far. Understandably GHC runs type class inference to concrete types much more. NOR compilation time should be a metric, when the elegance and flexibility to have pleasent longevity is more important, and the `ghcid` & HLS recompile only diff bits.

Overall, seems that because of the recursion schemes, λω polymorphism (type class) - works great. I was thinking that HNix may get some type class inference in the closed loop (*means I forgot how that thing called*). But seems probably because of the recursion schemes design, it makes type code non-recursive, because of it the λω works great.

The profiling in fact run even faster. I run profiling to look what I've changed by polymorphing the code. - The profiling reports the exact same picture which is to `master`, the exact same stack with the same volume and so on, nothing was seen.

The Nixpkgs walk: `cabal v2-run hnix -- --eval --expr "import <nixpkgs> {}" --find`  walks great.

When this basic clean-up is done, would run cleaner benchmark trials to be thorough.