### PR TITLE
deps: ref-ft upd, Fresh: rm instance MonadAtomicRef

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -115,8 +115,8 @@
           (package hashable >= 1.3.1) -- gained instance
           $ Hashable1 NonEmpty:: Nix.Expr.Types -> Void -- please use upstreamed instance
 
-        -- | Upstreamed, going to apper in the next release of `ref-tf`.
-        MonadAtomicRef   (Fix1T t m) :: Nix.Standard -> Nix.Utils.Fix1
+        -- | Was upstreamed, released in `ref-tf >= 0.5`.
+        MonadAtomicRef   (Fix1T t m) :: Nix.Standard -> Void
 
         MonadRef         (Fix1T t m) :: Nix.Standard -> Nix.Utils.Fix1
         MonadEnv         (Fix1T t m) :: Nix.Standard -> Nix.Effects

--- a/default.nix
+++ b/default.nix
@@ -91,7 +91,7 @@
 #   , nixos-20.03  # Last stable release, gets almost no updates to recipes, gets only required backports
 #   ...
 #   }
-, rev ? "0aeba64fb26e4defa0842a942757144659c6e29f"
+, rev ? "39e6bf76474ce742eb027a88c4da6331f0a1526f"
 
 , pkgs ?
     if builtins.compareVersions builtins.nixVersion "2.0" > 0
@@ -185,6 +185,12 @@ let
     name = cabalName;
     # Do not include into closure the files listed in .gitignore
     root = packageRoot;
+
+    overrides = self: super: {
+
+      ref-tf = super.ref-tf_0_5;
+
+    };
 
     modifier = drv: hlib.overrideCabal drv (attrs: {
       buildTools = (attrs.buildTools or []) ++ [

--- a/hnix.cabal
+++ b/hnix.cabal
@@ -437,7 +437,7 @@ library
     , pretty-show >= 1.9.5 && < 1.11
     , prettyprinter >= 1.7.0 && < 1.8
     , process >= 1.6.3 && < 1.7
-    , ref-tf >= 0.4.0 && <= 0.4.0.2
+    , ref-tf >= 0.5 && < 0.6
     , regex-tdfa >= 1.2.3 && < 1.4
     , relude >= 0.7.0 && < 1.0.0
     , scientific >= 0.3.6 && < 0.4

--- a/src/Nix/Fresh.hs
+++ b/src/Nix/Fresh.hs
@@ -18,9 +18,8 @@ import           Control.Monad.Catch  ( MonadCatch
                                       )
 import           Control.Monad.Except ( MonadFix )
 import           Control.Monad.Ref    ( MonadAtomicRef(..)
-                                      , MonadRef(writeRef, readRef)
+                                      , MonadRef()
                                       )
-import           Control.Monad.ST     ( ST )
 
 import           Nix.Var
 import           Nix.Thunk
@@ -66,19 +65,3 @@ instance
 
 runFreshIdT :: Functor m => Var m i -> FreshIdT i m a -> m a
 runFreshIdT i m = runReaderT (unFreshIdT m) i
-
--- Orphan instance needed by Infer.hs and Lint.hs
-
--- Since there's no forking, it's automatically atomic.
---  2021-02-09: NOTE: Submitted upstream: https://github.com/mainland/ref-tf/pull/4
-instance MonadAtomicRef (ST s) where
-  atomicModifyRef r f = do
-    v <- readRef r
-    let (a, b) = f v
-    writeRef r a
-    pure b
-  atomicModifyRef' r f = do
-    v <- readRef r
-    let (a, b) = f v
-    writeRef r $! a
-    pure b


### PR DESCRIPTION
Upstreamed instance update arrived. `ref-tf` has unrestrictive bounds, so backward compatible, so just removing the instance.