### PR TITLE
Flipping `demand`

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -17,6 +17,8 @@
       * `querryM`
       * `querryThunk`
 
+  * [(link)](https://github.com/haskell-nix/hnix/pull/862/files#diff-caa5d6592de00a0b23b2996143181d5cb60ebe00abcd0ba39b271caa764aa086) `Nix.Value.Monad`: `class MonadValue v m`: `demand` unflipped the arguments. All its implementations got more straigh-forward to use and `demand` now tail recurse.
+
   * [(link)](https://github.com/haskell-nix/hnix/pull/859/commits/8e043bcbda13ea4fd66d3eefd6da690bb3923edd) `Nix.Value.Equal`: `valueEqM`: freed from `RankNTypes: forall t f m .`.
 
   * [(link)](https://github.com/haskell-nix/hnix/pull/802/commits/529095deaf6bc6b102fe5a3ac7baccfbb8852e49#) `Nix.Strings`: all `hacky*` functions replaced with lawful implemetations, because of that all functions become lawful - dropped the `principled` suffix from functions:

--- a/main/Main.hs
+++ b/main/Main.hs
@@ -74,13 +74,11 @@ main = do
 
   handleResult opts mpath = \case
     Failure err ->
-      (bool
+      bool
         errorWithoutStackTrace
         (liftIO . hPutStrLn stderr)
         (ignoreErrors opts)
-        )
-        $  "Parse failed: "
-        <> show err
+        $ "Parse failed: " <> show err
 
     Success expr -> do
       when (check opts) $ do

--- a/main/Main.hs
+++ b/main/Main.hs
@@ -180,7 +180,7 @@ main = do
                 val <- readVar @(StandardT (StdIdT IO)) ref
                 case val of
                   Computed _    -> pure (k, Nothing)
-                  _ | descend   -> fmap (k,        ) $ forceEntry path nv
+                  _ | descend   -> (k,        ) <$> forceEntry path nv
                     | otherwise -> pure (k, Nothing)
               )
               (\ v -> pure (k, pure (Free v)))

--- a/main/Main.hs
+++ b/main/Main.hs
@@ -215,7 +215,7 @@ main = do
             _                              -> (True, True)
 
           forceEntry k v =
-            catch (pure <$> demand v pure) $ \(NixException frames) -> do
+            catch (pure <$> demand pure v) $ \(NixException frames) -> do
               liftIO
                 .   putStrLn
                 .   ("Exception forcing " <>)

--- a/main/Repl.hs
+++ b/main/Repl.hs
@@ -27,7 +27,7 @@ import           Nix                     hiding ( exec
                                                 )
 import           Nix.Scope
 import           Nix.Utils
-import           Nix.Value.Monad                (demand)
+import           Nix.Value.Monad                ( demand )
 
 import qualified Data.List
 import qualified Data.Maybe
@@ -395,11 +395,10 @@ completeFunc reversedPrev word
               -- Stop on last subField (we care about the keys at this level)
               [_] -> pure $ keys m
               f:fs ->
-                case Data.HashMap.Lazy.lookup f m of
-                  Nothing -> pure mempty
-                  Just e ->
-                    demand e
-                      (\e' -> (fmap . fmap) (("." <> f) <>) $ algebraicComplete fs e')
+                maybe
+                  (pure mempty)
+                  (demand (\e' -> (fmap . fmap) (("." <> f) <>) $ algebraicComplete fs e'))
+                  (Data.HashMap.Lazy.lookup f m)
 
       in case val of
         NVSet xs _ -> withMap xs

--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -1173,13 +1173,16 @@ sort_ comp = fromValue >=> sortByM (cmp comp) >=> toValue
  where
   cmp f a b = do
     isLessThan <- f `callFunc` a >>= (`callFunc` b)
-    fromValue isLessThan >>= \case
-      True  -> pure LT
-      False -> do
-        isGreaterThan <- f `callFunc` b >>= (`callFunc` a)
-        fromValue isGreaterThan <&> \case
-          True  -> GT
-          False -> EQ
+    fromValue isLessThan >>=
+      bool
+        (do
+          isGreaterThan <- f `callFunc` b >>= (`callFunc` a)
+          fromValue isGreaterThan <&>
+            bool
+              EQ
+              GT
+        )
+        (pure LT)
 
 lessThan
   :: MonadNix e t f m

--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -888,19 +888,9 @@ genericClosure
   :: forall e t f m . MonadNix e t f m => NValue t f m -> m (NValue t f m)
 genericClosure = fromValue @(AttrSet (NValue t f m)) >=> \s ->
   case (M.lookup "startSet" s, M.lookup "operator" s) of
-    (Nothing, Nothing) ->
-      throwError
-        $  ErrorCall
-        $  "builtins.genericClosure: "
-        <> "Attributes 'startSet' and 'operator' required"
-    (Nothing, Just _) ->
-      throwError
-        $ ErrorCall
-        $ "builtins.genericClosure: Attribute 'startSet' required"
-    (Just _, Nothing) ->
-      throwError
-        $ ErrorCall
-        $ "builtins.genericClosure: Attribute 'operator' required"
+    (Nothing    , Nothing        ) -> throwError $ ErrorCall $ "builtins.genericClosure: Attributes 'startSet' and 'operator' required"
+    (Nothing    , Just _         ) -> throwError $ ErrorCall $ "builtins.genericClosure: Attribute 'startSet' required"
+    (Just _     , Nothing        ) -> throwError $ ErrorCall $ "builtins.genericClosure: Attribute 'operator' required"
     (Just startSet, Just operator) ->
       demand startSet $ fromValue @[NValue t f m] >=> \ss ->
         demand operator $ \op -> toValue @[NValue t f m] =<< snd <$> go op ss S.empty

--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -789,7 +789,7 @@ builtinsBuiltin
   :: forall e t f m
    . MonadNix e t f m
   => m (NValue t f m)
-builtinsBuiltin = (throwError $ ErrorCall "HNix does not provide builtins.builtins at the moment. Using builtins directly should be preferred")
+builtinsBuiltin = throwError $ ErrorCall "HNix does not provide builtins.builtins at the moment. Using builtins directly should be preferred"
 
 dirOf :: MonadNix e t f m => NValue t f m -> m (NValue t f m)
 dirOf x = demand x $ \case
@@ -804,8 +804,7 @@ unsafeDiscardStringContext
   :: MonadNix e t f m => NValue t f m -> m (NValue t f m)
 unsafeDiscardStringContext mnv = do
   ns <- fromValue mnv
-  toValue $ makeNixStringWithoutContext $ stringIgnoreContext
-    ns
+  toValue $ makeNixStringWithoutContext $ stringIgnoreContext ns
 
 seq_
   :: MonadNix e t f m
@@ -1163,7 +1162,7 @@ scopedImport asetArg pathArg = fromValue @(AttrSet (NValue t f m)) asetArg >>= \
 getEnv_ :: MonadNix e t f m => NValue t f m -> m (NValue t f m)
 getEnv_ = fromValue >=> fromStringNoContext >=> \s -> do
   mres <- getEnvVar (Text.unpack s)
-  toValue $ makeNixStringWithoutContext $ maybe "" Text.pack mres
+  toValue $ makeNixStringWithoutContext $ maybe mempty Text.pack mres
 
 sort_
   :: MonadNix e t f m
@@ -1297,12 +1296,7 @@ absolutePathFromValue :: MonadNix e t f m => NValue t f m -> m FilePath
 absolutePathFromValue = \case
   NVStr ns -> do
     let path = Text.unpack $ stringIgnoreContext ns
-    unless (isAbsolute path)
-      $  throwError
-      $  ErrorCall
-      $  "string "
-      <> show path
-      <> " doesn't represent an absolute path"
+    unless (isAbsolute path) $ throwError $ ErrorCall $ "string " <> show path <> " doesn't represent an absolute path"
     pure path
   NVPath path -> pure path
   v           -> throwError $ ErrorCall $ "expected a path, got " <> show v

--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -851,13 +851,11 @@ genList
   => NValue t f m
   -> NValue t f m
   -> m (NValue t f m)
-genList f = fromValue @Integer >=> \n -> if n >= 0
-  then toValue =<< forM [0 .. n - 1] (\i -> defer $ (f `callFunc`) =<< toValue i)
-  else
-    throwError
-    $  ErrorCall
-    $  "builtins.genList: Expected a non-negative number, got "
-    <> show n
+genList f = fromValue @Integer >=> \n ->
+  bool
+    (throwError $ ErrorCall $ "builtins.genList: Expected a non-negative number, got " <> show n)
+    (toValue =<< forM [0 .. n - 1] (\i -> defer $ (f `callFunc`) =<< toValue i))
+    (n >= 0)
 
 -- We wrap values solely to provide an Ord instance for genericClosure
 newtype WValue t f m = WValue (NValue t f m)

--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -337,23 +337,26 @@ foldNixPath f z = do
     _ -> throwError $ ErrorCall $ "Unexpected entry in NIX_PATH: " <> show x
 
 nixPath :: MonadNix e t f m => m (NValue t f m)
-nixPath = fmap nvList $ flip foldNixPath mempty $ \p mn ty rest ->
-  pure
-    $ flip nvSet mempty ( M.fromList
-        [ case ty of
-          PathEntryPath -> ("path", nvPath p)
-          PathEntryURI ->
-            ( "uri"
-            , nvStr $ makeNixStringWithoutContext $ Text.pack p
-            )
+nixPath = fmap nvList $ flip foldNixPath mempty $
+  \p mn ty rest ->
+    pure $
+      flip nvSet
+        mempty
+        (M.fromList
+          [ case ty of
+            PathEntryPath -> ("path", nvPath p)
+            PathEntryURI ->
+              ( "uri"
+              , nvStr $ makeNixStringWithoutContext $ Text.pack p
+              )
 
-        , ( "prefix"
-          , nvStr
-            $ makeNixStringWithoutContext $ Text.pack $ fromMaybe "" mn
-          )
-        ]
-      )
-    : rest
+          , ( "prefix"
+            , nvStr
+              $ makeNixStringWithoutContext $ Text.pack $ fromMaybe "" mn
+            )
+          ]
+        )
+      : rest
 
 toString :: MonadNix e t f m => NValue t f m -> m (NValue t f m)
 toString = coerceToString callFunc DontCopyToStore CoerceAny >=> toValue

--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -840,15 +840,10 @@ elemAt_
   -> NValue t f m
   -> m (NValue t f m)
 elemAt_ xs n = fromValue n >>= \n' -> fromValue xs >>= \xs' ->
-  case elemAt xs' n' of
-    Just a -> pure a
-    Nothing ->
-      throwError
-        $  ErrorCall
-        $  "builtins.elem: Index "
-        <> show n'
-        <> " too large for list of length "
-        <> show (length xs')
+  maybe
+    (throwError $ ErrorCall $ "builtins.elem: Index " <> show n' <> " too large for list of length " <> show (length xs'))
+    pure
+    (elemAt xs' n')
 
 genList
   :: forall e t f m

--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -1449,19 +1449,21 @@ fetchurl v = demand v $ \case
  where
   go :: Maybe (NValue t f m) -> NValue t f m -> m (NValue t f m)
   go _msha = \case
-    NVStr ns -> noContextAttrs ns >>= getURL >>= \case -- msha
-      Left  e -> throwError e
-      Right p -> toValue p
+    NVStr ns -> noContextAttrs ns >>= getURL >>=
+      either -- msha
+        throwError
+        toValue
     v ->
       throwError
         $  ErrorCall
         $  "builtins.fetchurl: Expected URI or string, got "
         <> show v
 
-  noContextAttrs ns = case getStringNoContext ns of
-    Nothing ->
-      throwError $ ErrorCall $ "builtins.fetchurl: unsupported arguments to url"
-    Just t -> pure t
+  noContextAttrs ns =
+    maybe
+      (throwError $ ErrorCall $ "builtins.fetchurl: unsupported arguments to url")
+      pure
+      (getStringNoContext ns)
 
 partition_
   :: forall e t f m

--- a/src/Nix/Effects/Basic.hs
+++ b/src/Nix/Effects/Basic.hs
@@ -222,7 +222,11 @@ findPathM = findPathBy existingPath
   existingPath path = do
     apath  <- makeAbsolutePath @t @f path
     exists <- doesPathExist apath
-    pure $ if exists then pure apath else mempty
+    pure $
+      bool
+        mempty
+        (pure apath)
+        exists
 
 defaultImportPath
   :: (MonadNix e t f m, MonadState (HashMap FilePath NExprLoc, b) m)

--- a/src/Nix/Effects/Derivation.hs
+++ b/src/Nix/Effects/Derivation.hs
@@ -316,12 +316,18 @@ buildDerivationWithContext drvAttrs = do
           mHash
 
       -- filter out null values if needed.
-      attrs <- if not ignoreNulls
-        then pure drvAttrs
-        else M.mapMaybe id <$> forM drvAttrs (demand' ?? (\case
-            NVConstant NNull -> pure Nothing
-            value -> pure $ pure value
-          ))
+      attrs <-
+        bool
+          (pure drvAttrs)
+          (M.mapMaybe id <$> forM drvAttrs
+            (demand'
+              (pure . \case
+                NVConstant NNull -> Nothing
+                value -> pure value
+              )
+            )
+          )
+          ignoreNulls
 
       env <- if useJson
         then do

--- a/src/Nix/Effects/Derivation.hs
+++ b/src/Nix/Effects/Derivation.hs
@@ -348,8 +348,8 @@ buildDerivationWithContext drvAttrs = do
 
     -- common functions, lifted to WithStringContextT
 
-    demand' :: NValue t f m -> (NValue t f m -> WithStringContextT m a) -> WithStringContextT m a
-    demand' v f = join $ lift $ demand v (pure . f)
+    demand' :: (NValue t f m -> WithStringContextT m a) -> NValue t f m -> WithStringContextT m a
+    demand' f v = join $ lift $ demand (pure . f) v
 
     fromValue' :: (FromValue a m (NValue' t f m (NValue t f m)), MonadNix e t f m) => NValue t f m -> WithStringContextT m a
     fromValue' = lift . fromValue

