### PR TITLE
(Text.unpack -> toString), (Text.pack -> toText)

### DIFF
--- a/main/Main.hs
+++ b/main/Main.hs
@@ -22,7 +22,6 @@ import qualified Data.Map                      as Map
 import           Data.Maybe                     ( fromJust )
 import qualified Data.String                   as String
 import           Data.Time
-import qualified Data.Text                     as Text
 import qualified Data.Text.IO                  as Text
 import           Nix
 import           Nix.Convert

--- a/main/Main.hs
+++ b/main/Main.hs
@@ -158,7 +158,7 @@ main = do
    where
     printer
       | finder opts = findAttrs <=< fromValue @(AttrSet (StdValue (StandardT (StdIdT IO))))
-      | xml    opts = liftIO . putStrLn . Text.unpack . stringIgnoreContext . toXML <=< normalForm
+      | xml    opts = liftIO . putStrLn . toString . stringIgnoreContext . toXML <=< normalForm
       | json   opts = liftIO . Text.putStrLn . stringIgnoreContext <=< nvalueToJSONNixString
       | strict opts = liftIO . print . prettyNValue <=< normalForm
       | values opts = liftIO . print . prettyNValueProv <=< removeEffects
@@ -173,7 +173,7 @@ main = do
           xs <- forM (sortOn fst (M.toList s)) $ \(k, nv) ->
             free
               (\ (StdThunk (extract -> Thunk _ _ ref)) -> do
-                let path         = prefix <> Text.unpack k
+                let path         = prefix <> toString k
                     (_, descend) = filterEntry path k
                 val <- readVar @(StandardT (StdIdT IO)) ref
                 case val of
@@ -184,7 +184,7 @@ main = do
               (\ v -> pure (k, pure (Free v)))
               nv
           for_ xs $ \(k, mv) -> do
-            let path              = prefix <> Text.unpack k
+            let path              = prefix <> toString k
                 (report, descend) = filterEntry path k
             when report $ do
               liftIO $ putStrLn path

--- a/main/Repl.hs
+++ b/main/Repl.hs
@@ -261,7 +261,7 @@ cmd
   -> Repl e t f m ()
 cmd source =
   do
-    mVal <- exec True (Text.pack source)
+    mVal <- exec True $ toText source
     maybe
       (pure ())
       printValue
@@ -321,7 +321,7 @@ typeof args = do
   traverse_ printValueType mVal
 
  where
-  line = Text.pack args
+  line = toText args
   printValueType val =
     do
       s <- lift . lift . showValueType $ val
@@ -380,7 +380,7 @@ completeFunc reversedPrev word
     listFiles word
 
   -- Attributes of sets in REPL context
-  | var : subFields <- Text.split (== '.') (Text.pack word) , not $ null subFields =
+  | var : subFields <- Text.split (== '.') (toText word) , not $ null subFields =
     do
       s <- get
       maybe

--- a/main/Repl.hs
+++ b/main/Repl.hs
@@ -116,7 +116,7 @@ main' iniVal =
               optMatcher command options arguments
           x -> cmd $ String.unwords x
         )
-        (String.words . Text.unpack <$> Text.lines f)
+        (String.words . toString <$> Text.lines f)
 
   handleMissing e
     | Error.isDoesNotExistError e = pure ""
@@ -180,8 +180,8 @@ initState mIni = do
     evalText :: (MonadNix e t f m) => Text -> m (NValue t f m)
     evalText expr =
       either
-        (\ e -> fail $ "Impossible happened: Unable to parse expression - '" <> Text.unpack expr <> "' fail was " <> show e)
-        (\ e -> do evalExprLoc e)
+        (\ e -> fail $ toString $ "Impossible happened: Unable to parse expression - '" <> expr <> "' fail was " <> show e)
+        evalExprLoc
         (parseNixTextLoc expr)
 
 type Repl e t f m = HaskelineT (StateT (IState t f m) m)
@@ -288,7 +288,7 @@ browse :: (MonadNix e t f m, MonadIO m)
 browse _ = do
   st <- get
   for_ (Data.HashMap.Lazy.toList $ replCtx st) $ \(k, v) -> do
-    liftIO $ putStr $ Text.unpack $ k <> " = "
+    liftIO $ putStr $ toString $ k <> " = "
     printValue v
 
 -- | @:load@ command
@@ -388,7 +388,7 @@ completeFunc reversedPrev word
         (\ binding ->
           do
             candidates <- lift $ algebraicComplete subFields binding
-            pure $ notFinished <$> listCompletion (Text.unpack . (var <>) <$> candidates)
+            pure $ notFinished <$> listCompletion (toString . (var <>) <$> candidates)
         )
         (Data.HashMap.Lazy.lookup var (replCtx s))
 
@@ -402,8 +402,8 @@ completeFunc reversedPrev word
 
       pure $ listCompletion
         $ ["__includes"]
-        <> (Text.unpack <$> contextKeys)
-        <> (Text.unpack <$> shortBuiltins)
+        <> (toString <$> contextKeys)
+        <> (toString <$> shortBuiltins)
 
   where
     listCompletion = fmap simpleCompletion . filter (word `List.isPrefixOf`)

--- a/src/Nix.hs
+++ b/src/Nix.hs
@@ -156,12 +156,12 @@ processResult h val = do
     (\case
       NVSet xs _ ->
         maybe
-          (errorWithoutStackTrace $ "Set does not contain key '" <> Text.unpack k <> "'")
+          (errorWithoutStackTrace $ toString $ "Set does not contain key '" <> k <> "'")
           (list
             h
             go
             ks
           )
           (M.lookup k xs)
-      _ -> errorWithoutStackTrace $ "Expected a set for selector '" <> Text.unpack k <> "', but got: " <> show v
+      _ -> errorWithoutStackTrace $ toString $ "Expected a set for selector '" <> k <> "', but got: " <> show v
     ) =<< demand v

