### PR TITLE
toText refactors

### DIFF
--- a/main/Repl.hs
+++ b/main/Repl.hs
@@ -111,7 +111,7 @@ main' iniVal =
           ((prefix:command) : xs) | prefix == commandPrefix ->
             do
               let arguments = String.unwords xs
-              optMatcher command options arguments
+              optMatcher (toText command) options (toText arguments)
           x -> cmd $ String.unwords x
         )
         (String.words . toString <$> lines f)
@@ -125,13 +125,13 @@ main' iniVal =
   -- * @MonadIO m@ instead of @MonadHaskeline m@
   -- * @putStrLn@ instead of @outputStrLn@
   optMatcher :: MonadIO m
-             => String
+             => Text
              -> Console.Options m
-             -> String
+             -> Text
              -> m ()
-  optMatcher s [] _ = liftIO $ putStrLn $ "No such command :" <> s
+  optMatcher s [] _ = liftIO $ Text.IO.putStrLn $ "No such command :" <> s
   optMatcher s ((x, m) : xs) args
-    | s `isPrefixOf` x = m args
+    | s `Text.isPrefixOf` toText x = m $ toString args
     | otherwise = optMatcher s xs args
 
 

--- a/main/Repl.hs
+++ b/main/Repl.hs
@@ -339,7 +339,7 @@ setConfig args =
   case Text.words args of
     []       -> liftIO $ putStrLn "No option to set specified"
     (x:_xs)  ->
-      case filter ((==x) . (toText . helpSetOptionName)) helpSetOptions of
+      case filter ((==x) . helpSetOptionName) helpSetOptions of
         [opt] -> modify (\s -> s { replCfg = helpSetOptionFunction opt (replCfg s) })
         _     -> liftIO $ putStrLn "No such option"
 
@@ -431,7 +431,7 @@ completeFunc reversedPrev word
             f:fs ->
               maybe
                 (pure mempty)
-                (((fmap . fmap) (("." <> f) <>) . algebraicComplete fs) <=< demand)
+                ((<<$>>) (("." <> f) <>) . algebraicComplete fs <=< demand)
                 (Data.HashMap.Lazy.lookup f m)
       in
       case val of

--- a/main/Repl.hs
+++ b/main/Repl.hs
@@ -404,10 +404,10 @@ completeFunc reversedPrev word
           (Just (NVSet builtins _)) = Data.HashMap.Lazy.lookup "builtins" (replCtx s)
           shortBuiltins = Data.HashMap.Lazy.keys builtins
 
-      pure $ listCompletion
-        $ ["__includes"]
-        <> (toString <$> contextKeys)
-        <> (toString <$> shortBuiltins)
+      pure $ listCompletion $ toString <$>
+        ["__includes"]
+          <> contextKeys
+          <> shortBuiltins
 
   where
     listCompletion = fmap simpleCompletion . filter (word `isPrefixOf`)

--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -199,7 +199,7 @@ foldNixPath z f =
       $ (fromInclude . stringIgnoreContext <$> dirs)
         <> maybe
             mempty
-            (uriAwareSplit . toText)
+            (uriAwareSplit)
             mPath
         <> [ fromInclude $ "nix=" <> toText dataDir <> "/nix/corepkgs" ]
  where
@@ -1249,9 +1249,7 @@ getEnvNix v =
     mres <- getEnvVar s
 
     toValue $ makeNixStringWithoutContext $
-      maybe
-        mempty
-        toText mres
+      fromMaybe mempty mres
 
 sortNix
   :: MonadNix e t f m

--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -984,7 +984,7 @@ genericClosureNix c =
               []           -> k
               WValue j : _ -> j
             )
-          (fmap . fmap) (t :) (go op (S.insert (WValue k) ks) (ts <> ys))
+          (t :) <<$>> go op (S.insert (WValue k) ks) (ts <> ys)
         )
         (go op ks ts)
         (S.member (WValue k) ks)