--- a/src/Nix/Eval.hs
+++ b/src/Nix/Eval.hs
@@ -355,9 +355,10 @@ evalSetterKeyName
 evalSetterKeyName = \case
   StaticKey k -> pure (pure k)
   DynamicKey k ->
-    runAntiquoted "\n" assembleString (>>= fromValueMay) k <&> \case
-      Just ns -> Just (stringIgnoreContext ns)
-      _       -> mempty
+    runAntiquoted "\n" assembleString (>>= fromValueMay) k <&>
+      maybe
+        mempty
+        (pure . stringIgnoreContext)
 
 assembleString
   :: forall v m

--- a/src/Nix/Eval.hs
+++ b/src/Nix/Eval.hs
@@ -115,9 +115,10 @@ eval (NSym "__curPos") = evalCurPos
 
 eval (NSym var       ) = do
   mres <- lookupVar var
-  case mres of
-    Just x  -> demand x $ evaledSym var
-    Nothing -> freeVariable var
+  maybe
+    (freeVariable var)
+    (demand (evaledSym var))
+    mres
 
 eval (NConstant    x      ) = evalConstant x
 eval (NStr         str    ) = evalString str
@@ -188,9 +189,7 @@ attrSetAlter
   -> AttrSet SourcePos
   -> m v
   -> m (AttrSet (m v), AttrSet SourcePos)
