### PR TITLE
deps: await to catch ref-tf > 0.4.0.2

### DIFF
--- a/hnix.cabal
+++ b/hnix.cabal
@@ -430,7 +430,7 @@ library
     , parser-combinators >= 1.0.1 && < 1.4
     , prettyprinter >= 1.7.0 && < 1.8
     , process >= 1.6.3 && < 1.7
-    , ref-tf >= 0.4.0 && < 0.5
+    , ref-tf >= 0.4.0 && <= 0.4.0.2
     , regex-tdfa >= 1.2.3 && < 1.4
     , scientific >= 0.3.6 && < 0.4
     , semialign >= 1 && < 1.2


### PR DESCRIPTION
Since:
```haskell
instance .. MonadAtomicRef (ST a)
```
is upstreamed: https://github.com/mainland/ref-tf

Catch in on the next release.