### PR TITLE
to Text migrations; TH refactor

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -148,11 +148,19 @@
   * [(link)](https://github.com/haskell-nix/hnix/pull/884/files) `Nix.Thunk.Basic`: `instance MonadThunk (NThunkF m v) m v`: `queryM`: implementation no longer blocks the thunk resource it only reads from.
   
   * [(link)](https://github.com/haskell-nix/hnix/pull/908/files): Migrated `(String -> Text)`:
-    * `Nix.Value`: `{NValueF, nvBuiltin{,'}, builtin{,2,3}`
+    * `Nix.Value`: `{NValueF, nvBuiltin{,'}, builtin{,2,3}}`
     * `Nix.Eval`: `MonadNixEval`
     * `Nix.Render.Frame`: `render{Expr,Value}`
     * `Nix.Type`: `TVar`
     * `Nix.Thunk`: `ThunkLoop`
+    * `Nix.Exec`: `{nvBuiltinP, nixInstantiateExpr, exec}`
+    * `Nix.Effects`:
+      * `class`:
+        * `MonadExec: exec'`
+        * `MonadEnv: getEnvVar`
+        * `MonadInstantiate: instatiateExpr`
+      * `parseStoreResult`
+    * `Nix.Effects.Derivation`: `renderSymbolic`
 
 * Additional:
   * [(link)](https://github.com/haskell-nix/hnix/commit/7e6cd97bf3288cb584241611fdb25bf85d7e0ba7) `cabal.project`: freed from the `cryptohash-sha512` override, Hackage trustees made a revision.

--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -190,7 +190,7 @@ foldNixPath z f =
     dataDir  <-
       maybe
         getDataDir
-        pure
+        (pure . toString)
         mDataDir
 
     foldrM
@@ -1246,7 +1246,7 @@ getEnvNix :: MonadNix e t f m => NValue t f m -> m (NValue t f m)
 getEnvNix v =
   do
     s <- fromStringNoContext =<< fromValue v
-    mres <- getEnvVar (toString s)
+    mres <- getEnvVar s
 
     toValue $ makeNixStringWithoutContext $
       maybe

--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -1563,7 +1563,7 @@ execNix xs =
     -- 2018-11-19: NOTE: Still need to do something with the context here
     -- See prim_exec in nix/src/libexpr/primops.cc
     -- Requires the implementation of EvalState::realiseContext
-    exec (toString . stringIgnoreContext <$> xs)
+    exec (stringIgnoreContext <$> xs)
 
 fetchurlNix
   :: forall e t f m . MonadNix e t f m => NValue t f m -> m (NValue t f m)

--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -111,7 +111,7 @@ data Builtin v =
 
 -- | Types that support conversion to nix in a particular monad
 class ToBuiltin t f m a | a -> m where
-  toBuiltin :: String -> a -> m (NValue t f m)
+  toBuiltin :: Text -> a -> m (NValue t f m)
 
 instance
   ( MonadNix e t f m
@@ -127,7 +127,7 @@ instance
   )
   => ToBuiltin t f m (a -> b) where
   toBuiltin name f =
-    pure $ nvBuiltin (toText name) (toBuiltin name . f <=< fromValue . Deeper)
+    pure $ nvBuiltin name (toBuiltin name . f <=< fromValue . Deeper)
 
 -- *** @WValue@ closure wrapper to have @Ord@
 
@@ -1895,7 +1895,7 @@ builtinsList = sequence
     -> Text
     -> a
     -> m (Builtin (NValue t f m))
-  add' t n v = mkBuiltin t n (toBuiltin (toString n) v)
+  add' t n v = mkBuiltin t n (toBuiltin n v)
 
 
 -- * Exported

--- a/src/Nix/Effects.hs
+++ b/src/Nix/Effects.hs
@@ -180,8 +180,8 @@ class
   Monad m
   => MonadInstantiate m where
 
-    instantiateExpr :: String -> m (Either ErrorCall NExprLoc)
-    default instantiateExpr :: (MonadTrans t, MonadInstantiate m', m ~ t m') => String -> m (Either ErrorCall NExprLoc)
+    instantiateExpr :: Text -> m (Either ErrorCall NExprLoc)
+    default instantiateExpr :: (MonadTrans t, MonadInstantiate m', m ~ t m') => Text -> m (Either ErrorCall NExprLoc)
     instantiateExpr = lift . instantiateExpr
 
 
@@ -197,16 +197,17 @@ instance MonadInstantiate IO where
       (exitCode, out, err) <-
         readProcessWithExitCode
           "nix-instantiate"
-          ["--eval", "--expr", expr]
+          ["--eval", "--expr", toString expr]
           ""
 
-      pure $ case exitCode of
-        ExitSuccess ->
-          either
-            (\ e -> Left $ ErrorCall $ "Error parsing output of nix-instantiate: " <> show e)
-            pure
-            (parseNixTextLoc (toText out))
-        status -> Left $ ErrorCall $ "nix-instantiate failed: " <> show status <> ": " <> err
+      pure $
+        case exitCode of
+          ExitSuccess ->
+            either
+              (\ e -> Left $ ErrorCall $ "Error parsing output of nix-instantiate: " <> show e)
+              pure
+              (parseNixTextLoc (toText out))
+          status -> Left $ ErrorCall $ "nix-instantiate failed: " <> show status <> ": " <> err
 
 deriving
   instance

--- a/src/Nix/Effects.hs
+++ b/src/Nix/Effects.hs
@@ -226,8 +226,8 @@ class
   Monad m
   => MonadEnv m where
 
-  getEnvVar :: String -> m (Maybe String)
-  default getEnvVar :: (MonadTrans t, MonadEnv m', m ~ t m') => String -> m (Maybe String)
+  getEnvVar :: Text -> m (Maybe Text)
+  default getEnvVar :: (MonadTrans t, MonadEnv m', m ~ t m') => Text -> m (Maybe Text)
   getEnvVar = lift . getEnvVar
 
   getCurrentSystemOS :: m Text
@@ -242,7 +242,7 @@ class
 -- ** Instances
 
 instance MonadEnv IO where
-  getEnvVar            = Env.lookupEnv
+  getEnvVar            = (fmap . fmap) toText . Env.lookupEnv . toString
 
   getCurrentSystemOS   = pure $ toText System.Info.os
 

--- a/src/Nix/Effects.hs
+++ b/src/Nix/Effects.hs
@@ -411,20 +411,20 @@ instance MonadStore IO where
         do
           -- TODO: redesign the filter parameter
           res <- Store.Remote.runStore $ Store.Remote.addToStore @'Store.SHA256 pathName path recursive (const False) repair
-          pure . either
+          either
             Left -- err
             (pure . StorePath . decodeUtf8 . Store.storePathToRawFilePath) -- store path
-            =<< parseStoreResult "addToStore" res
+            <$> parseStoreResult "addToStore" res
       )
       (Store.makeStorePathName name)
 
   addTextToStore' name text references repair =
     do
       res <- Store.Remote.runStore $ Store.Remote.addTextToStore name text references repair
-      pure . either
+      either
         Left -- err
         (pure . StorePath . decodeUtf8 . Store.storePathToRawFilePath) -- path
-        =<< parseStoreResult "addTextToStore" res
+        <$> parseStoreResult "addTextToStore" res
 
 
 -- ** Functions

--- a/src/Nix/Effects/Basic.hs
+++ b/src/Nix/Effects/Basic.hs
@@ -201,7 +201,7 @@ fetchTarball =
 
 {- jww (2018-04-11): This should be written using pipes in another module
     fetch :: Text -> Maybe (NThunk m) -> m (NValue t f m)
-    fetch uri msha = case takeExtension (toString uri) of
+    fetch uri msha = case takeExtension uri of
         ".tgz" -> undefined
         ".gz"  -> undefined
         ".bz2" -> undefined
@@ -213,7 +213,7 @@ fetchTarball =
 
   fetch :: Text -> Maybe (NValue t f m) -> m (NValue t f m)
   fetch uri Nothing =
-    nixInstantiateExpr $ "builtins.fetchTarball \"" <> toString uri <> "\""
+    nixInstantiateExpr $ "builtins.fetchTarball \"" <> uri <> "\""
   fetch url (Just t) =
       (\nv -> do
         nsSha <- fromValue nv
@@ -221,7 +221,7 @@ fetchTarball =
         let sha = stringIgnoreContext nsSha
 
         nixInstantiateExpr
-          $ "builtins.fetchTarball { " <> "url    = \"" <> toString url <> "\"; " <> "sha256 = \"" <> toString sha <> "\"; }"
+          $ "builtins.fetchTarball { " <> "url    = \"" <> url <> "\"; " <> "sha256 = \"" <> sha <> "\"; }"
       ) =<< demand t
 
 defaultFindPath :: MonadNix e t f m => [NValue t f m] -> FilePath -> m FilePath

--- a/src/Nix/Effects/Derivation.hs
+++ b/src/Nix/Effects/Derivation.hs
@@ -332,7 +332,7 @@ buildDerivationWithContext drvAttrs = do
           rawString :: Text <- extractNixString jsonString
           pure $ Map.singleton "__json" rawString
         else
-          traverse (lift . coerceToString callFunc CopyToStore CoerceAny >=> extractNixString) $
+          traverse (extractNixString <=< lift . coerceToString callFunc CopyToStore CoerceAny) $
             Map.fromList $ M.toList $ deleteKeys [ "args", "__ignoreNulls" ] attrs
 
       pure $ Derivation { platform, builder, args, env,  hashMode, useJson

--- a/src/Nix/Eval.hs
+++ b/src/Nix/Eval.hs
@@ -48,7 +48,8 @@ class (Show v, Monad m) => MonadEval v m where
   evalAssert      :: v -> m v -> m v
   evalApp         :: v -> m v -> m v
   evalAbs         :: Params (m v)
-                  -> ( forall a. m v
+                  -> ( forall a
+                    . m v
                     -> ( AttrSet (m v)
                       -> m v
                       -> m (a, v)

--- a/src/Nix/Exec.hs
+++ b/src/Nix/Exec.hs
@@ -549,4 +549,4 @@ exec args = either throwError evalExprLoc =<< exec' args
 
 nixInstantiateExpr
   :: (MonadNix e t f m, MonadInstantiate m) => String -> m (NValue t f m)
-nixInstantiateExpr s = either throwError evalExprLoc =<< instantiateExpr s
+nixInstantiateExpr s = either throwError evalExprLoc =<< instantiateExpr (toText s)

--- a/src/Nix/Exec.hs
+++ b/src/Nix/Exec.hs
@@ -28,6 +28,7 @@ import           Control.Monad.Fix
 import           Data.Fix
 import qualified Data.HashMap.Lazy             as M
 import qualified Data.List.NonEmpty            as NE
+import qualified Data.Text                     as Text
 import           Nix.Atoms
 import           Nix.Cited
 import           Nix.Convert
@@ -48,7 +49,7 @@ import           Nix.Value.Equal
 import           Nix.Value.Monad
 import           Prettyprinter
 #ifdef MIN_VERSION_pretty_show
-import qualified Text.Show.Pretty as PS
+import qualified Text.Show.Pretty              as PS
 #endif
 
 #ifdef MIN_VERSION_ghc_datasize
@@ -137,7 +138,7 @@ type MonadNix e t f m
   )
 
 data ExecFrame t f m = Assertion SrcSpan (NValue t f m)
-    deriving (Show, Typeable)
+  deriving (Show, Typeable)
 
 instance MonadDataErrorContext t f m => Exception (ExecFrame t f m)
 
@@ -160,24 +161,30 @@ instance MonadNix e t f m => MonadEval (NValue t f m) m where
   synHole name = do
     span  <- currentPos
     scope <- currentScopes
-    evalError @(NValue t f m) $ SynHole $ SynHoleInfo
-      { _synHoleInfo_expr  = Fix $ NSynHole_ span name
-      , _synHoleInfo_scope = scope
-      }
+    evalError @(NValue t f m) $ SynHole $
+      SynHoleInfo
+        { _synHoleInfo_expr  = Fix $ NSynHole_ span name
+        , _synHoleInfo_scope = scope
+        }
 
-  attrMissing ks Nothing =
-    evalError @(NValue t f m) $ ErrorCall $ "Inheriting unknown attribute: " <> intercalate "." (fmap toString (NE.toList ks))
 
-  attrMissing ks (Just s) =
-    evalError @(NValue t f m)
-      $ ErrorCall $ "Could not look up attribute " <> intercalate "." (fmap toString (NE.toList ks)) <> " in " <> show (prettyNValue s)
+  attrMissing ks ms =
+    evalError @(NValue t f m) $ ErrorCall $ toString $
+      maybe
+        ("Inheriting unknown attribute: " <> attr)
+        (\ s ->
+          "Could not look up attribute " <> attr <> " in " <> show (prettyNValue s)
+        )
+        ms
+       where
+        attr = Text.intercalate "." (NE.toList ks)
 
   evalCurPos = do
     scope                  <- currentScopes
     span@(SrcSpan delta _) <- currentPos
     addProvenance @_ @_ @(NValue t f m)
-      (Provenance scope (NSym_ span "__curPos"))
-      <$> toValue delta
+      (Provenance scope (NSym_ span "__curPos")) <$>
+        toValue delta
 
   evaledSym name val = do
     scope <- currentScopes
@@ -212,13 +219,14 @@ instance MonadNix e t f m => MonadEval (NValue t f m) m where
   evalLiteralPath p = do
     scope <- currentScopes
     span  <- currentPos
-    nvPathP (Provenance scope (NLiteralPath_ span p))
-      <$> makeAbsolutePath @t @f @m p
+    nvPathP (Provenance scope (NLiteralPath_ span p)) <$>
+      makeAbsolutePath @t @f @m p
 
   evalEnvPath p = do
     scope <- currentScopes
     span  <- currentPos
-    nvPathP (Provenance scope (NEnvPath_ span p)) <$> findEnvPath @t @f @m p
+    nvPathP (Provenance scope (NEnvPath_ span p)) <$>
+      findEnvPath @t @f @m p
 
   evalUnary op arg = do
     scope <- currentScopes
@@ -259,16 +267,16 @@ instance MonadNix e t f m => MonadEval (NValue t f m) m where
           scope <- currentScopes
           (\b ->
               addProvenance (Provenance scope (NAssert_ span (pure c) (pure b))) b
-            )
-            <$> body
+            ) <$>
+            body
         )
         b
 
   evalApp f x = do
     scope <- currentScopes
     span  <- currentPos
-    addProvenance (Provenance scope (NBinary_ span NApp (pure f) Nothing))
-      <$> (callFunc f =<< defer x)
+    addProvenance (Provenance scope (NBinary_ span NApp (pure f) Nothing)) <$>
+      (callFunc f =<< defer x)
 
   evalAbs p k = do
     scope <- currentScopes
@@ -415,23 +423,24 @@ execBinaryOpForced scope span op lval rval = case op of
 
       (NVStr ls, NVStr rs) -> pure $ nvStrP prov (ls <> rs)
       (NVStr ls, rs@NVPath{}) ->
-        (\rs2 -> nvStrP prov (ls <> rs2))
-          <$> coerceToString callFunc CopyToStore CoerceStringy rs
+        (\rs2 -> nvStrP prov (ls <> rs2)) <$>
+          coerceToString callFunc CopyToStore CoerceStringy rs
       (NVPath ls, NVStr rs) ->
         maybe
           (throwError $ ErrorCall "A string that refers to a store path cannot be appended to a path.") -- data/nix/src/libexpr/eval.cc:1412
           (\ rs2 ->
-             nvPathP prov <$> makeAbsolutePath @t @f (ls <> toString rs2)
+            nvPathP prov <$>
+              makeAbsolutePath @t @f (ls <> toString rs2)
           )
           (getStringNoContext rs)
       (NVPath ls, NVPath rs) -> nvPathP prov <$> makeAbsolutePath @t @f (ls <> rs)
 
       (ls@NVSet{}, NVStr rs) ->
-        (\ls2 -> nvStrP prov (ls2 <> rs))
-          <$> coerceToString callFunc DontCopyToStore CoerceStringy ls
+        (\ls2 -> nvStrP prov (ls2 <> rs)) <$>
+          coerceToString callFunc DontCopyToStore CoerceStringy ls
       (NVStr ls, rs@NVSet{}) ->
-        (\rs2 -> nvStrP prov (ls <> rs2))
-          <$> coerceToString callFunc DontCopyToStore CoerceStringy rs
+        (\rs2 -> nvStrP prov (ls <> rs2)) <$>
+          coerceToString callFunc DontCopyToStore CoerceStringy rs
       _ -> unsupportedTypes
 
   NEq   -> alreadyHandled

--- a/src/Nix/Exec.hs
+++ b/src/Nix/Exec.hs
@@ -548,5 +548,5 @@ exec :: (MonadNix e t f m, MonadInstantiate m) => [String] -> m (NValue t f m)
 exec args = either throwError evalExprLoc =<< exec' args
 
 nixInstantiateExpr
-  :: (MonadNix e t f m, MonadInstantiate m) => String -> m (NValue t f m)
-nixInstantiateExpr s = either throwError evalExprLoc =<< instantiateExpr (toText s)
+  :: (MonadNix e t f m, MonadInstantiate m) => Text -> m (NValue t f m)
+nixInstantiateExpr s = either throwError evalExprLoc =<< instantiateExpr s

--- a/src/Nix/Exec.hs
+++ b/src/Nix/Exec.hs
@@ -545,7 +545,7 @@ evalExprLoc expr = do
   raise k f x = ReaderT $ \e -> k (\t -> runReaderT (f t) e) x
 
 exec :: (MonadNix e t f m, MonadInstantiate m) => [String] -> m (NValue t f m)
-exec args = either throwError evalExprLoc =<< exec' args
+exec args = either throwError evalExprLoc =<< exec' (toText <$> args)
 
 nixInstantiateExpr
   :: (MonadNix e t f m, MonadInstantiate m) => Text -> m (NValue t f m)

--- a/src/Nix/Exec.hs
+++ b/src/Nix/Exec.hs
@@ -110,10 +110,10 @@ nvClosureP p x f = addProvenance p (nvClosure x f)
 nvBuiltinP
   :: MonadCited t f m
   => Provenance m (NValue t f m)
-  -> String
+  -> Text
   -> (NValue t f m -> m (NValue t f m))
   -> NValue t f m
-nvBuiltinP p name f = addProvenance p (nvBuiltin (toText name) f)
+nvBuiltinP p name f = addProvenance p (nvBuiltin name f)
 
 type MonadCitedThunks t f m
   = ( MonadThunk t m (NValue t f m)

--- a/src/Nix/Exec.hs
+++ b/src/Nix/Exec.hs
@@ -544,8 +544,8 @@ evalExprLoc expr = do
   phi = Eval.eval . annotated . getCompose
   raise k f x = ReaderT $ \e -> k (\t -> runReaderT (f t) e) x
 
-exec :: (MonadNix e t f m, MonadInstantiate m) => [String] -> m (NValue t f m)
-exec args = either throwError evalExprLoc =<< exec' (toText <$> args)
+exec :: (MonadNix e t f m, MonadInstantiate m) => [Text] -> m (NValue t f m)
+exec args = either throwError evalExprLoc =<< exec' args
 
 nixInstantiateExpr
   :: (MonadNix e t f m, MonadInstantiate m) => Text -> m (NValue t f m)

--- a/src/Nix/Reduce.hs
+++ b/src/Nix/Reduce.hs
@@ -368,7 +368,7 @@ pruneTree opts =
             | otherwise        -> pure $ NList (fmap (fromMaybe nNull) l)
     NSet recur binds
       | reduceSets opts -> pure $ NSet recur (mapMaybe sequence binds)
-      | otherwise -> pure $ NSet recur (fmap (fmap (fromMaybe nNull)) binds)
+      | otherwise -> pure $ NSet recur ((fmap . fmap) (fromMaybe nNull) binds)
 
     NLet binds (Just body@(Fix (Compose (Ann _ x)))) ->
       pure $ case mapMaybe pruneBinding binds of
@@ -438,7 +438,7 @@ pruneTree opts =
   pruneParams (Param n) = Param n
   pruneParams (ParamSet xs b n)
     | reduceSets opts = ParamSet
-      (fmap (second (maybe (pure nNull) (pure . fromMaybe nNull))) xs)
+      (fmap (second (pure . (maybe nNull (fromMaybe nNull)))) xs)
       b
       n
     | otherwise = ParamSet (fmap (second (fmap (fromMaybe nNull))) xs) b n


### PR DESCRIPTION
Currently covered the case of most of the HNix.
 * In the next PRs, the last modules that are most high-level: `{Builtins, Repls, Main}`.
 * There are a couple of `String` cases with list processing and such that got left below.
 * `FilePath` is still `FilePath` for `FilePath` legacy reasons.
 * In the code got to the Store String iceberg, which needs attention.
 
 In this PR: everything else pretty much Text now.
 
TH got refactored, now process of `freeVars` is more vivid.
Replaced `fmap toString` in several places with duing one call.
Reduced `=<<` to `<$>` in one place.