-attrSetAlter [] _ _ _ _ =
-  evalError @v $ ErrorCall "invalid selector with no components"
-
+attrSetAlter [] _ _ _ _ = evalError @v $ ErrorCall "invalid selector with no components"
 attrSetAlter (k : ks) pos m p val = case M.lookup k m of
   Nothing | null ks   -> go
           | otherwise -> recurse M.empty M.empty

--- a/src/Nix/Eval.hs
+++ b/src/Nix/Eval.hs
@@ -177,7 +177,7 @@ evalWithAttrSet aset body = do
   -- computed once.
   scope <- currentScopes :: m (Scopes m v)
   s     <- defer $ withScopes scope aset
-  let s' = demand s $ fmap fst . fromValue @(AttrSet v, AttrSet SourcePos)
+  let s' = demand (fmap fst . fromValue @(AttrSet v, AttrSet SourcePos)) s
   pushWeakScope s' body
 
 attrSetAlter
@@ -198,7 +198,7 @@ attrSetAlter (k : ks) pos m p val = case M.lookup k m of
     -> go
     | otherwise
     -> x >>= fromValue @(AttrSet v, AttrSet SourcePos) >>= \(st, sp) ->
-      recurse (demand ?? pure <$> st) sp
+      recurse (demand pure <$> st) sp
  where
   go = pure (M.insert k val m, M.insert k pos p)
 