--- a/src/Nix/Atoms.hs
+++ b/src/Nix/Atoms.hs
@@ -11,8 +11,6 @@ import           Codec.Serialise                ( Serialise )
 
 import           Data.Data                      ( Data)
 import           Data.Fixed                     ( mod' )
-import           Data.Text                      ( pack
-                                                )
 import           Data.Binary                    ( Binary )
 import           Data.Aeson.Types               ( FromJSON
                                                 , ToJSON
@@ -63,11 +61,14 @@ instance FromJSON NAtom
 -- | Translate an atom into its Nix representation.
 atomText :: NAtom -> Text
 atomText (NURI   t) = t
-atomText (NInt   i) = pack (show i)
-atomText (NFloat f) = pack (showNixFloat f)
+atomText (NInt   i) = show i
+atomText (NFloat f) = showNixFloat f
  where
-  showNixFloat x
-    | x `mod'` 1 /= 0 = show x
-    | otherwise       = show (truncate x :: Int)
+  showNixFloat :: Float -> Text
+  showNixFloat x =
+    bool
+      (show x)
+      (show (truncate x :: Int))
+      (x `mod'` 1 == 0)
 atomText (NBool  b) = if b then "true" else "false"
 atomText NNull      = "null"

--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -28,7 +28,6 @@ module Nix.Builtins
 where
 
 import           Prelude                 hiding ( traceM
-                                                , toString
                                                 , anyM
                                                 , allM
                                                 )
@@ -253,7 +252,7 @@ builtinsList = sequence
   , add2 Normal   "toFile"           toFile
   , add  Normal   "toJSON"           prim_toJSON
   , add  Normal   "toPath"           toPath
-  , add  TopLevel "toString"         toString
+  , add  TopLevel "toString"         toString_
   , add  Normal   "toXML"            toXML_
   , add2 TopLevel "trace"            trace_
   , add0 Normal   "true"             (pure $ nvConstant $ NBool True)
@@ -271,7 +270,7 @@ builtinsList = sequence
   arity2 f = ((Prim . pure) .) . f
 
   mkThunk :: Text -> m (NValue t f m) -> m (NValue t f m)
-  mkThunk n = defer . withFrame Info (ErrorCall $ "While calling builtin " <> Text.unpack n <> "\n")
+  mkThunk n = defer . withFrame Info (ErrorCall $ "While calling builtin " <> toString n <> "\n")
   wrap :: BuiltinType -> Text -> v -> Builtin v
   wrap t n f = Builtin t (n, f)
   mkBuiltin :: BuiltinType -> Text -> m (NValue t f m) -> m (Builtin (NValue t f m))
@@ -291,7 +290,7 @@ builtinsList = sequence
       -> m (NValue t f m)
       )
     -> m (Builtin (NValue t f m))
-  add  t n v = mkBuiltin t n (builtin (Text.unpack n) v)
+  add  t n v = mkBuiltin t n (builtin (toString n) v)
 
   add2
     :: BuiltinType
@@ -301,7 +300,7 @@ builtinsList = sequence
       -> m (NValue t f m)
       )
     -> m (Builtin (NValue t f m))
-  add2 t n v = mkBuiltin t n (builtin2 (Text.unpack n) v)
+  add2 t n v = mkBuiltin t n (builtin2 (toString n) v)
 
   add3
     :: BuiltinType
@@ -312,7 +311,7 @@ builtinsList = sequence
       -> m (NValue t f m)
       )
     -> m (Builtin (NValue t f m))
-  add3 t n v = mkBuiltin t n (builtin3 (Text.unpack n) v)
+  add3 t n v = mkBuiltin t n (builtin3 (toString n) v)
 
   add'
     :: forall a
@@ -321,7 +320,7 @@ builtinsList = sequence
     -> Text
     -> a
     -> m (Builtin (NValue t f m))
-  add' t n v = mkBuiltin t n (toBuiltin (Text.unpack n) v)
+  add' t n v = mkBuiltin t n (toBuiltin (toString n) v)
 
 
 -- * Primops
@@ -394,8 +393,8 @@ foldNixPath f z =
       ("://" `Text.isInfixOf` x)
   go (x, ty) rest =
     case Text.splitOn "=" x of
-      [p] -> f (Text.unpack p) mempty ty rest
-      [n, p] -> f (Text.unpack p) (pure (Text.unpack n)) ty rest
+      [p] -> f (toString p) mempty ty rest
+      [n, p] -> f (toString p) (pure (toString n)) ty rest
       _ -> throwError $ ErrorCall $ "Unexpected entry in NIX_PATH: " <> show x
 
 nixPath :: MonadNix e t f m => m (NValue t f m)
@@ -416,8 +415,8 @@ nixPath = fmap nvList $ flip foldNixPath mempty $
  where
   mkNvStr = nvStr . makeNixStringWithoutContext . Text.pack
 
-toString :: MonadNix e t f m => NValue t f m -> m (NValue t f m)
-toString = toValue <=< coerceToString callFunc DontCopyToStore CoerceAny
+toString_ :: MonadNix e t f m => NValue t f m -> m (NValue t f m)
+toString_ = toValue <=< coerceToString callFunc DontCopyToStore CoerceAny
 
 hasAttr
   :: forall e t f m
@@ -435,7 +434,7 @@ hasAttr x y =
 attrsetGet :: MonadNix e t f m => Text -> AttrSet (NValue t f m) -> m (NValue t f m)
 attrsetGet k s =
   maybe
-    (throwError $ ErrorCall $ "Attribute '" <> Text.unpack k <> "' required")
+    (throwError $ ErrorCall $ "Attribute '" <> toString k <> "' required")
     pure
     (M.lookup k s)
 
@@ -613,7 +612,7 @@ splitVersion s =
         let (digits, rest) = Text.span isDigit s
         in
         VersionComponent_Number
-            (fromMaybe (error $ "splitVersion: couldn't parse " <> show digits) $ readMaybe $ Text.unpack digits) : splitVersion rest
+            (fromMaybe (error $ "splitVersion: couldn't parse " <> show digits) $ readMaybe $ toString digits) : splitVersion rest
 
       | otherwise ->
         let
@@ -900,7 +899,7 @@ baseNameOf :: MonadNix e t f m => NValue t f m -> m (NValue t f m)
 baseNameOf x = do
   ns <- coerceToString callFunc DontCopyToStore CoerceStringy x
   pure $ nvStr $
-    modifyNixContents (Text.pack . takeFileName . Text.unpack) ns
+    modifyNixContents (Text.pack . takeFileName . toString) ns
 
 bitAnd
   :: forall e t f m
@@ -953,7 +952,7 @@ dirOf nvdir =
     dir <- demand nvdir
 
     case dir of
-      NVStr ns -> pure $ nvStr $ modifyNixContents (Text.pack . takeDirectory . Text.unpack) ns
+      NVStr ns -> pure $ nvStr $ modifyNixContents (Text.pack . takeDirectory . toString) ns
       NVPath path -> pure $ nvPath $ takeDirectory path
       v -> throwError $ ErrorCall $ "dirOf: expected string or path, got " <> show v
 
@@ -1230,8 +1229,8 @@ toFile name s =
     s'    <- fromValue s
     mres  <-
       toFile_
