### PR TITLE
Migrating code to new demand implementation

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -43,13 +43,19 @@
         furtherF  :: (m a -> m a) -> t   -> m t
       ```
       
-  * [(link)](https://github.com/haskell-nix/hnix/pull/862/files) [(link)](https://github.com/haskell-nix/hnix/pull/870/files) `Nix.Value.Monad`: `class MonadValue v m`: unflipped the arguments of methods into a classical order. As a result, `demand` now tail recurse.
+  * [(link)](https://github.com/haskell-nix/hnix/pull/862/files) [(link)](https://github.com/haskell-nix/hnix/pull/870/files) [(link)](https://github.com/haskell-nix/hnix/pull/871/files)  [(link)](https://github.com/haskell-nix/hnix/pull/872/files) [(link)](https://github.com/haskell-nix/hnix/pull/873/files) `Nix.Value.Monad`: `class MonadValue v m`: instances became specialized, Kleisli versions unflipped the arguments of methods into a classical order and moved to the `class MonadValueF`. As a result, `demand` now gets optimized by GHC and also tail recurse. Please, use `f =<< demand t`, or just use `demandF`, while `demandF` in fact just `kleisli =<< demand t`.
       
       ```haskell
-      demand :: (v -> m r) -> v -> m r
-      -- was :: v -> (v -> m r) -> m r
-      inform :: (m v -> m v) -> v -> m v
-      -- was :: v -> (m v -> m v) -> m v
+      class MonadValue v m where
+      
+        demand :: v       ->         m v
+        -- was :: v -> (v -> m r) -> m r
+      
+      class MonadValueF v m where
+        demandF :: (v -> m r) -> v -> m r
+        -- was :: v -> (v -> m r) -> m r
+        informF :: (m v -> m v) -> v -> m v
+        -- was :: v -> (m v -> m v) -> m v
       ```
       
   * [(link)](https://github.com/haskell-nix/hnix/pull/863/files) `Nix.Normal`: `normalizeValue` removed first functional argument that was passing the function that did the thunk forcing. Now function provides the thunk forcing. Now to normalize simply use `normalizeValue v`.

--- a/main/Main.hs
+++ b/main/Main.hs
@@ -214,17 +214,18 @@ main = do
             _                              -> (True, True)
 
           forceEntry k v =
-            catch (pure <$> demandF pure v) $ \(NixException frames) -> do
-              liftIO
-                .   putStrLn
-                .   ("Exception forcing " <>)
-                .   (k <>)
-                .   (": " <>)
-                .   show
-                =<< renderFrames @(StdValue (StandardT (StdIdT IO)))
-                      @(StdThunk (StandardT (StdIdT IO)))
-                      frames
-              pure Nothing
+            catch (pure <$> (pure =<< demand v)) $ \(NixException frames) ->
+              do
+                liftIO
+                  . putStrLn
+                  . ("Exception forcing " <>)
+                  . (k <>)
+                  . (": " <>)
+                  . show
+                  =<< renderFrames @(StdValue (StandardT (StdIdT IO)))
+                        @(StdThunk (StandardT (StdIdT IO)))
+                        frames
+                pure Nothing
 
   reduction path mp x = do
     eres <- Nix.withNixContext mp

--- a/src/Nix/Convert.hs
+++ b/src/Nix/Convert.hs
@@ -107,44 +107,40 @@ type Convertible e t f m
   = (Framed e m, MonadDataErrorContext t f m, MonadThunk t m (NValue t f m))
 
 instance ( Convertible e t f m
-         , MonadValueF (NValue t f m) m
+         , MonadValue (NValue t f m) m
          , FromValue a m (NValue' t f m (NValue t f m))
          )
   => FromValue a m (NValue t f m) where
 
   fromValueMay =
-    demandF $
-      free
-        (fromValueMay <=< force)
-        fromValueMay
+    free
+      (fromValueMay <=< force)
+      fromValueMay
+      <=< demand
 
   fromValue =
-    demandF $
-      free
-        (fromValue <=< force)
-        fromValue
+    free
+      (fromValue <=< force)
+      fromValue
+      <=< demand
 
 instance ( Convertible e t f m
-         , MonadValueF (NValue t f m) m
+         , MonadValue (NValue t f m) m
          , FromValue a m (Deeper (NValue' t f m (NValue t f m)))
          )
   => FromValue a m (Deeper (NValue t f m)) where
 
   fromValueMay (Deeper v) =
-    demandF
-      (free
-        ((fromValueMay . Deeper) <=< force)
-        (fromValueMay . Deeper)
-      )
-      v
+    free
+      ((fromValueMay . Deeper) <=< force)
+      (fromValueMay . Deeper)
+      =<< demand v
 
   fromValue (Deeper v) =
-    demandF
-      (free
-        ((fromValue . Deeper) <=< force)
-        (fromValue . Deeper)
-      )
-      v
+    free
+      ((fromValue . Deeper) <=< force)
+      (fromValue . Deeper)
+      =<< demand v
 
 instance Convertible e t f m
   => FromValue () m (NValue' t f m (NValue t f m)) where
@@ -203,7 +199,7 @@ instance Convertible e t f m
   fromValue = fromMayToValue TFloat
 
 instance ( Convertible e t f m
-         , MonadValueF (NValue t f m) m
+         , MonadValue (NValue t f m) m
          , MonadEffects t f m
          )
   => FromValue NixString m (NValue' t f m (NValue t f m)) where
@@ -239,7 +235,7 @@ newtype Path = Path { getPath :: FilePath }
     deriving Show
 
 instance ( Convertible e t f m
-         , MonadValueF (NValue t f m) m
+         , MonadValue (NValue t f m) m
          )
   => FromValue Path m (NValue' t f m (NValue t f m)) where
 

--- a/src/Nix/Effects/Derivation.hs
+++ b/src/Nix/Effects/Derivation.hs
@@ -351,7 +351,7 @@ buildDerivationWithContext drvAttrs = do
     -- common functions, lifted to WithStringContextT
 
     demandF' :: (NValue t f m -> WithStringContextT m a) -> NValue t f m -> WithStringContextT m a
-    demandF' f v = join $ lift $ demandF (pure . f) v
+    demandF' f v = join $ lift $ f <$> demand v
 
     fromValue' :: (FromValue a m (NValue' t f m (NValue t f m)), MonadNix e t f m) => NValue t f m -> WithStringContextT m a
     fromValue' = lift . fromValue

--- a/src/Nix/Standard.hs
+++ b/src/Nix/Standard.hs
@@ -273,7 +273,7 @@ instance
     -> m r
   demandF f v =
     free
-      ((demandF f) <=< force)
+      (f <=< demand <=< force)
       (const $ f v)
       v
 


### PR DESCRIPTION
 - :heavy_check_mark: Gradual switches where posible.
 - :heavy_check_mark: All uses of it, including all `Builtins` are processed.
 - :heavy_check_mark: A couplr of several level `do` blocks became 1.
 - :heavy_check_mark: Several of the monadic binds became functors.
 - :heavy_check_mark: ChangeLog (also would be rewritten couple of times by the further change updates)
 
This almost fully closes the https://github.com/haskell-nix/hnix/issues/850

What is further left there is basically to move Kleisli out of `inform`, `informF` is for that, then do the includes of the function uses inside the `do` blocks and fold the lambdas, binds and `do` blocks further. With the current lispy sectioning, it is easy and semi-automatic.