### PR TITLE
Builtins: refactor; Utils: inline what is definitely inlinable; fx to Eq1 NValue'; fx all warns

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -96,7 +96,6 @@
         FromJSON NAtom :: Nix.Expr.Types -> Nix.Atoms
         ToJSON   NAtom :: Nix.Expr.Types -> Nix.Atoms
 
-        -- | Instance was TH, now simple derivable
         Eq1 (NValueF p m)     :: Nix.Value.Equal -> Nix.Value
 
         Eq1 (NValue' t f m a) :: Nix.Value.Equal -> Nix.Value 

--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -503,7 +503,7 @@ any_
   => NValue t f m
   -> NValue t f m
   -> m (NValue t f m)
-any_ f = toValue <=< anyM fromValue <=< mapM (f `callFunc`) <=< fromValue
+any_ f = toValue <=< anyM fromValue <=< mapM (callFunc f) <=< fromValue
 
 allM :: Monad m => (a -> m Bool) -> [a] -> m Bool
 allM _ []       = pure True
@@ -519,7 +519,7 @@ all_
   => NValue t f m
   -> NValue t f m
   -> m (NValue t f m)
-all_ f = toValue <=< allM fromValue <=< mapM (f `callFunc`) <=< fromValue
+all_ f = toValue <=< allM fromValue <=< mapM (callFunc f) <=< fromValue
 
 foldl'_
   :: forall e t f m
@@ -528,8 +528,9 @@ foldl'_
   -> NValue t f m
   -> NValue t f m
   -> m (NValue t f m)
-foldl'_ f z xs = fromValue @[NValue t f m] xs >>= foldM go z
-  where go b a = f `callFunc` b >>= (`callFunc` a)
+foldl'_ f z xs =  foldM go z =<< fromValue @[NValue t f m] xs
+ where
+  go b a = f `callFunc` b >>= (`callFunc` a)
 
 head_ :: MonadNix e t f m => NValue t f m -> m (NValue t f m)
 head_ =
@@ -589,7 +590,7 @@ splitVersion_ :: MonadNix e t f m => NValue t f m -> m (NValue t f m)
 splitVersion_ v =
   do
     s <- fromStringNoContext =<< fromValue v
-    pure$
+    pure $
       nvList $
         nvStr . makeNixStringWithoutContext . versionComponentToString <$> splitVersion s
 

--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -666,13 +666,11 @@ match_ pat str =
         ("", sarr, "") ->
           do
             let s = fmap fst (elems sarr)
-            nvList <$> traverse (mkMatch . decodeUtf8)
-              (bool
-                id
-                tail
-                (length s > 1)
-                s
-              )
+            nvList
+              <$>
+                traverse
+                  (mkMatch . decodeUtf8)
+                  ((tail `ifTrue` (length s > 1)) s) -- (length <= 1) allowed & passes-through here the full string
         _ -> (pure $ nvConstant NNull)
       )
       (matchOnceText re (encodeUtf8 s))

--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -563,28 +563,31 @@ versionComponentSeparators :: String
 versionComponentSeparators = ".-"
 
 splitVersion :: Text -> [VersionComponent]
-splitVersion s = case Text.uncons s of
-  Nothing -> mempty
-  Just (h, t)
-    | h `elem` versionComponentSeparators
-    -> splitVersion t
-    | isDigit h
-    -> let (digits, rest) = Text.span isDigit s
-       in
-         VersionComponent_Number
-             (fromMaybe (error $ "splitVersion: couldn't parse " <> show digits)
-             $ readMaybe
-             $ Text.unpack digits
-             )
-           : splitVersion rest
-    | otherwise
-    -> let (chars, rest) = Text.span
-             (\c -> not $ isDigit c || c `elem` versionComponentSeparators)
-             s
-           thisComponent = case chars of
-             "pre" -> VersionComponent_Pre
-             x     -> VersionComponent_String x
-       in  thisComponent : splitVersion rest
+splitVersion s =
+  case Text.uncons s of
+    Nothing -> mempty
+    Just (h, t)
+
+      | h `elem` versionComponentSeparators -> splitVersion t
+
+      | isDigit h ->
+        let (digits, rest) = Text.span isDigit s
+        in
+        VersionComponent_Number
+            (fromMaybe (error $ "splitVersion: couldn't parse " <> show digits) $ readMaybe $ Text.unpack digits) : splitVersion rest
+
+      | otherwise ->
+        let
+          (chars, rest) =
+            Text.span
+              (\c -> not $ isDigit c || c `elem` versionComponentSeparators)
+              s
+          thisComponent =
+            case chars of
+              "pre" -> VersionComponent_Pre
+              x     -> VersionComponent_String x
+        in
+        thisComponent : splitVersion rest
 
 splitVersion_ :: MonadNix e t f m => NValue t f m -> m (NValue t f m)
 splitVersion_ v =