-        (Text.unpack name')
-        (Text.unpack $ stringIgnoreContext s')
+        (toString name')
+        (toString $ stringIgnoreContext s')
 
     let
       t  = Text.pack $ unStorePath mres
@@ -1249,7 +1248,7 @@ pathExists_ nvpath =
 
     case path of
       NVPath p  -> toValue =<< pathExists p
-      NVStr  ns -> toValue =<< pathExists (Text.unpack $ stringIgnoreContext ns)
+      NVStr  ns -> toValue =<< pathExists (toString $ stringIgnoreContext ns)
       _v -> throwError $ ErrorCall $ "builtins.pathExists: expected path, got " <> show _v
 
 hasKind
@@ -1316,7 +1315,7 @@ throw_ mnv =
   do
     ns <- coerceToString callFunc CopyToStore CoerceStringy mnv
 
-    throwError . ErrorCall . Text.unpack $ stringIgnoreContext ns
+    throwError . ErrorCall . toString $ stringIgnoreContext ns
 
 import_
   :: forall e t f m . MonadNix e t f m => NValue t f m -> m (NValue t f m)
@@ -1358,7 +1357,7 @@ getEnv_ :: MonadNix e t f m => NValue t f m -> m (NValue t f m)
 getEnv_ v =
   do
     s <- fromStringNoContext =<< fromValue v
-    mres <- getEnvVar (Text.unpack s)
+    mres <- getEnvVar (toString s)
 
     toValue $ makeNixStringWithoutContext $
       maybe
@@ -1518,7 +1517,7 @@ absolutePathFromValue =
     NVStr ns ->
       do
         let
-          path = Text.unpack $ stringIgnoreContext ns
+          path = toString $ stringIgnoreContext ns
 
         unless (isAbsolute path) $ throwError $ ErrorCall $ "string " <> show path <> " doesn't represent an absolute path"
         pure path
@@ -1543,7 +1542,7 @@ findFile_ nvaset nvfilepath =
     case (aset, filePath) of
       (NVList x, NVStr ns) ->
         do
-          mres <- findPath @t @f @m x (Text.unpack (stringIgnoreContext ns))
+          mres <- findPath @t @f @m x (toString (stringIgnoreContext ns))
 
           pure $ nvPath mres
 
@@ -1675,7 +1674,7 @@ trace_
   -> m (NValue t f m)
 trace_ msg action =
   do
-    traceEffect @t @f @m . Text.unpack . stringIgnoreContext =<< fromValue msg
+    traceEffect @t @f @m . toString . stringIgnoreContext =<< fromValue msg
     pure action
 
 -- Please, can function remember fail context
@@ -1695,7 +1694,7 @@ exec_ xs = do
   -- 2018-11-19: NOTE: Still need to do something with the context here
   -- See prim_exec in nix/src/libexpr/primops.cc
   -- Requires the implementation of EvalState::realiseContext
-  exec (fmap (Text.unpack . stringIgnoreContext) xs)
+  exec (fmap (toString . stringIgnoreContext) xs)
 
 fetchurl
   :: forall e t f m . MonadNix e t f m => NValue t f m -> m (NValue t f m)

--- a/src/Nix/Convert.hs
+++ b/src/Nix/Convert.hs
@@ -27,7 +27,6 @@ module Nix.Convert where
 import           Prelude                 hiding ( force )
 import           Control.Monad.Free
 import qualified Data.HashMap.Lazy             as M
-import qualified Data.Text                     as Text
 import           Nix.Atoms
 import           Nix.Effects
 import           Nix.Expr.Types
@@ -202,7 +201,7 @@ instance ( Convertible e t f m
       NVStr' ns -> pure $ pure ns
       NVPath' p ->
         fmap
-          (pure . (\s -> makeNixStringWithSingletonContext s (StringContext s DirectPath)) . Text.pack . unStorePath)
+          (pure . (\s -> makeNixStringWithSingletonContext s (StringContext s DirectPath)) . toText . unStorePath)
           (addPath p)
       NVSet' s _ ->
         maybe
@@ -380,7 +379,7 @@ instance ( Convertible e t f m
          )
   => ToValue SourcePos m (NValue' t f m (NValue t f m)) where
   toValue (SourcePos f l c) = do
-    f' <- toValue (makeNixStringWithoutContext (Text.pack f))
+    f' <- toValue (makeNixStringWithoutContext (toText f))
     l' <- toValue (unPos l)
     c' <- toValue (unPos c)
     let pos = M.fromList [("file" :: Text, f'), ("line", l'), ("column", c')]

--- a/src/Nix/Convert.hs
+++ b/src/Nix/Convert.hs
@@ -235,7 +235,7 @@ instance ( Convertible e t f m
   fromValueMay =
     \case
       NVPath' p  -> pure $ pure $ Path p
-      NVStr'  ns -> pure $ Path . Text.unpack <$> getStringNoContext  ns
+      NVStr'  ns -> pure $ Path . toString <$> getStringNoContext  ns
       NVSet' s _ ->
         maybe
           (pure Nothing)

--- a/src/Nix/Effects.hs
+++ b/src/Nix/Effects.hs
@@ -302,7 +302,7 @@ class
 
 instance MonadHttp IO where
   getURL url = do
-    let urlstr = T.unpack url
+    let urlstr = toString url
     traceM $ "fetching HTTP URL: " <> urlstr
     req     <- parseRequest urlstr
     manager <-
@@ -411,13 +411,13 @@ instance MonadStore IO where
           res <- Store.Remote.runStore $ Store.Remote.addToStore @'Store.SHA256 pathName path recursive (const False) repair
           parseStoreResult "addToStore" res >>= \case
             Left err -> pure $ Left err
-            Right storePath -> pure $ Right $ StorePath $ T.unpack $ T.decodeUtf8 $ Store.storePathToRawFilePath storePath
+            Right storePath -> pure $ Right $ StorePath $ toString $ T.decodeUtf8 $ Store.storePathToRawFilePath storePath
 
   addTextToStore' name text references repair = do
     res <- Store.Remote.runStore $ Store.Remote.addTextToStore name text references repair
     parseStoreResult "addTextToStore" res >>= \case
       Left err -> pure $ Left err
-      Right path -> pure $ Right $ StorePath $ T.unpack $ T.decodeUtf8 $ Store.storePathToRawFilePath path
+      Right path -> pure $ Right $ StorePath $ toString $ T.decodeUtf8 $ Store.storePathToRawFilePath path
 
 
 -- ** Functions

--- a/src/Nix/Effects.hs
+++ b/src/Nix/Effects.hs
@@ -150,7 +150,7 @@ instance MonadExec IO where
     []            -> pure $ Left $ ErrorCall "exec: missing program"
     (prog : args) -> do
       (exitCode, out, _) <- liftIO $ readProcessWithExitCode prog args ""
-      let t    = T.strip (T.pack out)
+      let t    = T.strip (toText out)
       let emsg = "program[" <> prog <> "] args=" <> show args
       case exitCode of
         ExitSuccess ->
@@ -205,7 +205,7 @@ instance MonadInstantiate IO where
           either
             (\ e -> Left $ ErrorCall $ "Error parsing output of nix-instantiate: " <> show e)
             pure
-            (parseNixTextLoc (T.pack out))
+            (parseNixTextLoc (toText out))
         status -> Left $ ErrorCall $ "nix-instantiate failed: " <> show status <> ": " <> err
 
 deriving
@@ -243,10 +243,10 @@ class
 instance MonadEnv IO where
   getEnvVar            = Env.lookupEnv
 
-  getCurrentSystemOS   = pure $ T.pack System.Info.os
+  getCurrentSystemOS   = pure $ toText System.Info.os
 
   -- Invert the conversion done by GHC_CONVERT_CPU in GHC's aclocal.m4
-  getCurrentSystemArch = pure $ T.pack $ case System.Info.arch of
+  getCurrentSystemArch = pure $ toText $ case System.Info.arch of
     "i386" -> "i686"
     arch   -> arch
 
@@ -432,10 +432,10 @@ addTextToStore :: (Framed e m, MonadStore m) => StorePathName -> Text -> Store.S
 addTextToStore a b c d = either throwError pure =<< addTextToStore' a b c d
 
 addPath :: (Framed e m, MonadStore m) => FilePath -> m StorePath
-addPath p = either throwError pure =<< addToStore (T.pack $ takeFileName p) p True False
+addPath p = either throwError pure =<< addToStore (toText $ takeFileName p) p True False
 
 toFile_ :: (Framed e m, MonadStore m) => FilePath -> String -> m StorePath
-toFile_ p contents = addTextToStore (T.pack p) (T.pack contents) HS.empty False
+toFile_ p contents = addTextToStore (toText p) (toText contents) HS.empty False
 
 -- * misc
 

--- a/src/Nix/Effects/Basic.hs
+++ b/src/Nix/Effects/Basic.hs
@@ -157,7 +157,7 @@ findPathBy finder ls name = do
                       let pfx = stringIgnoreContext nsPfx in
                       bool
                         mempty
-                        (pure (Text.unpack pfx))
+                        (pure (toString pfx))
                         (not $ Text.null pfx)
                     _ -> mempty
             )
@@ -201,7 +201,7 @@ fetchTarball =
 
 {- jww (2018-04-11): This should be written using pipes in another module
     fetch :: Text -> Maybe (NThunk m) -> m (NValue t f m)
-    fetch uri msha = case takeExtension (Text.unpack uri) of
+    fetch uri msha = case takeExtension (toString uri) of
         ".tgz" -> undefined
         ".gz"  -> undefined
         ".bz2" -> undefined
@@ -213,7 +213,7 @@ fetchTarball =
 
   fetch :: Text -> Maybe (NValue t f m) -> m (NValue t f m)
   fetch uri Nothing =
-    nixInstantiateExpr $ "builtins.fetchTarball \"" <> Text.unpack uri <> "\""
+    nixInstantiateExpr $ "builtins.fetchTarball \"" <> toString uri <> "\""
   fetch url (Just t) =
       (\nv -> do
         nsSha <- fromValue nv
@@ -221,7 +221,7 @@ fetchTarball =
         let sha = stringIgnoreContext nsSha
 
         nixInstantiateExpr
-          $ "builtins.fetchTarball { " <> "url    = \"" <> Text.unpack url <> "\"; " <> "sha256 = \"" <> Text.unpack sha <> "\"; }"
+          $ "builtins.fetchTarball { " <> "url    = \"" <> toString url <> "\"; " <> "sha256 = \"" <> toString sha <> "\"; }"
       ) =<< demand t
 
 defaultFindPath :: MonadNix e t f m => [NValue t f m] -> FilePath -> m FilePath

--- a/src/Nix/Effects/Derivation.hs
+++ b/src/Nix/Effects/Derivation.hs
@@ -118,7 +118,7 @@ hashDerivationModulo drv@Derivation{inputs = (inputSrcs, inputDrvs)} = do
     case MS.lookup path cache of
       Just hash -> pure (hash, outs)
       Nothing -> do
-        drv' <- readDerivation $ Text.unpack path
+        drv' <- readDerivation $ toString path
         hash <- Store.encodeInBase Store.Base16 <$> hashDerivationModulo drv'
         pure (hash, outs)
     )

--- a/src/Nix/Effects/Derivation.hs
+++ b/src/Nix/Effects/Derivation.hs
@@ -95,7 +95,7 @@ writeDerivation drv@Derivation{inputs, name} = do
   let (inputSrcs, inputDrvs) = inputs
   references <- fmap Set.fromList $ traverse parsePath $ Set.toList $ Set.union inputSrcs $ Set.fromList $ Map.keys inputDrvs
   path <- addTextToStore (Text.append name ".drv") (unparseDrv drv) (S.fromList $ Set.toList references) False
-  parsePath $ Text.pack $ unStorePath path
+  parsePath $ toText $ unStorePath path
 
 -- | Traverse the graph of inputDrvs to replace fixed output derivations with their fixed output hash.
 -- this avoids propagating changes to their .drv when the output hash stays the same.
@@ -199,7 +199,7 @@ derivationParser = do
   pure $ Derivation {inputs = (inputSrcs, inputDrvs), ..}
  where
   s :: Parsec () Text Text
-  s = fmap Text.pack $ string "\"" *> manyTill (escaped <|> regular) (string "\"")
+  s = fmap toText $ string "\"" *> manyTill (escaped <|> regular) (string "\"")
   escaped = char '\\' *>
     (   '\n' <$ string "n"
     <|> '\r' <$ string "r"

--- a/src/Nix/Exec.hs
+++ b/src/Nix/Exec.hs
@@ -28,7 +28,6 @@ import           Control.Monad.Fix
 import           Data.Fix
 import qualified Data.HashMap.Lazy             as M
 import qualified Data.List.NonEmpty            as NE
-import qualified Data.Text                     as Text
 import           Nix.Atoms
 import           Nix.Cited
 import           Nix.Convert

--- a/src/Nix/Exec.hs
+++ b/src/Nix/Exec.hs
@@ -150,7 +150,7 @@ wrapExprLoc span x = Fix (Fix (NSym_ span "<?>") <$ x)
 -- Currently instance is stuck in orphanage between the requirements to be MonadEval, aka Eval stage, and emposed requirement to be MonadNix (Execution stage). MonadNix constraint tries to put the cart before horse and seems superflous, since Eval in Nix also needs and can throw exceptions. It is between `nverr` and `evalError`.
 instance MonadNix e t f m => MonadEval (NValue t f m) m where
   freeVariable var =
-    nverr @e @t @f $ ErrorCall $ "Undefined variable '" <> Text.unpack var <> "'"
+    nverr @e @t @f $ ErrorCall $ "Undefined variable '" <> toString var <> "'"
 
   synHole name = do
     span  <- currentPos
@@ -161,11 +161,11 @@ instance MonadNix e t f m => MonadEval (NValue t f m) m where
       }
 
   attrMissing ks Nothing =
-    evalError @(NValue t f m) $ ErrorCall $ "Inheriting unknown attribute: " <> intercalate "." (fmap Text.unpack (NE.toList ks))
+    evalError @(NValue t f m) $ ErrorCall $ "Inheriting unknown attribute: " <> intercalate "." (fmap toString (NE.toList ks))
 
   attrMissing ks (Just s) =
     evalError @(NValue t f m)
-      $ ErrorCall $ "Could not look up attribute " <> intercalate "." (fmap Text.unpack (NE.toList ks)) <> " in " <> show (prettyNValue s)
+      $ ErrorCall $ "Could not look up attribute " <> intercalate "." (fmap toString (NE.toList ks)) <> " in " <> show (prettyNValue s)
 
   evalCurPos = do
     scope                  <- currentScopes
@@ -416,7 +416,7 @@ execBinaryOpForced scope span op lval rval = case op of
         maybe
           (throwError $ ErrorCall "A string that refers to a store path cannot be appended to a path.") -- data/nix/src/libexpr/eval.cc:1412
           (\ rs2 ->
-             nvPathP prov <$> makeAbsolutePath @t @f (ls <> Text.unpack rs2)
+             nvPathP prov <$> makeAbsolutePath @t @f (ls <> toString rs2)
           )
           (getStringNoContext rs)
       (NVPath ls, NVPath rs) -> nvPathP prov <$> makeAbsolutePath @t @f (ls <> rs)

--- a/src/Nix/Expr/Types.hs
+++ b/src/Nix/Expr/Types.hs
@@ -42,7 +42,6 @@ import           Data.Hashable.Lifted
 import qualified Data.List.NonEmpty            as NE
 import           Data.Ord.Deriving
 import qualified Text.Show
-import           Data.Text                      ( pack )
 import           Data.Traversable
 import           GHC.Generics
 import           Language.Haskell.TH.Syntax
@@ -202,7 +201,7 @@ instance Serialise r => Serialise (NString r)
 -- | For the the 'IsString' instance, we use a plain doublequoted string.
 instance IsString (NString r) where
   fromString ""     = DoubleQuoted mempty
-  fromString string = DoubleQuoted [Plain $ pack string]
+  fromString string = DoubleQuoted [Plain $ toText string]
 
 
 -- ** @NKeyName@
@@ -484,8 +483,8 @@ instance IsString NExpr where
 instance Lift (Fix NExprF) where
   lift = dataToExpQ $ \b ->
     case Reflection.typeOf b `eqTypeRep` Reflection.typeRep @Text of
-      Just HRefl -> pure [| pack $(liftString $ toString b) |]
       Nothing    -> Nothing
+      Just HRefl -> pure [| (toText :: String -> Text) $(liftString $ toString b) |]
 #if MIN_VERSION_template_haskell(2,17,0)
   liftTyped = unsafeCodeCoerce . lift
 #elif MIN_VERSION_template_haskell(2,16,0)

--- a/src/Nix/Expr/Types.hs
+++ b/src/Nix/Expr/Types.hs
@@ -42,9 +42,7 @@ import           Data.Hashable.Lifted
 import qualified Data.List.NonEmpty            as NE
 import           Data.Ord.Deriving
 import qualified Text.Show
-import           Data.Text                      ( pack
-                                                , unpack
-                                                )
+import           Data.Text                      ( pack )
 import           Data.Traversable
 import           GHC.Generics
 import           Language.Haskell.TH.Syntax
@@ -486,7 +484,7 @@ instance IsString NExpr where
 instance Lift (Fix NExprF) where
   lift = dataToExpQ $ \b ->
     case Reflection.typeOf b `eqTypeRep` Reflection.typeRep @Text of
-      Just HRefl -> pure [| pack $(liftString $ unpack b) |]
+      Just HRefl -> pure [| pack $(liftString $ toString b) |]
       Nothing    -> Nothing
 #if MIN_VERSION_template_haskell(2,17,0)
   liftTyped = unsafeCodeCoerce . lift

--- a/src/Nix/Expr/Types/Annotated.hs
+++ b/src/Nix/Expr/Types/Annotated.hs
@@ -37,7 +37,6 @@ import           Data.Fix                       ( Fix(..)
 import           Data.Functor.Compose
 import           Data.Hashable.Lifted
 import           Data.Ord.Deriving
-import           Data.Text                      ( pack )
 import           GHC.Generics
 import           Nix.Atoms
 import           Nix.Expr.Types
@@ -164,7 +163,7 @@ nStr :: Ann SrcSpan (NString NExprLoc) -> NExprLoc
 nStr (Ann s1 s) = AnnE s1 (NStr s)
 
 deltaInfo :: SourcePos -> (Text, Int, Int)
-deltaInfo (SourcePos fp l c) = (pack fp, unPos l, unPos c)
+deltaInfo (SourcePos fp l c) = (toText fp, unPos l, unPos c)
 
 nNull :: NExprLoc
 nNull = Fix (Compose (Ann nullSpan (NConstant NNull)))

--- a/src/Nix/Json.hs
+++ b/src/Nix/Json.hs
@@ -6,7 +6,6 @@ module Nix.Json where
 import qualified Data.Aeson                    as A
 import qualified Data.Aeson.Encoding           as A
 import qualified Data.HashMap.Lazy             as HM
-import qualified Data.Text                     as Text
 import qualified Data.Text.Lazy                as TL
 import qualified Data.Text.Lazy.Encoding       as TL
 import qualified Data.Vector                   as V
@@ -47,7 +46,7 @@ nvalueToJSON = \case
   NVPath p ->
     do
       fp <- lift $ unStorePath <$> addPath p
-      addSingletonStringContext $ StringContext (Text.pack fp) DirectPath
+      addSingletonStringContext $ StringContext (toText fp) DirectPath
       pure $ A.toJSON fp
   v -> lift $ throwError $ CoercionToJson v
 

--- a/src/Nix/Lint.hs
+++ b/src/Nix/Lint.hs
@@ -304,11 +304,11 @@ instance (MonadThunkId m, MonadAtomicRef m, MonadCatch m)
 
 
 instance MonadLint e m => MonadEval (Symbolic m) m where
-  freeVariable var = symerr $ "Undefined variable '" <> Text.unpack var <> "'"
+  freeVariable var = symerr $ "Undefined variable '" <> toString var <> "'"
 
-  attrMissing ks Nothing = evalError @(Symbolic m) $ ErrorCall $ "Inheriting unknown attribute: " <> intercalate "." (fmap Text.unpack (NE.toList ks))
+  attrMissing ks Nothing = evalError @(Symbolic m) $ ErrorCall $ "Inheriting unknown attribute: " <> intercalate "." (fmap toString (NE.toList ks))
 
-  attrMissing ks (Just s) = evalError @(Symbolic m) $ ErrorCall $ "Could not look up attribute " <> intercalate "." (fmap Text.unpack (NE.toList ks)) <> " in " <> show s
+  attrMissing ks (Just s) = evalError @(Symbolic m) $ ErrorCall $ "Could not look up attribute " <> intercalate "." (fmap toString (NE.toList ks)) <> " in " <> show s
 
   evalCurPos = do
     f <- mkSymbolic [TPath]

--- a/src/Nix/Lint.hs
+++ b/src/Nix/Lint.hs
@@ -314,19 +314,17 @@ instance MonadLint e m => MonadEval (Symbolic m) m where
     f <- mkSymbolic [TPath]
     l <- mkSymbolic [TConstant [TInt]]
     c <- mkSymbolic [TConstant [TInt]]
-    mkSymbolic [TSet (pure (M.fromList (go f l c)))]
-   where
-    go f l c =
-      [(Text.pack "file", f), (Text.pack "line", l), (Text.pack "col", c)]
+    mkSymbolic [TSet (pure (M.fromList [("file", f), ("line", l), ("col", c)]))]
 
   evalConstant c = mkSymbolic [go c]
    where
-    go = \case
-      NURI   _ -> TStr
-      NInt   _ -> TConstant [TInt]
-      NFloat _ -> TConstant [TFloat]
-      NBool  _ -> TConstant [TBool]
-      NNull    -> TConstant [TNull]
+    go =
+      \case
+        NURI   _ -> TStr
+        NInt   _ -> TConstant [TInt]
+        NFloat _ -> TConstant [TFloat]
+        NBool  _ -> TConstant [TBool]
+        NNull    -> TConstant [TNull]
 
   evalString      = const $ mkSymbolic [TStr]
   evalLiteralPath = const $ mkSymbolic [TPath]

--- a/src/Nix/Parser.hs
+++ b/src/Nix/Parser.hs
@@ -624,7 +624,7 @@ opWithLoc name op f =
   do
     Ann ann _ <-
       annotateLocation $
-        {- dbg (unpack name) $ -}
+        {- dbg (toString name) $ -}
         operator name
 
     pure $ f (Ann ann op)

--- a/src/Nix/Parser.hs
+++ b/src/Nix/Parser.hs
@@ -71,7 +71,6 @@ import qualified Data.List.NonEmpty            as NE
 import qualified Data.Map                      as Map
 import           Data.Text                      ( cons
                                                 , singleton
-                                                , pack
                                                 )
 import           Nix.Expr                hiding ( ($>) )
 import           Nix.Expr.Strings               ( escapeCodes
@@ -312,7 +311,7 @@ nixUri = lexeme $ annotateLocation1 $ try $ do
           || isDigit x
           || (`elem` ("%/?:@&=+$,-_.!~*'" :: String)) x
   pure $ NStr $ DoubleQuoted
-    [Plain $ pack $ start : protocol ++ ':' : address]
+    [Plain $ toText $ start : protocol ++ ':' : address]
 
 nixString' :: Parser (NString NExprLoc)
 nixString' = lexeme (doubleQuoted <+> indented <?> "string")
@@ -360,7 +359,7 @@ nixString' = lexeme (doubleQuoted <+> indented <?> "string")
     Antiquoted <$>
       (antiStart *> nixToplevelForm <* char '}')
         <+> Plain . singleton <$>
-          char '$' <+> esc <+> Plain . pack <$>
+          char '$' <+> esc <+> Plain . toText <$>
             some plainChar
    where
     plainChar =

--- a/src/Nix/Pretty.hs
+++ b/src/Nix/Pretty.hs
@@ -21,8 +21,7 @@ import           Data.HashMap.Lazy              ( toList )
 import qualified Data.HashMap.Lazy             as M
 import qualified Data.HashSet                  as HashSet
 import qualified Data.List.NonEmpty            as NE
-import           Data.Text                      ( pack
-                                                , replace
+import           Data.Text                      ( replace
                                                 , strip
                                                 )
 import qualified Data.Text                     as Text
@@ -327,7 +326,7 @@ valueToExpr = iterNValue (\_ _ -> thk) phi
     ]
   phi (NVClosure' _ _   ) = Fix . NSym $ "<closure>"
   phi (NVPath' p        ) = Fix $ NLiteralPath p
-  phi (NVBuiltin' name _) = Fix . NSym $ "builtins." <> pack name
+  phi (NVBuiltin' name _) = Fix . NSym $ "builtins." <> toText name
 
   mkStr ns = Fix $ NStr $ DoubleQuoted [Plain (stringIgnoreContext ns)]
 
@@ -386,7 +385,7 @@ printNix = iterNValue (\_ _ -> thk) phi
   phi :: NValue' t f m String -> String
   phi (NVConstant' a ) = toString $ atomText a
   phi (NVStr'      ns) = show $ stringIgnoreContext ns
-  phi (NVList'     l ) = toString $ "[ " <> unwords (fmap pack l) <> " ]"
+  phi (NVList'     l ) = toString $ "[ " <> unwords (fmap toText l) <> " ]"
   phi (NVSet' s _) =
     "{ " <>
       concat

--- a/src/Nix/Pretty.hs
+++ b/src/Nix/Pretty.hs
@@ -22,7 +22,6 @@ import qualified Data.HashMap.Lazy             as M
 import qualified Data.HashSet                  as HashSet
 import qualified Data.List.NonEmpty            as NE
 import           Data.Text                      ( pack
-                                                , unpack
                                                 , replace
                                                 , strip
                                                 )
@@ -110,9 +109,9 @@ wrapPath op sub =
 prettyString :: NString (NixDoc ann) -> Doc ann
 prettyString (DoubleQuoted parts) = "\"" <> (mconcat . fmap prettyPart $ parts) <> "\""
  where
-  -- It serializes (@unpack@) Text -> String, because the helper code is done for String,
+  -- It serializes Text -> String, because the helper code is done for String,
   -- please, can someone break that code.
-  prettyPart (Plain t)      = pretty . concatMap escape . unpack $ t
+  prettyPart (Plain t)      = pretty . concatMap escape . toString $ t
   prettyPart EscapedNewline = "''\\n"
   prettyPart (Antiquoted r) = "${" <> withoutParens r <> "}"
   escape '"' = "\\\""
@@ -385,13 +384,13 @@ printNix = iterNValue (\_ _ -> thk) phi
 
   -- Please, reduce this horrifying String -> Text -> String marshaling in favour of Text
   phi :: NValue' t f m String -> String
-  phi (NVConstant' a ) = unpack $ atomText a
+  phi (NVConstant' a ) = toString $ atomText a
   phi (NVStr'      ns) = show $ stringIgnoreContext ns
-  phi (NVList'     l ) = unpack $ "[ " <> unwords (fmap pack l) <> " ]"
+  phi (NVList'     l ) = toString $ "[ " <> unwords (fmap pack l) <> " ]"
   phi (NVSet' s _) =
     "{ " <>
       concat
-        [ check (unpack k) <> " = " <> v <> "; "
+        [ check (toString k) <> " = " <> v <> "; "
         | (k, v) <- sort $ toList s
         ] <> "}"
    where

--- a/src/Nix/TH.hs
+++ b/src/Nix/TH.hs
@@ -31,7 +31,7 @@ quoteExprExp s = do
     expr
  where
   liftText :: Text.Text -> Q Exp
-  liftText txt = AppE (VarE 'Text.pack) <$> liftString (Text.unpack txt)
+  liftText txt = AppE (VarE 'toText) <$> liftString (toString txt)
 
 quoteExprPat :: String -> PatQ
 quoteExprPat s = do
@@ -122,12 +122,12 @@ instance ToExpr Float where
 
 metaExp :: Set VarName -> NExprLoc -> Maybe ExpQ
 metaExp fvs (Fix (NSym_ _ x)) | x `Set.member` fvs =
-  pure [| toExpr $(varE (mkName (Text.unpack x))) |]
+  pure [| toExpr $(varE (mkName $ toString x)) |]
 metaExp _ _ = Nothing
 
 metaPat :: Set VarName -> NExprLoc -> Maybe PatQ
 metaPat fvs (Fix (NSym_ _ x)) | x `Set.member` fvs =
-  pure (varP (mkName (Text.unpack x)))
+  pure (varP (mkName $ toString x))
 metaPat _ _ = Nothing
 
 nix :: QuasiQuoter

--- a/src/Nix/TH.hs
+++ b/src/Nix/TH.hs
@@ -25,7 +25,7 @@ quoteExprExp s = do
     either
       (fail . show)
       pure
-      (parseNixText (Text.pack s))
+      (parseNixText $ toText s)
   dataToExpQ
     (const Nothing `extQ` metaExp (freeVars expr) `extQ` (pure . liftText))
     expr
@@ -39,7 +39,7 @@ quoteExprPat s = do
     either
       (fail . show)
       pure
-      (parseNixText (Text.pack s))
+      (parseNixText $ toText s)
   dataToPatQ
     (const Nothing `extQ` metaPat (freeVars expr))
     expr

--- a/src/Nix/Utils.hs
+++ b/src/Nix/Utils.hs
@@ -131,14 +131,14 @@ data NixPathEntryType = PathEntryPath | PathEntryURI deriving (Show, Eq)
 -- | @NIX_PATH@ is colon-separated, but can also contain URLs, which have a colon
 -- (i.e. @https://...@)
 uriAwareSplit :: Text -> [(Text, NixPathEntryType)]
-uriAwareSplit = go where
-  go str = case Text.break (== ':') str of
+uriAwareSplit txt =
+  case Text.break (== ':') txt of
     (e1, e2)
       | Text.null e2                              -> [(e1, PathEntryPath)]
-      | Text.pack "://" `Text.isPrefixOf` e2      ->
-        let ((suffix, _) : path) = go (Text.drop 3 e2) in
-        (e1 <> Text.pack "://" <> suffix, PathEntryURI) : path
-      | otherwise                                 -> (e1, PathEntryPath) : go (Text.drop 1 e2)
+      | "://" `Text.isPrefixOf` e2      ->
+        let ((suffix, _) : path) = uriAwareSplit (Text.drop 3 e2) in
+        (e1 <> "://" <> suffix, PathEntryURI) : path
+      | otherwise                                 -> (e1, PathEntryPath) : uriAwareSplit (Text.drop 1 e2)
 
 alterF
   :: (Eq k, Hashable k, Functor f)

--- a/src/Nix/XML.hs
+++ b/src/Nix/XML.hs
@@ -110,10 +110,10 @@ paramsXML (ParamSet s b mname) =
  where
   battr = [ Attr (unqual "ellipsis") "1" | b ]
   nattr =
-      maybe
-        mempty
-        ((: mempty) . Attr (unqual "name") . toString)
-        mname
+    maybe
+      mempty
+      ((: mempty) . Attr (unqual "name") . toString)
+      mname
 
 paramSetXML :: ParamSet r -> [Content]
 paramSetXML = fmap (\(k, _) -> Elem $ mkEName "attr" (toString k))

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -10,7 +10,6 @@ import           GHC.Err (errorWithoutStackTrace)
 import           Data.Fix
 import           Data.List (isSuffixOf, lookup)
 import qualified Data.String as String
-import           Data.Text (unpack)
 import           Data.Time
 import qualified EvalTests
 import           NeatInterpolation (text)
@@ -58,11 +57,11 @@ ensureNixpkgsCanParse =
           runWithBasicEffectsIO (defaultOptions time) $
             Nix.nixEvalExprLoc mempty expr
         let dir = stringIgnoreContext ns
-        exists <- fileExist (unpack dir)
+        exists <- fileExist $ toString dir
         unless exists $
           errorWithoutStackTrace $
             "Directory " <> show dir <> " does not exist"
-        files <- globDir1 (compile "**/*.nix") (unpack dir)
+        files <- globDir1 (compile "**/*.nix") $ toString dir
         when (null files) $
           errorWithoutStackTrace $
             "Directory " <> show dir <> " does not have any files"

--- a/tests/NixLanguageTests.hs
+++ b/tests/NixLanguageTests.hs
@@ -127,7 +127,7 @@ assertLangOk :: Options -> FilePath -> Assertion
 assertLangOk opts file = do
   actual   <- printNix <$> hnixEvalFile opts (file <> ".nix")
   expected <- Text.readFile $ file <> ".exp"
-  assertEqual "" expected $ Text.pack (actual <> "\n")
+  assertEqual "" expected $ toText (actual <> "\n")
 
 assertLangOkXml :: Options -> FilePath -> Assertion
 assertLangOkXml opts file = do

--- a/tests/NixLanguageTests.hs
+++ b/tests/NixLanguageTests.hs
@@ -156,7 +156,7 @@ assertEval _opts files = do
           Opts.execParserPure
             Opts.defaultPrefs
             (nixOptionsInfo time)
-            (fixup (fmap Text.unpack (Text.splitOn " " flags')))
+            (fixup (fmap toString (Text.splitOn " " flags')))
         of
           Opts.Failure err ->
             errorWithoutStackTrace

--- a/tests/NixLanguageTests.hs
+++ b/tests/NixLanguageTests.hs
@@ -113,11 +113,7 @@ assertParseFail opts file = do
         (\ expr ->
           do
             _ <- pure $! runST $ void $ lint opts expr
-            assertFailure $
-              "Unexpected success parsing `"
-              <> file
-              <> ":\nParsed value: "
-              <> show expr
+            assertFailure $ "Unexpected success parsing `" <> file <> ":\nParsed value: " <> show expr
         )
         eres
       )
@@ -158,12 +154,7 @@ assertEval _opts files = do
             (nixOptionsInfo time)
             (fixup (fmap toString (Text.splitOn " " flags')))
         of
-          Opts.Failure err ->
-            errorWithoutStackTrace
-              $  "Error parsing flags from "
-              <> name
-              <> ".flags: "
-              <> show err
+          Opts.Failure err   -> errorWithoutStackTrace $ "Error parsing flags from " <> name <> ".flags: " <> show err
           Opts.Success opts' -> assertLangOk opts' name
           Opts.CompletionInvoked _ -> fail "unused"
     _ -> assertFailure $ "Unknown test type " <> show files
@@ -180,9 +171,9 @@ assertEvalFail :: FilePath -> Assertion
 assertEvalFail file = catch ?? (\(_ :: SomeException) -> pure ()) $ do
   time       <- liftIO getCurrentTime
   evalResult <- printNix <$> hnixEvalFile (defaultOptions time) file
-  evalResult
-    `seq` assertFailure
-    $     file
-    <>    " should not evaluate.\nThe evaluation result was `"
-    <>    evalResult
-    <>    "`."
+  evalResult `seq`
+    assertFailure $
+      file
+      <> " should not evaluate.\nThe evaluation result was `"
+      <> evalResult
+      <> "`."

--- a/tests/ParserTests.hs
+++ b/tests/ParserTests.hs
@@ -9,7 +9,6 @@
 module ParserTests (tests) where
 
 import Data.Fix
-import Data.Text (unpack)
 import NeatInterpolation (text)
 import Nix.Atoms
 import Nix.Expr
@@ -367,10 +366,10 @@ assertParseText :: Text -> NExpr -> Assertion
 assertParseText str expected =
   either
     (\ err ->
-      assertFailure $ "Unexpected fail parsing `" <> unpack str <> "':\n" <> show err
+      assertFailure $ toString $ "Unexpected fail parsing `" <> str <> "':\n" <> show err
     )
     (assertEqual
-      ("When parsing " <> unpack str)
+      ("When parsing " <> toString str)
       (stripPositionInfo expected)
       . stripPositionInfo
     )
@@ -396,7 +395,7 @@ assertParseFail str =
   either
     (const $ pure ())
     (\ r ->
-      assertFailure $ "Unexpected success parsing `" <> unpack str <> ":\nParsed value: " <> show r
+      assertFailure $ toString $ "Unexpected success parsing `" <> str <> ":\nParsed value: " <> show r
     )
     (parseNixText str)
 

--- a/tests/PrettyParseTests.hs
+++ b/tests/PrettyParseTests.hs
@@ -15,8 +15,6 @@ import           Data.Char
 import           Data.Fix
 import qualified Data.List.NonEmpty            as NE
 import qualified Data.String                   as String
-import           Data.Text                      ( pack
-                                                )
 import           Hedgehog
 import qualified Hedgehog.Gen                  as Gen
 import qualified Hedgehog.Range                as Range
@@ -34,7 +32,7 @@ asciiString :: MonadGen m => m String
 asciiString = Gen.list (Range.linear 1 15) Gen.lower
 
 asciiText :: Gen Text
-asciiText = pack <$> asciiString
+asciiText = toText <$> asciiString
 
 -- Might want to replace this instance with a constant value
 genPos :: Gen Pos
@@ -183,11 +181,11 @@ normalize = foldFix $ \case
 prop_prettyparse :: Monad m => NExpr -> PropertyT m ()
 prop_prettyparse p = do
   let prog = show (prettyNix p)
-  case parse (pack prog) of
+  case parse (toText prog) of
     Left s -> do
       footnote $ show $ vsep
         -- Remove :: Text type annotation after String -> Text migration.
-        [fillSep ["Parse failed:", pretty ((show s) :: Text)], indent 2 (prettyNix p)]
+        [fillSep ["Parse failed:", pretty (show s :: Text)], indent 2 (prettyNix p)]
       discard
     Right v
       | equivUpToNormalization p v -> success

--- a/tests/TestCommon.hs
+++ b/tests/TestCommon.hs
@@ -7,7 +7,6 @@ module TestCommon where
 
 import           GHC.Err                        ( errorWithoutStackTrace )
 import           Control.Monad.Catch
-import           Data.Text                      ( unpack )
 import           Data.Time
 import           Nix
 import           Nix.Standard
@@ -43,7 +42,7 @@ hnixEvalFile opts file =
 hnixEvalText :: Options -> Text -> IO (StdValue (StandardT (StdIdT IO)))
 hnixEvalText opts src =
   either
-    (\ err -> fail $ "Parsing failed for expression `" <> unpack src <> "`.\n" <> show err)
+    (\ err -> fail $ toString $ "Parsing failed for expression `" <> src <> "`.\n" <> show err)
     (\ expr ->
       runWithBasicEffects opts $ normalForm =<< nixEvalExpr mempty expr
     )
@@ -75,4 +74,4 @@ assertEvalMatchesNix expr = do
   nixVal  <- nixEvalString expr'
   assertEqual expr' nixVal hnixVal
  where
-  expr' = unpack expr
+  expr' = toString expr


### PR DESCRIPTION
This is the continuation of the `String -> Text` (#897) migration.

Now instead of `{,T,Text}.unpack` when to search String - one at once would receive the majority of the places where String is used.

Text - the same thing, before it could been `{,T,Text}.pack`.

Now everything is seen and reads literally.

If everything is right, this PR (and maybe `relude` switch) shaved 23% on Firefox evaluation. This can be the result of:
  * did refactors where was appropriate. In particular - refactored the `String.Coerce` main function, its body now is more understandable to people and optimizable to the compiler, also result now would not run `CoerceAny` pattern matching for `CoerceStringy` cases.
  * moved in several places the bind operations into the  `do` blocks, since `ApplicativeDo` can work on them, if we miss something that `ApplicativeDo` knows.
  * also fused a couple of functions in a few places.
  * also maybe `relude` did some additional internal optimization of functions.
  * maybe it is due to some other things.
  
  This patch is backward-compatible.