@@ -257,7 +257,7 @@ evalBinds recursive binds = do
     finalValue >>= fromValue >>= \(o', p') ->
           -- jww (2018-05-09): What to do with the key position here?
                                               pure $ fmap
-      (\(k, v) -> ([k], fromMaybe pos (M.lookup k p'), demand v pure))
+      (\(k, v) -> ([k], fromMaybe pos (M.lookup k p'), demand pure v))
       (M.toList o')
 
   go _ (NamedVar pathExpr finalValue pos) = do
@@ -284,21 +284,29 @@ evalBinds recursive binds = do
       result     -> [result]
 
   go scope (Inherit ms names pos) =
-    fmap catMaybes $ forM names $ evalSetterKeyName >=> \case
-      Nothing  -> pure Nothing
-      Just key -> pure $ Just
-        ( [key]
-        , pos
-        , do
-          mv <- case ms of
-            Nothing -> withScopes scope $ lookupVar key
-            Just s ->
-              s >>= fromValue @(AttrSet v, AttrSet SourcePos) >>= \(attrset, _) ->
-                clearScopes @v $ pushScope attrset $ lookupVar key
-          case mv of
-            Nothing -> attrMissing (key :| []) Nothing
-            Just v  -> demand v pure
+    fmap catMaybes $ forM names $ evalSetterKeyName >=>
+      (pure . maybe
+        Nothing
+        (\ key -> pure
+          ([key]
+          , pos
+          , do
+            mv <-
+              maybe
+                (withScopes scope $ lookupVar key)
+                (\ s ->
+                    --  2021-02-25: NOTE: This is obviously a do block.
+                    -- In the middle of the huge move, can not test refactor compilation.
+                  s >>= fromValue @(AttrSet v, AttrSet SourcePos) >>= \(attrset, _) ->
+                    clearScopes @v $ pushScope attrset $ lookupVar key)
+                ms
+            maybe
+              (attrMissing (key :| []) Nothing)
+              (demand pure)
+              mv
+          )
         )
+      )
 
   buildResult
     :: Scopes m v
@@ -329,8 +337,8 @@ evalSelect aset attr = do
   extract x path@(k :| ks) = fromValueMay x >>= \case
     Just (s :: AttrSet v, p :: AttrSet SourcePos)
       | Just t <- M.lookup k s -> case ks of
-        []     -> pure $ Right $ demand t pure
-        y : ys -> demand t $ extract ?? (y :| ys)
+        []     -> pure $ pure $ demand pure t
+        y : ys -> demand (extract ?? (y :| ys)) t
       | otherwise -> Left . (, path) <$> toValue (s, p)
     Nothing -> pure $ Left (x, path)
 
@@ -341,10 +349,10 @@ evalGetterKeyName
    . (MonadEval v m, FromValue NixString m v)
   => NKeyName (m v)
   -> m Text
-evalGetterKeyName = evalSetterKeyName >=> \case
-  Just k -> pure k
-  Nothing ->
-    evalError @v $ ErrorCall "value is null while a string was expected"
+evalGetterKeyName = evalSetterKeyName >=>
+  maybe
+    (evalError @v $ ErrorCall "value is null while a string was expected")
+    pure
 
 -- | Evaluate a component of an attribute path in a context where we are
 -- *binding* a value

--- a/src/Nix/Exec.hs
+++ b/src/Nix/Exec.hs
@@ -31,6 +31,7 @@ import           Control.Monad
 import           Control.Monad.Catch     hiding ( catchJust )
 import           Control.Monad.Fix
 import           Control.Monad.Reader
+import           Data.Bool                      ( bool )
 import           Data.Fix
 import qualified Data.HashMap.Lazy             as M
 import           Data.List
@@ -344,32 +345,46 @@ execBinaryOp
   -> NValue t f m
   -> m (NValue t f m)
   -> m (NValue t f m)
-
+--  2021-02-25: NOTE: These are do blocks. Currently in the middle of the big rewrite, can not check their refactor. Please help.
 execBinaryOp scope span op lval rarg = case op of
-  NEq   -> rarg >>= \rval -> valueEqM lval rval >>= boolOp rval
-  NNEq  -> rarg >>= \rval -> valueEqM lval rval >>= boolOp rval . not
-  NOr   -> fromValue lval >>= \l -> if l
-             then bypass True
-             else rarg >>= \rval -> fromValue rval >>= boolOp rval
-  NAnd  -> fromValue lval >>= \l -> if l
-             then rarg >>= \rval -> fromValue rval >>= boolOp rval
-             else bypass False
-  NImpl -> fromValue lval >>= \l -> if l
-             then rarg >>= \rval -> fromValue rval >>= boolOp rval
-             else bypass True
-  _     -> rarg >>= \rval ->
-             demand rval $ \rval' ->
-               demand lval $ \lval' ->
-                 execBinaryOpForced scope span op lval' rval'
+  NEq   -> helperEq id
+  NNEq  -> helperEq not
+  NOr   ->
+    helperLogic flip True
+  NAnd  ->
+    helperLogic id False
+  NImpl ->
+    helperLogic id True
+  _     -> rarg >>=
+    (\rval ->
+      demand
+      (\rval' ->
+        demand
+          (\lval' -> execBinaryOpForced scope span op lval' rval')
+          lval
+      )
+      rval)
 
  where
-  toBoolOp :: Maybe (NValue t f m) -> Bool -> m (NValue t f m)
-  toBoolOp r b = pure $ nvConstantP
-    (Provenance scope (NBinary_ span op (pure lval) r))
-    (NBool b)
+
+  helperEq flag = rarg >>= \rval -> valueEqM lval rval >>= boolOp rval . flag
+
+  helperLogic flp flag =
+    fromValue lval >>=
+      flp bool
+        (bypass flag)
+        (rarg >>= \rval -> fromValue rval >>= boolOp rval)
+
   boolOp rval = toBoolOp (pure rval)
+
   bypass      = toBoolOp Nothing
 
+  toBoolOp :: Maybe (NValue t f m) -> Bool -> m (NValue t f m)
+  toBoolOp r b =
+    pure $
+      nvConstantP
+        (Provenance scope (NBinary_ span op (pure lval) r))
+        (NBool b)
 
 execBinaryOpForced
   :: forall e t f m

--- a/src/Nix/Normal.hs
+++ b/src/Nix/Normal.hs
@@ -132,4 +132,4 @@ dethunk
   :: (MonadThunk t m (NValue t f m), MonadDataContext f m)
   => t
   -> m (NValue t f m)
-dethunk t = queryM removeEffects (pure opaque) t
+dethunk = queryM removeEffects (pure opaque)

--- a/src/Nix/Standard.hs
+++ b/src/Nix/Standard.hs
@@ -48,6 +48,7 @@ import           Nix.Render
 import           Nix.Scope
 import           Nix.Thunk
 import           Nix.Thunk.Basic
+import           Nix.Utils                      ( free )
 import           Nix.Utils.Fix1
 import           Nix.Value
 import           Nix.Value.Monad
@@ -158,13 +159,16 @@ instance ( MonadAtomicRef m
   defer = fmap pure . thunk
 
   demand
-    :: StdValue m
-    -> ( StdValue m
+    :: ( StdValue m
       -> m r
       )
+    -> StdValue m
     -> m r
-  demand (Pure v) f = force (`demand` f) v
-  demand (Free v) f = f (Free v)
+  demand f v =
+    free
+      (force (demand f))
+      (const $ f v)
+      v
 
   inform
     :: StdValue m

--- a/src/Nix/Type/Infer.hs
+++ b/src/Nix/Type/Infer.hs
@@ -50,7 +50,7 @@ import           Data.List                      ( delete
                                                 )
 import           Data.Map                       ( Map )
 import qualified Data.Map                      as Map
-import           Data.Maybe                     ( fromJust )
+import           Data.Maybe                     ( fromJust, fromMaybe )
 import qualified Data.Set                      as Set
 import           Data.Text                      ( Text )
 import           Nix.Atoms
@@ -554,9 +554,9 @@ instance MonadInfer m
     let sing _ = Judgment As.empty mempty
     pure $ pure (M.mapWithKey sing xs, M.empty)
   fromValueMay _ = pure mempty
-  fromValue = fromValueMay >=> \case
-    Just v  -> pure v
-    Nothing -> pure (M.empty, M.empty)
+  fromValue = fromValueMay >=>
+    pure . fromMaybe
+      (M.empty, M.empty)
 
 instance MonadInfer m
   => ToValue (AttrSet (Judgment s), AttrSet SourcePos)

--- a/src/Nix/Utils.hs
+++ b/src/Nix/Utils.hs
@@ -169,6 +169,10 @@ alterF
   -> k
   -> HashMap k v
   -> f (HashMap k v)
-alterF f k m = f (M.lookup k m) <&> \case
-  Nothing -> M.delete k m
-  Just v  -> M.insert k v m
+alterF f k m =
+  fmap
+    (maybe
+      (M.delete k m)
+      (\ v -> M.insert k v m)
+    )
+    $ f $ M.lookup k m

--- a/src/Nix/Utils.hs
+++ b/src/Nix/Utils.hs
@@ -176,3 +176,11 @@ alterF f k m =
       (\ v -> M.insert k v m)
     )
     $ f $ M.lookup k m
+
+
+-- | Lambda analog of @maybe@ or @either@ for Free monad.
+free :: (a -> b) -> (f (Free f a) -> b) -> Free f a -> b
+free fP fF m =
+  case m of
+    Pure a -> fP a
+    Free fa -> fF fa

--- a/src/Nix/Utils.hs
+++ b/src/Nix/Utils.hs
@@ -100,8 +100,10 @@ lifted f k = liftWith (\run -> f (run . k)) >>= restoreT . pure
 freeToFix :: Functor f => (a -> Fix f) -> Free f a -> Fix f
 freeToFix f = go
  where
-  go (Pure a) = f a
-  go (Free v) = Fix (fmap go v)
+  go =
+    free
+      f
+      (Fix . fmap go)
 
 fixToFree :: Functor f => Fix f -> Free f a
 fixToFree = Free . go where go (Fix f) = fmap (Free . go) f

--- a/src/Nix/Value/Equal.hs
+++ b/src/Nix/Value/Equal.hs
@@ -142,12 +142,19 @@ valueEqM x@(Free _) (  Pure y) = thunkEqM ?? y =<< thunk (pure x)
 valueEqM (Free (NValue (extract -> x))) (Free (NValue (extract -> y))) =
   valueFEqM (compareAttrSetsM f valueEqM) valueEqM x y
  where
-  f (Pure t) = (`force` t) $ \case
-    NVStr s -> pure $ pure s
-    _       -> pure mempty
-  f (Free v) = case v of
-    NVStr' s -> pure $ pure s
-    _        -> pure mempty
+  f m =
+    free
+      (force
+        (pure . \case
+          NVStr s -> pure s
+          _       -> mempty
+        )
+      )
+      (pure . \case
+        NVStr' s -> pure s
+        _        -> mempty
+      )
+      m
 
 thunkEqM :: (MonadThunk t m (NValue t f m), Comonad f) => t -> t -> m Bool
 thunkEqM lt rt = (`force` lt) $ \lv -> (`force` rt) $ \rv ->

--- a/src/Nix/Value/Monad.hs
+++ b/src/Nix/Value/Monad.hs
@@ -4,7 +4,7 @@ module Nix.Value.Monad where
 
 class MonadValue v m where
   defer :: m v -> m v
-  demand :: v -> (v -> m r) -> m r
+  demand :: (v -> m r) -> v -> m r
   -- | If 'v' is a thunk, 'inform' allows us to modify the action to be
   --   performed by the thunk, perhaps by enriching it with scope info, for
   --   example.


### PR DESCRIPTION
A milestone stage towards #850

Remember that `force` would lose the functional argument.
`demand` would be something along the lines of `free -> f =<< force thunk`.

By the result of the `demand` - it would be seen, is in viable to keep it, or simply replace with that `free -> f =<< force thunk` or move `free` logic into `force` and use `force` with `=<<`.

So instead of the `demand` it would be between function and its argument would be `force v`.

In other words, unflipping required to unfold the code.

But the further following folded elegantness worth it.

Also all those `\case` really are helper functions that explain themself.

Or, `alg` if you want.