--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -1664,13 +1664,19 @@ partition_
   => NValue t f m
   -> NValue t f m
   -> m (NValue t f m)
-partition_ f = fromValue @[NValue t f m] >=> \l -> do
-  let match t = f `callFunc` t >>= fmap (, t) . fromValue
-  selection <- traverse match l
-  let (right, wrong) = partition fst selection
-  let makeSide       = nvList . fmap snd
-  toValue @(AttrSet (NValue t f m))
-    $ M.fromList [("right", makeSide right), ("wrong", makeSide wrong)]
+partition_ f nvlst =
+  do
+    l <- fromValue @[NValue t f m] nvlst
+    let
+      match t = fmap (, t) . fromValue =<< callFunc f t
+    selection <- traverse match l
+
+    let
+      (right, wrong) = partition fst selection
+      makeSide       = nvList . fmap snd
+
+    toValue @(AttrSet (NValue t f m))
+      $ M.fromList [("right", makeSide right), ("wrong", makeSide wrong)]
 
 currentSystem :: MonadNix e t f m => m (NValue t f m)
 currentSystem = do
@@ -1755,6 +1761,7 @@ appendContext x y =
         y
     )
     x
+
 newtype Prim m a = Prim { runPrim :: m a }
 
 -- | Types that support conversion to nix in a particular monad

--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -1303,16 +1303,22 @@ scopedImport asetArg pathArg =
       $ importPath @t @f @m path'
 
 getEnv_ :: MonadNix e t f m => NValue t f m -> m (NValue t f m)
-getEnv_ = fromValue >=> fromStringNoContext >=> \s -> do
-  mres <- getEnvVar (Text.unpack s)
-  toValue $ makeNixStringWithoutContext $ maybe mempty Text.pack mres
+getEnv_ v =
+  do
+    s <- fromStringNoContext =<< fromValue v
+    mres <- getEnvVar (Text.unpack s)
+
+    toValue $ makeNixStringWithoutContext $
+      maybe
+        mempty
+        Text.pack mres
 
 sort_
   :: MonadNix e t f m
   => NValue t f m
   -> NValue t f m
   -> m (NValue t f m)
-sort_ comp = fromValue >=> sortByM (cmp comp) >=> toValue
+sort_ comp = toValue <=< sortByM (cmp comp) <=< fromValue
  where
   cmp f a b = do
     isLessThan <- f `callFunc` a >>= (`callFunc` b)

--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -642,13 +642,16 @@ match_
   => NValue t f m
   -> NValue t f m
   -> m (NValue t f m)
-match_ pat str = fromValue pat >>= fromStringNoContext >>= \p ->
-  fromValue str >>= \ns ->
+match_ pat str =
   do
-        -- NOTE: Currently prim_match in nix/src/libexpr/primops.cc ignores the
-        -- context of its second argument. This is probably a bug but we're
-        -- going to preserve the behavior here until it is fixed upstream.
-        -- Relevant issue: https://github.com/NixOS/nix/issues/2547
+    s <- fromValue pat
+    p <- fromStringNoContext s
+    ns <- fromValue str
+
+    -- NOTE: 2018-11-19: Currently prim_match in nix/src/libexpr/primops.cc
+    -- ignores the context of its second argument. This is probably a bug but we're
+    -- going to preserve the behavior here until it is fixed upstream.
+    -- Relevant issue: https://github.com/NixOS/nix/issues/2547
     let
       s  = stringIgnoreContext ns
       re = makeRegex (encodeUtf8 p) :: Regex

--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -1320,18 +1320,19 @@ sort_
   -> m (NValue t f m)
 sort_ comp = toValue <=< sortByM (cmp comp) <=< fromValue
  where
