### PR TITLE
New `demand` implementation; treewide tmp migration demand(->F)

### DIFF
--- a/main/Main.hs
+++ b/main/Main.hs
@@ -214,7 +214,7 @@ main = do
             _                              -> (True, True)
 
           forceEntry k v =
-            catch (pure <$> demand pure v) $ \(NixException frames) -> do
+            catch (pure <$> demandF pure v) $ \(NixException frames) -> do
               liftIO
                 .   putStrLn
                 .   ("Exception forcing " <>)

--- a/main/Repl.hs
+++ b/main/Repl.hs
@@ -27,7 +27,7 @@ import           Nix                     hiding ( exec
                                                 )
 import           Nix.Scope
 import           Nix.Utils
-import           Nix.Value.Monad                ( demand )
+import           Nix.Value.Monad                ( demandF )
 
 import qualified Data.List
 import qualified Data.Maybe
@@ -340,7 +340,7 @@ completion = System.Console.Repline.Prefix
 -- | Main completion function
 --
 -- Heavily inspired by Dhall Repl, with `algebraicComplete`
--- adjusted to monadic variant able to `demand` thunks.
+-- adjusted to monadic variant able to `demandF` thunks.
 completeFunc
   :: forall e t f m . (MonadNix e t f m, MonadIO m)
   => String
@@ -399,7 +399,7 @@ completeFunc reversedPrev word
               f:fs ->
                 maybe
                   (pure mempty)
-                  (demand (\e' -> (fmap . fmap) (("." <> f) <>) $ algebraicComplete fs e'))
+                  (demandF (\e' -> (fmap . fmap) (("." <> f) <>) $ algebraicComplete fs e'))
                   (Data.HashMap.Lazy.lookup f m)
 
       in case val of

--- a/src/Nix.hs
+++ b/src/Nix.hs
@@ -115,7 +115,7 @@ evaluateExpression mpath evaluator handler expr = do
     (second mkStr)
     (argstr opts)
   evaluator mpath expr >>= \f ->