@@ -1937,9 +1937,9 @@ builtins =
     pushScope (M.fromList lst) currentScopes
  where
   buildMap         =  fmap (M.fromList . fmap mapping) builtinsList
-  topLevelBuiltins = (fmap . fmap) mapping fullBuiltinsList
+  topLevelBuiltins = mapping <<$>> fullBuiltinsList
 
-  fullBuiltinsList = (fmap . fmap) go builtinsList
+  fullBuiltinsList = go <<$>> builtinsList
    where
     go b@(Builtin TopLevel _) = b
     go (Builtin Normal (name, builtin)) =

--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -175,7 +175,7 @@ foldNixPath
   :: forall e t f m r
    . MonadNix e t f m
   => r
-  -> (FilePath -> Maybe String -> NixPathEntryType -> r -> m r)
+  -> (FilePath -> Maybe Text -> NixPathEntryType -> r -> m r)
   -> m r
 foldNixPath z f =
   do
@@ -201,7 +201,7 @@ foldNixPath z f =
             mempty
             (uriAwareSplit . toText)
             mPath
-        <> [ fromInclude $ toText $ "nix=" <> dataDir <> "/nix/corepkgs" ]
+        <> [ fromInclude $ "nix=" <> toText dataDir <> "/nix/corepkgs" ]
  where
 
   fromInclude x = (x, ) $
@@ -213,7 +213,7 @@ foldNixPath z f =
   go (x, ty) rest =
     case Text.splitOn "=" x of
       [p] -> f (toString p) mempty ty rest
-      [n, p] -> f (toString p) (pure (toString n)) ty rest
+      [n, p] -> f (toString p) (pure n) ty rest
       _ -> throwError $ ErrorCall $ "Unexpected entry in NIX_PATH: " <> show x
 
 attrsetGet :: MonadNix e t f m => Text -> AttrSet (NValue t f m) -> m (NValue t f m)
@@ -430,7 +430,7 @@ nixPathNix =
                   PathEntryPath -> ("path", nvPath p)
                   PathEntryURI  -> ( "uri", mkNvStr p)
 
-                , ( "prefix", mkNvStr $ fromMaybe "" mn)
+                , ( "prefix", mkNvStr $ toString $ fromMaybe "" mn)
                 ]
               )
             )

