### PR TITLE
TH: Refactor

### DIFF
--- a/src/Nix/TH.hs
+++ b/src/Nix/TH.hs
@@ -25,11 +25,8 @@ quoteExprExp s = do
       pure
       (parseNixText $ toText s)
   dataToExpQ
-    (const Nothing `extQ` metaExp (freeVars expr) `extQ` (pure . liftText))
+    (const Nothing `extQ` metaExp (freeVars expr) `extQ` (pure . (TH.lift :: Text -> Q Exp)))
     expr
- where
-  liftText :: Text -> Q Exp
-  liftText txt = AppE (VarE 'id) <$> TH.lift txt
 
 quoteExprPat :: String -> PatQ
 quoteExprPat s = do

--- a/src/Nix/TH.hs
+++ b/src/Nix/TH.hs
@@ -11,9 +11,8 @@ import           Data.Fix
 import           Data.Generics.Aliases
 import           Data.Set                       ( (\\) )
 import qualified Data.Set                      as Set
-import qualified Data.Text                     as Text
 import           Language.Haskell.TH
-import           Language.Haskell.TH.Syntax     ( liftString )
+import qualified Language.Haskell.TH.Syntax    as TH
 import           Language.Haskell.TH.Quote
 import           Nix.Atoms
 import           Nix.Expr
@@ -30,8 +29,8 @@ quoteExprExp s = do
     (const Nothing `extQ` metaExp (freeVars expr) `extQ` (pure . liftText))
     expr
  where
-  liftText :: Text.Text -> Q Exp
-  liftText txt = AppE (VarE 'toText) <$> liftString (toString txt)
+  liftText :: Text -> Q Exp
+  liftText txt = AppE (VarE 'id) <$> TH.lift txt
 
 quoteExprPat :: String -> PatQ
 quoteExprPat s = do

--- a/src/Nix/TH.hs
+++ b/src/Nix/TH.hs
@@ -7,9 +7,8 @@
 
 module Nix.TH where
 
-import           Data.Fix
-import           Data.Generics.Aliases
-import           Data.Set                       ( (\\) )
+import           Data.Fix                       ( Fix(..) )
+import           Data.Generics.Aliases          ( extQ )
 import qualified Data.Set                      as Set
 import           Language.Haskell.TH
 import qualified Language.Haskell.TH.Syntax    as TH
@@ -45,40 +44,50 @@ quoteExprPat s = do
 
 freeVars :: NExpr -> Set VarName
 freeVars e = case unFix e of
-  (NConstant    _       ) -> mempty
-  (NStr         string  ) -> foldMap freeVars string
-  (NSym         var     ) -> Set.singleton var
-  (NList        list    ) -> foldMap freeVars list
-  (NSet NNonRecursive bindings) -> foldMap bindFree bindings
-  (NSet NRecursive bindings) -> foldMap bindFree bindings \\ foldMap bindDefs bindings
-  (NLiteralPath _       ) -> mempty
-  (NEnvPath     _       ) -> mempty
-  (NUnary _ expr        ) -> freeVars expr
-  (NBinary _ left right ) -> freeVars left `Set.union` freeVars right
-  (NSelect expr path orExpr) ->
-    freeVars expr
-      `Set.union` pathFree path
-      `Set.union` maybe mempty freeVars orExpr
-  (NHasAttr expr            path) -> freeVars expr `Set.union` pathFree path
+  (NConstant    _               ) -> mempty
+  (NStr         string          ) -> foldMap freeVars string
+  (NSym         var             ) -> Set.singleton var
+  (NList        list            ) -> foldMap freeVars list
+  (NSet   NNonRecursive bindings) -> foldMap bindFree bindings
+  (NSet   NRecursive bindings   ) -> Set.difference (foldMap bindFree bindings) (foldMap bindDefs bindings)
+  (NLiteralPath _               ) -> mempty
+  (NEnvPath     _               ) -> mempty
+  (NUnary       _    expr       ) -> freeVars expr
+  (NBinary      _    left right ) -> Set.union (freeVars left) (freeVars right)
+  (NSelect      expr path orExpr) ->
+    Set.unions
+      [ freeVars expr
+      , pathFree path
+      , maybe mempty freeVars orExpr
+      ]
+  (NHasAttr expr            path) -> Set.union (freeVars expr) (pathFree path)
   (NAbs     (Param varname) expr) -> Set.delete varname (freeVars expr)
   (NAbs (ParamSet set _ varname) expr) ->
-    -- Include all free variables from the expression and the default arguments
-    freeVars expr
-      `Set.union` Set.unions (mapMaybe (fmap freeVars . snd) set)
-    -- But remove the argument name if existing, and all arguments in the parameter set
-      \\          maybe mempty Set.singleton varname
-      \\          Set.fromList (fmap fst set)
-  (NLet bindings expr) ->
-    freeVars expr
-      `Set.union` foldMap bindFree bindings
-      \\          foldMap bindDefs bindings
-  (NIf cond th el) ->
-    freeVars cond `Set.union` freeVars th `Set.union` freeVars el
+    Set.union
+      -- Include all free variables from the expression and the default arguments
+      (freeVars expr)
+      -- But remove the argument name if existing, and all arguments in the parameter set
+      (Set.difference
+        (Set.unions (mapMaybe (fmap freeVars . snd) set))
+        (Set.difference
+          (maybe mempty Set.singleton varname)
+          (Set.fromList (fmap fst set))
+        )
+      )
+  (NLet            bindings expr) ->
+    Set.union
+      (freeVars expr)
+      (Set.difference
+        (foldMap bindFree bindings)
+        (foldMap bindDefs bindings)
+      )
+  (NIf          cond th   el    ) ->
+    Set.unions $ freeVars <$> [cond, th, el]
   -- Evaluation is needed to find out whether x is a "real" free variable in `with y; x`, we just include it
   -- This also makes sense because its value can be overridden by `x: with y; x`
-  (NWith   set       expr) -> freeVars set `Set.union` freeVars expr
-  (NAssert assertion expr) -> freeVars assertion `Set.union` freeVars expr
-  (NSynHole _            ) -> mempty
+  (NWith        set  expr       ) -> Set.union (freeVars set      ) (freeVars expr)
+  (NAssert      assertion expr  ) -> Set.union (freeVars assertion) (freeVars expr)
+  (NSynHole _                   ) -> mempty
 
  where
 
@@ -87,22 +96,22 @@ freeVars e = case unFix e of
   staticKey (DynamicKey _      ) = mempty
 
   bindDefs :: Binding r -> Set VarName
-  bindDefs (Inherit  Nothing                   _    _) = mempty
-  bindDefs (Inherit (Just _) keys _) = Set.fromList $ mapMaybe staticKey keys
+  bindDefs (Inherit   Nothing                  _    _) = mempty
+  bindDefs (Inherit  (Just _                 ) keys _) = Set.fromList $ mapMaybe staticKey keys
   bindDefs (NamedVar (StaticKey  varname :| _) _    _) = Set.singleton varname
   bindDefs (NamedVar (DynamicKey _       :| _) _    _) = mempty
 
   bindFree :: Binding NExpr -> Set VarName
-  bindFree (Inherit Nothing keys _) = Set.fromList $ mapMaybe staticKey keys
-  bindFree (Inherit (Just scope) _ _) = freeVars scope
-  bindFree (NamedVar path expr _) = pathFree path `Set.union` freeVars expr
+  bindFree (Inherit  Nothing     keys _) = Set.fromList $ mapMaybe staticKey keys
+  bindFree (Inherit (Just scope) _    _) = freeVars scope
+  bindFree (NamedVar path        expr _) = Set.union (pathFree path) (freeVars expr)
 
   pathFree :: NAttrPath NExpr -> Set VarName
   pathFree = foldMap (foldMap freeVars)
 
 
 class ToExpr a where
-    toExpr :: a -> NExprLoc
+  toExpr :: a -> NExprLoc
 
 instance ToExpr NExprLoc where
   toExpr = id


### PR DESCRIPTION
Looked into TH.

Really wanted to try to migrate:
```haskell
nix :: QuasiQuoter
nix = QuasiQuoter { quoteExp = quoteExprExp, quotePat = quoteExprPat }
```
 to text (`QuasiText` or something), but `QuasiText` is partial to `QuasiQuoter` and I need more TH knowledge to move this type of code.

Found some other improvements.

Particularly, reduced `liftText txt = AppE (VarE 'toText) <$> liftString (toString txt)` seems particularly interesting.