-  cmp f a b = do
-    isLessThan <- f `callFunc` a >>= (`callFunc` b)
-    fromValue isLessThan >>=
+  cmp f a b =
+    do
+      isLessThan <- (`callFunc` b) =<< callFunc f a
       bool
         (do
-          isGreaterThan <- f `callFunc` b >>= (`callFunc` a)
+          isGreaterThan <- (`callFunc` a) =<< callFunc f b
           fromValue isGreaterThan <&>
             bool
               EQ
               GT
         )
         (pure LT)
+        =<< fromValue isLessThan
 
 lessThan
   :: MonadNix e t f m

--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -655,10 +655,11 @@ match_ pat str =
     let
       s  = stringIgnoreContext ns
       re = makeRegex (encodeUtf8 p) :: Regex
-      mkMatch t
-          | Text.null t = toValue ()
-          | -- Shorthand for Null
-            otherwise   = toValue $ makeNixStringWithoutContext t
+      mkMatch t =
+        bool
+          (toValue ()) -- Shorthand for Null
+          (toValue $ makeNixStringWithoutContext t)
+          (not $ Text.null t)
     maybe
       (pure $ nvConstant NNull)
       (\case

--- a/src/Nix/Convert.hs
+++ b/src/Nix/Convert.hs
@@ -66,8 +66,8 @@ Do not add these instances back!
 -- * FromValue
 
 class FromValue a m v where
-    fromValue    :: v -> m a
-    fromValueMay :: v -> m (Maybe a)
+  fromValue    :: v -> m a
+  fromValueMay :: v -> m (Maybe a)
 
 
 -- Please, hide these helper function from export, to be sure they get optimized away.

--- a/src/Nix/Effects/Basic.hs
+++ b/src/Nix/Effects/Basic.hs
@@ -132,7 +132,7 @@ findPathBy finder ls name = do
     mpath
  where
   go :: Maybe FilePath -> NValue t f m -> m (Maybe FilePath)
-  go p =
+  go mp =
     maybe
       (demand
         (fromValue >=> \(s :: HashMap Text (NValue t f m)) -> do
@@ -158,7 +158,7 @@ findPathBy finder ls name = do
         )
       )
       (const . pure . pure)
-      p
+      mp
 
   tryPath p (Just n) | n' : ns <- splitDirectories name, n == n' =
     finder $ p <///> joinPath ns

--- a/src/Nix/Exec.hs
+++ b/src/Nix/Exec.hs
@@ -153,6 +153,7 @@ currentPos = asks (view hasLens)
 
 wrapExprLoc :: SrcSpan -> NExprLocF r -> NExprLoc
 wrapExprLoc span x = Fix (Fix (NSym_ span "<?>") <$ x)
+{-# inline wrapExprLoc #-}
 
 --  2021-01-07: NOTE: This instance belongs to be beside MonadEval type class.
 -- Currently instance is stuck in orphanage between the requirements to be MonadEval, aka Eval stage, and emposed requirement to be MonadNix (Execution stage). MonadNix constraint tries to put the cart before horse and seems superflous, since Eval in Nix also needs and can throw exceptions. It is between `nverr` and `evalError`.

--- a/src/Nix/Expr/Types/Annotated.hs
+++ b/src/Nix/Expr/Types/Annotated.hs
@@ -137,6 +137,7 @@ stripAnn = annotated . getCompose
 nUnary :: Ann SrcSpan NUnaryOp -> NExprLoc -> NExprLoc
 nUnary (Ann s1 u) e1@(AnnE s2 _) = AnnE (s1 <> s2) (NUnary u e1)
 nUnary _          _              = error "nUnary: unexpected"
+{-# inline nUnary#-}
 
 nBinary :: Ann SrcSpan NBinaryOp -> NExprLoc -> NExprLoc -> NExprLoc
 nBinary (Ann s1 b) e1@(AnnE s2 _) e2@(AnnE s3 _) =
@@ -171,9 +172,11 @@ deltaInfo (SourcePos fp l c) = (pack fp, unPos l, unPos c)
 
 nNull :: NExprLoc
 nNull = Fix (Compose (Ann nullSpan (NConstant NNull)))
+{-# inline nNull #-}
 
 nullSpan :: SrcSpan
 nullSpan = SrcSpan nullPos nullPos
+{-# inline nullSpan #-}
 
 -- | Pattern systems for matching on NExprLocF constructions.
 

--- a/src/Nix/Standard.hs
+++ b/src/Nix/Standard.hs
@@ -144,6 +144,7 @@ instance
     :: StdThunk m
     -> ThunkId  m
   thunkId = thunkId . _stdCited . _stdThunk
+  {-# inline thunkId #-}
 
   thunk
     :: m (StdValue m)
@@ -284,6 +285,7 @@ newtype StandardTF r m a
 
 instance MonadTrans (StandardTF r) where
   lift = StandardTF . lift . lift
+  {-# inline lift #-}
 
 instance (MonadPutStr r, MonadPutStr m)
   => MonadPutStr (StandardTF r m)

--- a/src/Nix/Utils.hs
+++ b/src/Nix/Utils.hs
@@ -63,9 +63,11 @@ type AlgM f m a = f a -> m a
 -- | "Transform" here means a modification of a catamorphism.
 type Transform f a = (Fix f -> a) -> Fix f -> a
 
+{-# inline (<&>)#-}
 (<&>) :: Functor f => f a -> (a -> c) -> f c
 (<&>) = flip (<$>)
 
+{-# inline (??)#-}
 (??) :: Functor f => f (a -> b) -> a -> f b
 fab ?? a = fmap ($ a) fab
 
@@ -179,11 +181,15 @@ alterF f k m =
     )
     $ f $ M.lookup k m
 
+{-# inline bool #-}
 -- | From @Data.Bool ( bool )@.
 bool :: a -> a -> Bool -> a
-bool f _ False = f
-bool _ t True  = t
+bool f t b =
+  if b
+    then t
+    else f
 
+{-# inline list #-}
 -- | Analog for @bool@ or @maybe@, for list-like cons structures.
 list
   :: Foldable t
@@ -194,17 +200,22 @@ list e f l =
     e
     (null l)
 
+{-# inline free #-}
 -- | Lambda analog of @maybe@ or @either@ for Free monad.
 free :: (a -> b) -> (f (Free f a) -> b) -> Free f a -> b
-free fP _  (Pure a ) = fP a
-free _  fF (Free fa) = fF fa
+free fP fF fr =
+  case fr of
+    Pure a -> fP a
+    Free fa -> fF fa
 
+{-# inline ifTrue #-}
 ifTrue :: (Monoid a)
   => a -> Bool -> a
 ifTrue =
   bool
     mempty
 
+{-# inline ifFalse #-}
 ifFalse :: (Monoid a)
   => a  -> Bool  -> a
 ifFalse f =
@@ -212,13 +223,14 @@ ifFalse f =
     f
     mempty
 
+{-# inline ifJust #-}
 ifJust :: (Monoid b)
   => (a -> b)  -> Maybe a  -> b
 ifJust =
   maybe
     mempty
 
-
+{-# inline ifNothing #-}
 ifNothing  :: (Monoid b)
   => b  -> Maybe a  -> b
 ifNothing f =
@@ -226,12 +238,14 @@ ifNothing f =
     f
     mempty
 
+{-# inline ifRight #-}
 ifRight :: (Monoid c)
   => (b -> c) -> Either a b -> c
 ifRight =
   either
     mempty
 
+{-# inline ifLeft #-}
 ifLeft :: (Monoid c)
   => (a -> c) -> Either a b -> c
 ifLeft f =
@@ -239,12 +253,14 @@ ifLeft f =
     f
     mempty
 
+{-# inline ifFree #-}
 ifFree :: (Monoid b)
   => (f (Free f a) -> b) -> Free f a -> b
 ifFree =
   free
     mempty
 
+{-# inline ifPure #-}
 ifPure :: (Monoid b)
   => (a -> b) -> Free f a -> b
 ifPure f =

--- a/src/Nix/Value.hs
+++ b/src/Nix/Value.hs
@@ -21,12 +21,19 @@
 module Nix.Value
 where
 
-import           Control.Comonad                ( Comonad, extract )
+import           Control.Comonad                ( Comonad
+                                                , extract
+                                                )
 import           Control.Exception              ( Exception )
 import           Control.Monad                  ( (<=<) )
 import           Control.Monad.Free             ( Free(..)
-                                                , hoistFree, iter, iterM )
-import           Control.Monad.Trans.Class      ( MonadTrans, lift )
+                                                , hoistFree
+                                                , iter
+                                                , iterM
+                                                )
+import           Control.Monad.Trans.Class      ( MonadTrans
+                                                , lift
+                                                )
 import qualified Data.Aeson                    as Aeson
 import           Data.Functor.Classes           ( Show1
                                                 , liftShowsPrec
@@ -38,7 +45,8 @@ import           Data.Typeable                  ( Typeable )
 import           GHC.Generics                   ( Generic )
 import           Lens.Family2.Stock             ( _1 )
 import           Lens.Family2.TH                ( makeTraversals
-                                                , makeLenses )
+                                                , makeLenses
+                                                )
 import           Nix.Atoms
 import           Nix.Expr.Types
 import           Nix.Expr.Types.Annotated
@@ -187,15 +195,22 @@ hoistNValueF
   :: (forall x . m x -> n x)
   -> NValueF p m a
   -> NValueF p n a
-hoistNValueF lft = \case
-  NVConstantF a  -> NVConstantF a
-  NVStrF      s  -> NVStrF s
-  NVPathF     p  -> NVPathF p
-  NVListF     l  -> NVListF l
-  NVSetF     s p -> NVSetF s p
-  NVClosureF p g -> NVClosureF p (lft . g)
-  NVBuiltinF s g -> NVBuiltinF s (lft . g)
-
+hoistNValueF lft =
+  \case
+    -- Pass-through the:
+    --   [ NVConstantF a
+    --   , NVStrF s
+    --   , NVPathF p
+    --   , NVListF l
+    --   , NVSetF s p
+    --   ]
+    NVConstantF a  -> NVConstantF a
+    NVStrF      s  -> NVStrF s
+    NVPathF     p  -> NVPathF p
+    NVListF     l  -> NVListF l
+    NVSetF     s p -> NVSetF s p
+    NVBuiltinF s g -> NVBuiltinF s (lft . g)
+    NVClosureF p g -> NVClosureF p (lft . g)
 {-# inline hoistNValueF #-}
 
 -- * @__NValue'__@: forming the (F(A))
@@ -625,40 +640,43 @@ data ValueType
 
 -- | Determine type of a value
 valueType :: NValueF a m r -> ValueType
-valueType = \case
-  NVConstantF a -> case a of
-    NURI   _ -> TString NoContext
-    NInt   _ -> TInt
-    NFloat _ -> TFloat
-    NBool  _ -> TBool
-    NNull    -> TNull
-  NVStrF ns  ->
-    TString $
-      bool
-        NoContext
-        HasContext
-        $ stringHasContext ns
-  NVListF{}    -> TList
-  NVSetF{}     -> TSet
-  NVClosureF{} -> TClosure
-  NVPathF{}    -> TPath
-  NVBuiltinF{} -> TBuiltin
+valueType =
+  \case
+    NVConstantF a ->
+      case a of
+        NURI   _ -> TString NoContext
+        NInt   _ -> TInt
+        NFloat _ -> TFloat
+        NBool  _ -> TBool
+        NNull    -> TNull
+    NVStrF ns  ->
+      TString $
+        bool
+          NoContext
+          HasContext
+          (stringHasContext ns)
+    NVListF{}    -> TList
+    NVSetF{}     -> TSet
+    NVClosureF{} -> TClosure
+    NVPathF{}    -> TPath
+    NVBuiltinF{} -> TBuiltin
 
 
 -- | Describe type value
 describeValue :: ValueType -> String
-describeValue = \case
-  TInt               -> "an integer"
-  TFloat             -> "a float"
-  TBool              -> "a boolean"
-  TNull              -> "a null"
-  TString NoContext  -> "a string"
-  TString HasContext -> "a string with context"
-  TList              -> "a list"
-  TSet               -> "an attr set"
-  TClosure           -> "a function"
-  TPath              -> "a path"
-  TBuiltin           -> "a builtin function"
+describeValue =
+  \case
+    TInt               -> "an integer"
+    TFloat             -> "a float"
+    TBool              -> "a boolean"
+    TNull              -> "a null"
+    TString NoContext  -> "a string"
+    TString HasContext -> "a string with context"
+    TList              -> "a list"
+    TSet               -> "an attr set"
+    TClosure           -> "a function"
+    TPath              -> "a path"
+    TBuiltin           -> "a builtin function"
 
 
 showValueType :: (MonadThunk t m (NValue t f m), Comonad f)

--- a/src/Nix/Value.hs
+++ b/src/Nix/Value.hs
@@ -196,6 +196,7 @@ hoistNValueF lft = \case
   NVClosureF p g -> NVClosureF p (lft . g)
   NVBuiltinF s g -> NVBuiltinF s (lft . g)
 
+{-# inline hoistNValueF #-}
 
 -- * @__NValue'__@: forming the (F(A))
 
@@ -266,6 +267,7 @@ iterNValue'
   -> r
 iterNValue' k f = f . fmap (\a -> k a (iterNValue' k f))
 
+-- *** Utils
 
 -- | @hoistFree@: Back & forth hoisting in the monad stack
 hoistNValue'
@@ -276,7 +278,7 @@ hoistNValue'
   -> NValue' t f n a
 hoistNValue' run lft (NValue v) =
     NValue $ lmapNValueF (hoistNValue lft run) . hoistNValueF lft <$> v
-
+{-# inline hoistNValue' #-}
 
 -- ** Monad
 
@@ -455,6 +457,7 @@ iterNValueM transform k f =
     go (Pure x) = Pure <$> x
     go (Free fa) = Free <$> bindNValue' transform go fa
 
+-- *** Utils
 
 -- | @hoistFree@, Back & forth hoisting in the monad stack
 hoistNValue
@@ -464,7 +467,7 @@ hoistNValue
   -> NValue t f m
   -> NValue t f n
 hoistNValue run lft = hoistFree (hoistNValue' run lft)
-
+{-# inline hoistNValue #-}
 
 -- ** MonadTrans
 

--- a/src/Nix/Value.hs
+++ b/src/Nix/Value.hs
@@ -53,6 +53,7 @@ import           Nix.Expr.Types.Annotated
 import           Nix.String
 import           Nix.Thunk
 import           Nix.Utils
+import           Data.Eq.Deriving
 
 
 -- * @__NValueF__@: Base functor
@@ -223,7 +224,7 @@ newtype NValue' t f m a =
     -- | Applying F-algebra carrier (@NValue@) to the F-algebra Base functor data type (@NValueF@), forming the \( F(A)-> A \)).
     _nValue :: f (NValueF (NValue t f m) m a)
     }
-  deriving (Generic, Typeable, Functor, Foldable, Eq1)
+  deriving (Generic, Typeable, Functor, Foldable)
 
 instance (Comonad f, Show a) => Show (NValue' t f m a) where
   show (NValue (extract -> v)) = show v
@@ -617,6 +618,7 @@ pattern NVClosure x f <- Free (NVClosure' x f)
 pattern NVBuiltin name f <- Free (NVBuiltin' name f)
 
 
+
 -- * @TStringContext@
 
 data TStringContext = NoContext | HasContext
@@ -710,7 +712,6 @@ deriving instance (Comonad f, Show t) => Show (ValueFrame t f m)
 type MonadDataContext f (m :: * -> *)
   = (Comonad f, Applicative f, Traversable f, Monad m)
 
-
 -- * @MonadDataErrorContext@
 
 type MonadDataErrorContext t f m
@@ -718,15 +719,20 @@ type MonadDataErrorContext t f m
 
 instance MonadDataErrorContext t f m => Exception (ValueFrame t f m)
 
+-- * @instance Eq1 NValue'@
 
--- ** NValue' traversals, getter & setters
+-- TH derivable works only after MonadDataContext
+$(deriveEq1 ''NValue')
 
+
+-- * @NValue'@ traversals, getter & setters
 
 -- | Make traversals for Nix traversable structures.
 $(makeTraversals ''NValueF)
 
 -- | Make lenses for the Nix values
 $(makeLenses ''NValue')
+
 
 -- | Lens-generated getter-setter function for a traversable NValue' key-val structures.
 --   Nix value analogue of the @Data-Aeson-Lens@:@key :: AsValue t => Text -> Traversal' t Value@.


### PR DESCRIPTION
Code is literally the code from the `base: Data.Bool`, in there it is also does not
have inline directive:
```haskell
-- | From @Data.Bool ( bool )@.
bool :: a -> a -> Bool -> a
bool f _ False = f
bool _ t True  = t
```
Through the profiler noticed that `bool` was drawing resources.

GHC was not inlining the `bool`. Imagine that.

So we should probably carefully start giving the nudges to the GHC to inline simple non-recursive code.

These Utils functions are a definite start.

This actually seems to shave-off quite well.