--- a/src/Nix/Effects.hs
+++ b/src/Nix/Effects.hs
@@ -25,7 +25,7 @@ import           Prelude                 hiding ( traceM
 import qualified Prelude
 import           Nix.Utils
 import qualified Data.HashSet                  as HS
-import qualified Data.Text                     as T
+import qualified Data.Text                     as Text
 import           Network.HTTP.Client     hiding ( path, Proxy )
 import           Network.HTTP.Client.TLS
 import           Network.HTTP.Types
@@ -150,11 +150,11 @@ instance MonadExec IO where
     []            -> pure $ Left $ ErrorCall "exec: missing program"
     (prog : args) -> do
       (exitCode, out, _) <- liftIO $ readProcessWithExitCode (toString prog) (toString <$> args) ""
-      let t    = T.strip (toText out)
+      let t    = Text.strip (toText out)
       let emsg = "program[" <> prog <> "] args=" <> show args
       case exitCode of
         ExitSuccess ->
-          if T.null t
+          if Text.null t
             then pure $ Left $ ErrorCall $ toString $ "exec has no output :" <> emsg
             else
               either
@@ -242,7 +242,7 @@ class
 -- ** Instances
 
 instance MonadEnv IO where
-  getEnvVar            = (fmap . fmap) toText . Env.lookupEnv . toString
+  getEnvVar            = (<<$>>) toText . Env.lookupEnv . toString
 
   getCurrentSystemOS   = pure $ toText System.Info.os
 

--- a/src/Nix/Exec.hs
+++ b/src/Nix/Exec.hs
@@ -307,7 +307,7 @@ callFunc fun arg =
       NVBuiltin name f    ->
         do
           span <- currentPos
-          withFrame Info ((Calling @m @(NValue t f m)) (toText name) span) (f arg)
+          withFrame Info ((Calling @m @(NValue t f m)) name span) (f arg)
       (NVSet m _) | Just f <- M.lookup "__functor" m ->
         ((`callFunc` arg) <=< (`callFunc` fun')) =<< demand f
       x -> throwError $ ErrorCall $ "Attempt to call non-function: " <> show x

--- a/src/Nix/Parser.hs
+++ b/src/Nix/Parser.hs
@@ -100,10 +100,8 @@ infixl 3 <+>
 nixExpr :: Parser NExprLoc
 nixExpr =
   makeExprParser
-    nixTerm $
-      (fmap . fmap)
-        snd
-        (nixOperators nixSelector)
+    nixTerm $ snd <<$>>
+        nixOperators nixSelector
 
 antiStart :: Parser Text
 antiStart = symbol "${" <?> show ("${" :: String)

--- a/src/Nix/Pretty.hs
+++ b/src/Nix/Pretty.hs
@@ -326,7 +326,7 @@ valueToExpr = iterNValue (\_ _ -> thk) phi
     ]
   phi (NVClosure' _ _   ) = Fix . NSym $ "<closure>"
   phi (NVPath' p        ) = Fix $ NLiteralPath p
-  phi (NVBuiltin' name _) = Fix . NSym $ "builtins." <> toText name
+  phi (NVBuiltin' name _) = Fix . NSym $ "builtins." <> name
 
   mkStr ns = Fix $ NStr $ DoubleQuoted [Plain (stringIgnoreContext ns)]
 
@@ -381,7 +381,6 @@ printNix = iterNValue (\_ _ -> thk) phi
  where
   thk = "<thunk>"
 
-  -- Please, reduce this horrifying String -> Text -> String marshaling in favour of Text
   phi :: NValue' t f m String -> String
   phi (NVConstant' a ) = toString $ atomText a
   phi (NVStr'      ns) = show $ stringIgnoreContext ns

--- a/src/Nix/Type/Infer.hs
+++ b/src/Nix/Type/Infer.hs
@@ -259,7 +259,7 @@ inferType env ex = do
 -- | Solve for the toplevel type of an expression in a given environment
 inferExpr :: Env -> NExpr -> Either InferError [Scheme]
 inferExpr env ex =
-  (fmap . fmap) (\(subst, ty) -> closeOver (subst `apply` ty)) $ runInfer $ inferType env ex
+  (\ (subst, ty) -> closeOver $ subst `apply` ty) <<$>> runInfer (inferType env ex)
 
 -- | Canonicalize and return the polymorphic toplevel type.
 closeOver :: Type -> Scheme

--- a/src/Nix/Value.hs
+++ b/src/Nix/Value.hs
@@ -459,7 +459,7 @@ nvBuiltin' :: (Applicative f, Functor m)
   => Text
   -> (NValue t f m -> m r)
   -> NValue' t f m r
-nvBuiltin' name f = NValue' $ pure $ NVBuiltinF (toText name) f
+nvBuiltin' name f = NValue' $ pure $ NVBuiltinF name f
 
 
 -- So above we have maps of Hask subcategory objects to Nix objects,


### PR DESCRIPTION
* What is currently left to migrate is the last realistic bit currently, the more complex String manipulations that initially passed by, and now would return and migrate it.

* What then what is left is Store Strings, FilePaths, and places that have heavy external String use, it is pity that a lot of libs give only Strings.
* Let's hope that more updates would arrive with current endeavors.
* We collectively as Haskellers need to pick upstreams to migrate to modern text types.

After the mentioned at the top migrations, would consider the migration as largely done in HNix, and would move to other things, probably to do what is possible for the GHC support.