### PR TITLE
Expr.Types: add hashable instances back; organize the module

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -7,53 +7,80 @@
 
   * [(link)](https://github.com/haskell-nix/hnix/pull/802/commits/529095deaf6bc6b102fe5a3ac7baccfbb8852e49#) `Nix.Strings`: all `hacky*` functions replaced with lawful implemetations, because of that all functions become lawful - dropped the `principled` suffix from functions:
     * `Nix.String`:
-      * `hackyGetStringNoContext` -> `getStringNoContext`.
-      * `hackyStringIgnoreContext` -> `stringIgnoreContext`.
-      * `hackyMakeNixStringWithoutContext` -> `makeNixStringWithoutContext`.
-      * `principledStringMConcat` -> `mconcat`.
-      * `principledStringMappend` -> `mappend`.
-      * `principledStringMempty` -> `mempty`.
-      * `principledMempty` -> `mempty`.
-      * `principledGetContext` -> `getContext`.
-      * `principledMakeNixString` -> `makeNixString`.
-      * `principledIntercalateNixString` -> `intercalateNixString`.
-      * `principledGetStringNoContext` -> `getStringNoContext`.
-      * `principledStringIgnoreContext` -> `stringIgnoreContext`.
-      * `principledMakeNixStringWithoutContext` -> `makeNixStringWithoutContext`.
-      * `principledMakeNixStringWithSingletonContext` -> `makeNixStringWithSingletonContext`.
-      * `principledModifyNixContents` -> `modifyNixContents`.
+        ```haskell
+        hackyGetStringNoContext          ->
+             getStringNoContext
+        hackyStringIgnoreContext         ->
+             stringIgnoreContext
+        hackyMakeNixStringWithoutContext ->
+             makeNixStringWithoutContext
+
+        principledMempty        -> mempty
+        principledStringMempty  -> mempty
+        principledStringMConcat -> mconcat
+        principledStringMappend -> mappend
+
+        principledGetContext                        ->
+                  getContext
+        principledMakeNixString                     ->
+                  makeNixString
+        principledIntercalateNixStrin               ->
+                  intercalateNixString
+        principledGetStringNoContext                ->
+                  getStringNoContext
+        principledStringIgnoreContext               ->
+                  stringIgnoreContext
+        principledMakeNixStringWithoutContext       ->
+                  makeNixStringWithoutContext
+        principledMakeNixStringWithSingletonContext ->
+                  makeNixStringWithSingletonContext
+        principledModifyNixContents                 ->
+                  modifyNixContents
+        ```
 
   * [(link)](https://github.com/haskell-nix/hnix/pull/805/files):
     * Data type: `MonadFix1T t m`: `Nix.Standard` -> `Nix.Utils.Fix1`
     * Children found their parents:
-      * `Binary NAtom`: `Nix.Expr.Types` -> `Nix.Atoms`
-      * `Eq1 (NValue' t f m a)`: `Nix.Value.Equal` -> `Nix.Value` - instance was TH, become regular derivable
-      * `Eq1 (NValueF p m)`: `Nix.Value.Equal` -> `Nix.Value`
-      * `FromJSON NAtom`: `Nix.Expr.Types` -> `Nix.Atoms`
-      * `ToJSON NAtom`: `Nix.Expr.Types` -> `Nix.Atoms`
-      * `HasCitations m v (NValue t f m)`: `Nix.Pretty` -> `Nix.Cited`
-      * `HasCitations m v (NValue' t f m a)`: `Nix.Pretty` -> `Nix.Cited`
-      * `Hashable1 Binding`: `Nix.Expr.Types` -> `Void` - please, report if it is needed
-      * `Hashable1 NExprF`: `Nix.Expr.Types` -> `Void` - please, report if it is needed
-      * `Hashable1 NonEmpty`: `Nix.Expr.Types` -> `Void` - please, report if it is needed
-      * `MonadAtomicRef (Fix1T t m)`: `Nix.Standard` -> `Nix.Utils.Fix1`
-      * `MonadEnv (Fix1 t)`: `Nix.Standard` -> `Nix.Efffects`
-      * `MonadEnv (Fix1T t m)`: `Nix.Standard` -> `Nix.Efffects`
-      * `MonadExec (Fix1 t)`: `Nix.Standard` -> `Nix.Efffects`
-      * `MonadExec (Fix1T t m)`: `Nix.Standard` -> `Nix.Efffects`
-      * `MonadFile (Fix1T t m)`: `Nix.Standard` -> `Nix.Render`
-      * `MonadHttp (Fix1 t)`: `Nix.Standard` -> `Nix.Efffects`
-      * `MonadHttp (Fix1T t m)`: `Nix.Standard` -> `Nix.Efffects`
-      * `MonadInstantiate (Fix1 t)`: `Nix.Standard` -> `Nix.Efffects`
-      * `MonadInstantiate (Fix1T t m)`: `Nix.Standard` -> `Nix.Efffects`
-      * `MonadIntrospect (Fix1 t)`: `Nix.Standard` -> `Nix.Efffects`
-      * `MonadIntrospect (Fix1T t m)`: `Nix.Standard` -> `Nix.Efffects`
-      * `MonadPaths (Fix1 t)`: `Nix.Standard` -> `Nix.Efffects`
-      * `MonadPaths (Fix1T t m)`: `Nix.Standard` -> `Nix.Efffects`
-      * `MonadPutStr (Fix1 t)`: `Nix.Standard` -> `Nix.Effects`
-      * `MonadPutStr (Fix1T t m)`: `Nix.Standard` -> `Nix.Efffects`
-      * `MonadRef (Fix1T t m)`: `Nix.Standard` -> `Nix.Utils.Fix1`
-      * `MonadStore (Fix1T t m)`: `Nix.Standard` -> `Nix.Efffects`
+        
+        ```haskell
+        Binary   NAtom: Nix.Expr.Types -> Nix.Atoms
+        FromJSON NAtom: Nix.Expr.Types -> Nix.Atoms
+        ToJSON   NAtom: Nix.Expr.Types -> Nix.Atoms
+
+        -- | Instance was TH, now simple derivable
+        Eq1 (NValueF p m)    : Nix.Value.Equal -> Nix.Value
+
+        Eq1 (NValue' t f m a): Nix.Value.Equal -> Nix.Value 
+
+        HasCitations m v (NValue' t f m a): Nix.Pretty -> Nix.Cited
+        HasCitations m v (NValue  t f m)  : Nix.Pretty -> Nix.Cited
+
+        when
+          (package hashable >= 1.3.1) -- gained instance
+          $ Hashable1 NonEmpty: Nix.Expr.Types -> Void -- instance was upstreamed
+
+        -- | Upstreamed, going to apper in the next release of `ref-tf`.
+        MonadAtomicRef   (Fix1T t m): Nix.Standard -> Nix.Utils.Fix1
+
+        MonadRef         (Fix1T t m): Nix.Standard -> Nix.Utils.Fix1
+        MonadEnv         (Fix1T t m): Nix.Standard -> Nix.Effects
+        MonadExec        (Fix1T t m): Nix.Standard -> Nix.Effects
+        MonadHttp        (Fix1T t m): Nix.Standard -> Nix.Effects
+        MonadInstantiate (Fix1T t m): Nix.Standard -> Nix.Effects
+        MonadIntrospect  (Fix1T t m): Nix.Standard -> Nix.Effects
+        MonadPaths       (Fix1T t m): Nix.Standard -> Nix.Effects
+        MonadPutStr      (Fix1T t m): Nix.Standard -> Nix.Effects
+        MonadStore       (Fix1T t m): Nix.Standard -> Nix.Effects
+        MonadFile        (Fix1T t m): Nix.Standard -> Nix.Render
+
+        MonadEnv         (Fix1 t)   : Nix.Standard -> Nix.Effects
+        MonadExec        (Fix1 t)   : Nix.Standard -> Nix.Effects
+        MonadHttp        (Fix1 t)   : Nix.Standard -> Nix.Effects
+        MonadInstantiate (Fix1 t)   : Nix.Standard -> Nix.Effects
+        MonadIntrospect  (Fix1 t)   : Nix.Standard -> Nix.Effects
+        MonadPaths       (Fix1 t)   : Nix.Standard -> Nix.Effects
+        MonadPutStr      (Fix1 t)   : Nix.Standard -> Nix.Effects
+        ```
   
 
 * Additional:

--- a/src/Nix/Expr/Types.hs
+++ b/src/Nix/Expr/Types.hs
@@ -183,6 +183,13 @@ instance Lift (Fix NExprF) where
   liftTyped = unsafeTExpCoerce . lift
 #endif
 
+#if !MIN_VERSION_hashable(1,3,1)
+-- there was none before, remove this in year >2022
+instance Hashable1 NonEmpty
+#endif
+
+instance Hashable1 NExprF
+
 -- | The monomorphic expression type is a fixed point of the polymorphic one.
 type NExpr = Fix NExprF
 
@@ -209,6 +216,8 @@ data Binding r
             Foldable, Traversable, Show, NFData, Hashable)
 
 instance NFData1 Binding
+
+instance Hashable1 Binding
 
 #ifdef MIN_VERSION_serialise
 instance Serialise r => Serialise (Binding r)

--- a/src/Nix/Expr/Types.hs
+++ b/src/Nix/Expr/Types.hs
@@ -176,7 +176,6 @@ instance Lift (Fix NExprF) where
     case Reflection.typeOf b `eqTypeRep` Reflection.typeRep @Text of
       Just HRefl -> pure [| pack $(liftString $ unpack b) |]
       Nothing    -> Nothing
-
 #if MIN_VERSION_template_haskell(2,17,0)
   liftTyped = unsafeCodeCoerce . lift
 #elif MIN_VERSION_template_haskell(2,16,0)
@@ -274,10 +273,9 @@ data Antiquoted (v :: *) (r :: *)
 instance Hashable v => Hashable1 (Antiquoted v)
 
 instance Hashable2 Antiquoted where
-  liftHashWithSalt2 ha _ salt (Plain a) = ha (salt `hashWithSalt` (0 :: Int)) a
-  liftHashWithSalt2 _ _ salt EscapedNewline = salt `hashWithSalt` (1 :: Int)
-  liftHashWithSalt2 _ hb salt (Antiquoted b) =
-    hb (salt `hashWithSalt` (2 :: Int)) b
+  liftHashWithSalt2 ha _  salt (Plain a)      = ha (salt `hashWithSalt` (0 :: Int)) a
+  liftHashWithSalt2 _  _  salt EscapedNewline =     salt `hashWithSalt` (1 :: Int)
+  liftHashWithSalt2 _  hb salt (Antiquoted b) = hb (salt `hashWithSalt` (2 :: Int)) b
 
 instance NFData v => NFData1 (Antiquoted v)
 


### PR DESCRIPTION
They were removed in b5ef442.

Thought to solve the orphans as much as possible, and through having the changelog memo maybe to sort-out the `hashable` situation before release.

Simon did work upstream that solves the root of the question: https://github.com/haskell-unordered-containers/hashable/issues/186, which

`hashable` provided the `NonEmpty` instance, which allows to return them back.

At once, organized the module, now it is easier to understand it altogether. For example, it was not obvious that `Binding` is part of the `NExprF`. And it is also now obvious that project can gain by forming at least 1 submodule from this code.