### PR TITLE
class MonadValue: unflip `inform`

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -43,11 +43,13 @@
         furtherF  :: (m a -> m a) -> t   -> m t
       ```
       
-  * [(link)](https://github.com/haskell-nix/hnix/pull/862/files) `Nix.Value.Monad`: `class MonadValue v m`: `demand` unflipped the arguments into a classical order. As a result, `demand` now tail recurse.
+  * [(link)](https://github.com/haskell-nix/hnix/pull/862/files) [(link)](https://github.com/haskell-nix/hnix/pull/870/files) `Nix.Value.Monad`: `class MonadValue v m`: unflipped the arguments of methods into a classical order. As a result, `demand` now tail recurse.
       
       ```haskell
       demand :: (v -> m r) -> v -> m r
       -- was :: v -> (v -> m r) -> m r
+      inform :: (m v -> m v) -> v -> m v
+      -- was :: v -> (m v -> m v) -> m v
       ```
       
   * [(link)](https://github.com/haskell-nix/hnix/pull/863/files) `Nix.Normal`: `normalizeValue` removed first functional argument that was passing the function that did the thunk forcing. Now function provides the thunk forcing. Now to normalize simply use `normalizeValue v`.

--- a/src/Nix/Effects/Basic.hs
+++ b/src/Nix/Effects/Basic.hs
@@ -150,15 +150,16 @@ findPathBy finder ls name = do
                   (demand
                     (\ nvmns ->
                       do
-                      (\case
-                        Just (nsPfx :: NixString) ->
-                          let pfx = stringIgnoreContext nsPfx in
-                          tryPath path $ bool
-                            mempty
-                            (pure (Text.unpack pfx))
-                            (not $ Text.null pfx)
-                        _ -> tryPath path mempty
-                       ) =<< fromValueMay nvmns
+                        mns <- fromValueMay nvmns
+                        tryPath path $
+                          case mns of
+                            Just (nsPfx :: NixString) ->
+                              let pfx = stringIgnoreContext nsPfx in
+                              bool
+                                mempty
+                                (pure (Text.unpack pfx))
+                                (not $ Text.null pfx)
+                            _ -> mempty
                     )
                   )
                   (M.lookup "prefix" s)

--- a/src/Nix/Effects/Basic.hs
+++ b/src/Nix/Effects/Basic.hs
@@ -153,9 +153,9 @@ findPathBy finder ls name = do
                       (\case
                         Just (nsPfx :: NixString) ->
                           let pfx = stringIgnoreContext nsPfx in
-                          bool
-                            (tryPath path mempty)
-                            (tryPath path (pure (Text.unpack pfx)))
+                          tryPath path $ bool
+                            mempty
+                            (pure (Text.unpack pfx))
                             (not $ Text.null pfx)
                         _ -> tryPath path mempty
                        ) =<< fromValueMay nvmns

--- a/src/Nix/Effects/Basic.hs
+++ b/src/Nix/Effects/Basic.hs
@@ -144,25 +144,26 @@ findPathBy finder ls name = do
             demand
               (\ nvpath ->
                 do
-                (Path path) <- fromValue nvpath
-                maybe
-                  (tryPath path mempty)
-                  (demand
-                    (\ nvmns ->
-                      do
-                        mns <- fromValueMay nvmns
-                        tryPath path $
-                          case mns of
-                            Just (nsPfx :: NixString) ->
-                              let pfx = stringIgnoreContext nsPfx in
-                              bool
-                                mempty
-                                (pure (Text.unpack pfx))
-                                (not $ Text.null pfx)
-                            _ -> mempty
+                  (Path path) <- fromValue nvpath
+
+                  maybe
+                    (tryPath path mempty)
+                    (demand
+                      (\ nvmns ->
+                        do
+                          mns <- fromValueMay nvmns
+                          tryPath path $
+                            case mns of
+                              Just (nsPfx :: NixString) ->
+                                let pfx = stringIgnoreContext nsPfx in
+                                bool
+                                  mempty
+                                  (pure (Text.unpack pfx))
+                                  (not $ Text.null pfx)
+                              _ -> mempty
+                      )
                     )
-                  )
-                  (M.lookup "prefix" s)
+                    (M.lookup "prefix" s)
               )
               p
         )

--- a/src/Nix/Eval.hs
+++ b/src/Nix/Eval.hs
@@ -163,7 +163,7 @@ eval (NAbs    params body) = do
   scope <- currentScopes :: m (Scopes m v)
   evalAbs params $ \arg k -> withScopes scope $ do
     args <- buildArgument params arg
-    pushScope args (k (fmap (inform ?? withScopes scope) args) body)
+    pushScope args (k (fmap (inform (withScopes scope)) args) body)
 
 eval (NSynHole name) = synHole name
 

--- a/src/Nix/Expr/Types/Annotated.hs
+++ b/src/Nix/Expr/Types/Annotated.hs
@@ -33,7 +33,8 @@ import           Data.Aeson.TH
 import           Data.Binary                    ( Binary(..) )
 import           Data.Data
 import           Data.Eq.Deriving
-import           Data.Fix                       ( Fix(..), unfoldFix )
+import           Data.Fix                       ( Fix(..)
+                                                , unfoldFix )
 import           Data.Function                  ( on )
 import           Data.Functor.Compose
 import           Data.Hashable

--- a/src/Nix/Standard.hs
+++ b/src/Nix/Standard.hs
@@ -246,14 +246,14 @@ instance ( MonadAtomicRef m
       v
 
   inform
-    :: StdValue m
-    -> ( m (StdValue m)
+    :: ( m (StdValue m)
       -> m (StdValue m)
       )
+    -> StdValue m
     -> m (StdValue m)
   --  2021-02-27: NOTE: When swapping, switch to `further`.
-  inform (Pure t) f = Pure <$> furtherF f t
-  inform (Free v) f = Free <$> bindNValue' id (`inform` f) v
+  inform f (Pure t) = Pure <$> furtherF f t
+  inform f (Free v) = Free <$> bindNValue' id (inform f) v
 
 
 {------------------------------------------------------------------------}

--- a/src/Nix/Type/Infer.hs
+++ b/src/Nix/Type/Infer.hs
@@ -414,12 +414,12 @@ instance Monad m => MonadValue (Judgment s) (InferT s m) where
   demand = ($)
 
   inform
-    :: Judgment s
-    -> ( InferT s m (Judgment s)
+    :: ( InferT s m (Judgment s)
       -> InferT s m (Judgment s)
       )
+    -> Judgment s
     -> InferT s m (Judgment s)
-  inform j f = f (pure j)
+  inform f j = f (pure j)
 
 {-
 instance MonadInfer m

--- a/src/Nix/Value/Monad.hs
+++ b/src/Nix/Value/Monad.hs
@@ -8,4 +8,4 @@ class MonadValue v m where
   -- | If 'v' is a thunk, 'inform' allows us to modify the action to be
   --   performed by the thunk, perhaps by enriching it with scope info, for
   --   example.
-  inform :: v -> (m v -> m v) -> m v
+  inform :: (m v -> m v) -> v -> m v


### PR DESCRIPTION
Now `inform` also tail-recurse, but it is not really used a whole lot.

This is a preparation for `MonadValue{,F}` formation (#850).