### PR TITLE
Form MonadValueF

### DIFF
--- a/src/Nix/Lint.hs
+++ b/src/Nix/Lint.hs
@@ -289,6 +289,15 @@ instance (MonadThunkId m, MonadAtomicRef m, MonadCatch m)
   demand f (ST v)= (demand f) =<< force v
   demand f (SV v)= f (SV v)
 
+
+instance (MonadThunkId m, MonadAtomicRef m, MonadCatch m)
+  => MonadValueF (Symbolic m) m where
+
+  demandF :: (Symbolic m -> m r) -> Symbolic m -> m r
+  demandF f (ST v)= (demandF f) =<< force v
+  demandF f (SV v)= f (SV v)
+
+
 instance MonadLint e m => MonadEval (Symbolic m) m where
   freeVariable var = symerr $ "Undefined variable '" <> Text.unpack var <> "'"
 

--- a/src/Nix/Type/Infer.hs
+++ b/src/Nix/Type/Infer.hs
@@ -421,6 +421,25 @@ instance Monad m => MonadValue (Judgment s) (InferT s m) where
     -> InferT s m (Judgment s)
   inform f j = f (pure j)
 
+
+--  2021-02-22: NOTE: Seems like suporflous instance
+instance Monad m => MonadValueF (Judgment s) (InferT s m) where
+
+  demandF
+    :: ( Judgment s
+      -> InferT s m r)
+    -> Judgment s
+    -> InferT s m r
+  demandF = ($)
+
+  informF
+    :: ( InferT s m (Judgment s)
+      -> InferT s m (Judgment s)
+      )
+    -> Judgment s
+    -> InferT s m (Judgment s)
+  informF f j = f (pure j)
+
 {-
 instance MonadInfer m
   => MonadThunk (JThunkT s m) (InferT s m) (Judgment s) where

--- a/src/Nix/Value/Monad.hs
+++ b/src/Nix/Value/Monad.hs
@@ -2,6 +2,8 @@
 
 module Nix.Value.Monad where
 
+-- * @MonadValue@ - a main implementation class
+
 class MonadValue v m where
   defer :: m v -> m v
   demand :: (v -> m r) -> v -> m r
@@ -9,3 +11,10 @@ class MonadValue v m where
   --   performed by the thunk, perhaps by enriching it with scope info, for
   --   example.
   inform :: (m v -> m v) -> v -> m v
+
+
+-- * @MonadValueF@ - a Kleisli-able customization class
+
+class MonadValueF v m where
+  demandF :: (v -> m r) -> v -> m r
+  informF :: (m v -> m v) -> v -> m v


### PR DESCRIPTION
Currenly simply duplicates, but this would allow me to `demand -> demandF` first and get working code, and so then working on switching to new `demand` would be easier, and this safe path also allows to use old version, `demandF`, in a couple of places if something, until everything figures-out.

Towards #850.