### PR TITLE
rm Setup.hs

### DIFF
--- a/Setup.hs
+++ b/Setup.hs
@@ -1,2 +1,0 @@
-import Distribution.Simple
-main = defaultMain


### PR DESCRIPTION
Allows HLS to work normally. Setup.hs, at least simple ones, seem to be under deprecation.