-    demand
+    demandF
       (\f' ->
         processResult handler =<<
           case f' of
@@ -149,7 +149,7 @@ processResult h val = do
   go :: [Text.Text] -> NValue t f m -> m a
   go [] v = h v
   go ((Text.decimal -> Right (n,"")) : ks) v =
-    demand
+    demandF
       (\case
         NVList xs ->
           list
@@ -161,7 +161,7 @@ processResult h val = do
       )
       v
   go (k : ks) v =
-    demand
+    demandF
       (\case
         NVSet xs _ ->
           maybe

--- a/src/Nix/Convert.hs
+++ b/src/Nix/Convert.hs
@@ -107,31 +107,31 @@ type Convertible e t f m
   = (Framed e m, MonadDataErrorContext t f m, MonadThunk t m (NValue t f m))
 
 instance ( Convertible e t f m
-         , MonadValue (NValue t f m) m
+         , MonadValueF (NValue t f m) m
          , FromValue a m (NValue' t f m (NValue t f m))
          )
   => FromValue a m (NValue t f m) where
 
   fromValueMay =
-    demand $
+    demandF $
       free
         (fromValueMay <=< force)
         fromValueMay
 
   fromValue =
-    demand $
+    demandF $
       free
         (fromValue <=< force)
         fromValue
 
 instance ( Convertible e t f m
-         , MonadValue (NValue t f m) m
+         , MonadValueF (NValue t f m) m
          , FromValue a m (Deeper (NValue' t f m (NValue t f m)))
          )
   => FromValue a m (Deeper (NValue t f m)) where
 
   fromValueMay (Deeper v) =
-    demand
+    demandF
       (free
         ((fromValueMay . Deeper) <=< force)
         (fromValueMay . Deeper)
@@ -139,7 +139,7 @@ instance ( Convertible e t f m
       v
 
   fromValue (Deeper v) =
-    demand
+    demandF
       (free
         ((fromValue . Deeper) <=< force)
         (fromValue . Deeper)
@@ -203,7 +203,7 @@ instance Convertible e t f m
   fromValue = fromMayToValue TFloat
 
 instance ( Convertible e t f m
-         , MonadValue (NValue t f m) m
+         , MonadValueF (NValue t f m) m
          , MonadEffects t f m
          )
   => FromValue NixString m (NValue' t f m (NValue t f m)) where
@@ -239,7 +239,7 @@ newtype Path = Path { getPath :: FilePath }
     deriving Show
 
 instance ( Convertible e t f m
-         , MonadValue (NValue t f m) m
+         , MonadValueF (NValue t f m) m
          )
   => FromValue Path m (NValue' t f m (NValue t f m)) where
 

--- a/src/Nix/Effects/Derivation.hs
+++ b/src/Nix/Effects/Derivation.hs
@@ -322,7 +322,7 @@ buildDerivationWithContext drvAttrs = do
         bool
           (pure drvAttrs)
           (M.mapMaybe id <$> forM drvAttrs
-            (demand'
+            (demandF'
               (pure . \case
                 NVConstant NNull -> Nothing
                 value -> pure value
@@ -350,8 +350,8 @@ buildDerivationWithContext drvAttrs = do
 
     -- common functions, lifted to WithStringContextT
 
-    demand' :: (NValue t f m -> WithStringContextT m a) -> NValue t f m -> WithStringContextT m a
-    demand' f v = join $ lift $ demand (pure . f) v
+    demandF' :: (NValue t f m -> WithStringContextT m a) -> NValue t f m -> WithStringContextT m a
+    demandF' f v = join $ lift $ demandF (pure . f) v
 
     fromValue' :: (FromValue a m (NValue' t f m (NValue t f m)), MonadNix e t f m) => NValue t f m -> WithStringContextT m a
     fromValue' = lift . fromValue

--- a/src/Nix/Eval.hs
+++ b/src/Nix/Eval.hs
@@ -82,6 +82,7 @@ type MonadNixEval v m
   = ( MonadEval v m
   , Scoped v m
   , MonadValue v m
+  , MonadValueF v m
   , MonadFix m
   , ToValue Bool m v
   , ToValue [v] m v
@@ -117,7 +118,7 @@ eval (NSym var       ) = do
   mres <- lookupVar var
   maybe
     (freeVariable var)
-    (demand (evaledSym var))
+    (demandF (evaledSym var))
     mres
 
 eval (NConstant    x      ) = evalConstant x
@@ -177,7 +178,7 @@ evalWithAttrSet aset body = do
   -- computed once.
   scope <- currentScopes :: m (Scopes m v)
   s     <- defer $ withScopes scope aset
-  let s' = demand (fmap fst . fromValue @(AttrSet v, AttrSet SourcePos)) s
+  let s' = demandF (fmap fst . fromValue @(AttrSet v, AttrSet SourcePos)) s
   pushWeakScope s' body
 
 attrSetAlter
@@ -198,7 +199,7 @@ attrSetAlter (k : ks) pos m p val =
       (\x ->
         do
           (st, sp) <- fromValue @(AttrSet v, AttrSet SourcePos) =<< x
-          recurse (demand pure <$> st) sp
+          recurse (demandF pure <$> st) sp
       )
       (M.lookup k m)
     )
@@ -269,7 +270,7 @@ evalBinds recursive binds = do
     finalValue >>= fromValue >>= \(o', p') ->
           -- jww (2018-05-09): What to do with the key position here?
                                               pure $ fmap
-      (\(k, v) -> ([k], fromMaybe pos (M.lookup k p'), demand pure v))
+      (\(k, v) -> ([k], fromMaybe pos (M.lookup k p'), demandF pure v))
       (M.toList o')
 
   go _ (NamedVar pathExpr finalValue pos) = do
@@ -314,7 +315,7 @@ evalBinds recursive binds = do
                 ms
             maybe
               (attrMissing (key :| []) Nothing)
-              (demand pure)
+              (demandF pure)
               mv
           )
         )
@@ -349,8 +350,8 @@ evalSelect aset attr = do
   extract x path@(k :| ks) = fromValueMay x >>= \case
     Just (s :: AttrSet v, p :: AttrSet SourcePos)
       | Just t <- M.lookup k s -> case ks of
-        []     -> pure $ pure $ demand pure t
-        y : ys -> demand (extract ?? (y :| ys)) t
+        []     -> pure $ pure $ demandF pure t
+        y : ys -> demandF (extract ?? (y :| ys)) t
       | otherwise -> Left . (, path) <$> toValue (s, p)
     Nothing -> pure $ Left (x, path)
 

--- a/src/Nix/Json.hs
+++ b/src/Nix/Json.hs
@@ -43,11 +43,11 @@ nvalueToJSON = \case
   NVList l ->
     A.Array
       .   V.fromList
-      <$> traverse (join . lift . demand (pure . nvalueToJSON)) l
+      <$> traverse (join . lift . demandF (pure . nvalueToJSON)) l
   NVSet m _ ->
     maybe
-      (A.Object <$> traverse (join . lift . demand (pure . nvalueToJSON)) m)
-      (join . lift . demand (pure . nvalueToJSON))
+      (A.Object <$> traverse (join . lift . demandF (pure . nvalueToJSON)) m)
+      (join . lift . demandF (pure . nvalueToJSON))
       (HM.lookup "outPath" m)
   NVPath p -> do
     fp <- lift $ unStorePath <$> addPath p

--- a/src/Nix/Standard.hs
+++ b/src/Nix/Standard.hs
@@ -221,12 +221,13 @@ instance
 
 -- * @instance MonadValue (StdValue m) m@
 
-instance ( MonadAtomicRef m
-         , MonadCatch m
-         , Typeable m
-         , MonadReader (Context m (StdValue m)) m
-         , MonadThunkId m
-         )
+instance
+  ( MonadAtomicRef m
+  , MonadCatch m
+  , Typeable m
+  , MonadReader (Context m (StdValue m)) m
+  , MonadThunkId m
+  )
   => MonadValue (StdValue m) m where
   defer
     :: m (StdValue m)
@@ -234,15 +235,12 @@ instance ( MonadAtomicRef m
   defer = fmap pure . thunk
 
   demand
-    :: ( StdValue m
-      -> m r
-      )
-    -> StdValue m
-    -> m r
-  demand f v =
+    :: StdValue m
+    -> m (StdValue m)
+  demand v =
     free
-      ((demand f) <=< force)
-      (const $ f v)
+      (demand <=< force)
+      (const $ pure v)
       v
 
   inform
@@ -258,12 +256,13 @@ instance ( MonadAtomicRef m
 
 -- * @instance MonadValueF (StdValue m) m@
 
-instance ( MonadAtomicRef m
-         , MonadCatch m
-         , Typeable m
-         , MonadReader (Context m (StdValue m)) m
-         , MonadThunkId m
-         )
+instance
+  ( MonadAtomicRef m
+  , MonadCatch m
+  , Typeable m
+  , MonadReader (Context m (StdValue m)) m
+  , MonadThunkId m
+  )
   => MonadValueF (StdValue m) m where
 
   demandF

--- a/src/Nix/Value/Monad.hs
+++ b/src/Nix/Value/Monad.hs
@@ -6,7 +6,7 @@ module Nix.Value.Monad where
 
 class MonadValue v m where
   defer :: m v -> m v
-  demand :: (v -> m r) -> v -> m r
+  demand :: v -> m v
   -- | If 'v' is a thunk, 'inform' allows us to modify the action to be
   --   performed by the thunk, perhaps by enriching it with scope info, for
   --   example.


### PR DESCRIPTION
This keeps project working, and allows to go though gradual manual migraiton of
97 uses of `demand` over the code.