### PR TITLE
Basic monad refactors

### DIFF
--- a/main/Main.hs
+++ b/main/Main.hs
@@ -240,7 +240,7 @@ main =
             -> Fix1T StandardTF (StdIdT IO) (Maybe a)
           forceEntry k v =
             catch
-              (pure <$> (pure =<< demand v))
+              (pure <$> demand v)
               (\ (NixException frames) ->
                 do
                   liftIO

--- a/main/Main.hs
+++ b/main/Main.hs
@@ -245,7 +245,7 @@ main =
                 do
                   liftIO
                     . Text.putStrLn
-                    . ("Exception forcing " <>) . (k <>) . (": " <>)
+                    . (("Exception forcing " <> k <> ": ") <>)
                     . show =<<
                       renderFrames
                         @(StdValue (StandardT (StdIdT IO)))

--- a/main/Main.hs
+++ b/main/Main.hs
@@ -176,7 +176,7 @@ main =
             xs <-
               traverse
                 (\ (k, nv) ->
-                  (free
+                  free
                     (\ (StdThunk (extract -> Thunk _ _ ref)) ->
                       do
                         let
@@ -194,7 +194,6 @@ main =
                     )
                     (\ v -> pure (k, pure (Free v)))
                     nv
-                  )
                 )
                 (sortWith fst (M.toList s))
             traverse_

--- a/main/Main.hs
+++ b/main/Main.hs
@@ -207,10 +207,10 @@ main =
                       liftIO $ Text.putStrLn path
                       when descend $
                         maybe
-                          (pure ())
+                          pass
                           (\case
                             NVSet s' _ -> go (path <> ".") s'
-                            _          -> pure ()
+                            _          -> pass
                           )
                           mv
               )

--- a/main/Repl.hs
+++ b/main/Repl.hs
@@ -376,8 +376,9 @@ completeFunc
 completeFunc reversedPrev word
   -- Commands
   | reversedPrev == ":" =
-    pure . listCompletion
-      $ fmap (toString . helpOptionName) (helpOptions :: HelpOptions e t f m)
+    pure . listCompletion $
+      toString . helpOptionName <$>
+        (helpOptions :: HelpOptions e t f m)
 
   -- Files
   | any (`isPrefixOf` word) [ "/", "./", "../", "~/" ] =
@@ -392,7 +393,12 @@ completeFunc reversedPrev word
         (\ binding ->
           do
             candidates <- lift $ algebraicComplete subFields binding
-            pure $ notFinished <$> listCompletion (toString . (var <>) <$> candidates)
+            pure $
+              notFinished <$>
+                listCompletion
+                  (toString . (var <>) <$>
+                    candidates
+                  )
         )
         (Data.HashMap.Lazy.lookup var (replCtx s))
 
@@ -431,7 +437,10 @@ completeFunc reversedPrev word
             f:fs ->
               maybe
                 stub
-                ((<<$>>) (("." <> f) <>) . algebraicComplete fs <=< demand)
+                ((<<$>>)
+                   (("." <> f) <>)
+                   . algebraicComplete fs <=< demand
+                )
                 (Data.HashMap.Lazy.lookup f m)
       in
       case val of

--- a/main/Repl.hs
+++ b/main/Repl.hs
@@ -326,7 +326,7 @@ typeof args = do
   printValueType val =
     do
       s <- lift . lift . showValueType $ val
-      liftIO $ putStrLn s
+      liftIO $ Text.putStrLn s
 
 
 -- | @:quit@ command
@@ -337,11 +337,11 @@ quit _ = liftIO Exit.exitSuccess
 setConfig :: (MonadNix e t f m, MonadIO m) => Text -> Repl e t f m ()
 setConfig args =
   case Text.words args of
-    []       -> liftIO $ putStrLn "No option to set specified"
+    []       -> liftIO $ Text.putStrLn "No option to set specified"
     (x:_xs)  ->
       case filter ((==x) . helpSetOptionName) helpSetOptions of
         [opt] -> modify (\s -> s { replCfg = helpSetOptionFunction opt (replCfg s) })
-        _     -> liftIO $ putStrLn "No such option"
+        _     -> liftIO $ Text.putStrLn "No such option"
 
 
 -- * Interactive Shell

--- a/main/Repl.hs
+++ b/main/Repl.hs
@@ -388,7 +388,7 @@ completeFunc reversedPrev word
     do
       s <- get
       maybe
-        (pure mempty)
+        stub
         (\ binding ->
           do
             candidates <- lift $ algebraicComplete subFields binding
@@ -430,13 +430,13 @@ completeFunc reversedPrev word
             [_] -> pure $ keys m
             f:fs ->
               maybe
-                (pure mempty)
+                stub
                 ((<<$>>) (("." <> f) <>) . algebraicComplete fs <=< demand)
                 (Data.HashMap.Lazy.lookup f m)
       in
       case val of
         NVSet xs _ -> withMap xs
-        _          -> pure mempty
+        _          -> stub
 
 -- | HelpOption inspired by Dhall Repl
 -- with `Doc` instead of String for syntax and doc

--- a/main/Repl.hs
+++ b/main/Repl.hs
@@ -230,7 +230,7 @@ exec update source = do
             -- If the result value is a set, update our context with it
             case val of
               NVSet xs _ -> put st { replCtx = Data.HashMap.Lazy.union xs (replCtx st) }
-              _          -> pure ()
+              _          -> pass
 
           pure $ pure val
         )
@@ -262,7 +262,7 @@ cmd source =
   do
     mVal <- exec True source
     maybe
-      (pure ())
+      pass
       printValue
       mVal
 

--- a/main/Repl.hs
+++ b/main/Repl.hs
@@ -30,7 +30,7 @@ import qualified Data.HashMap.Lazy
 import           Data.Char                      ( isSpace )
 import           Data.List                      ( dropWhileEnd )
 import qualified Data.Text                   as Text
-import qualified Data.Text.IO                as Text.IO
+import qualified Data.Text.IO                as Text
 import           Data.Version                   ( showVersion )
 import           Paths_hnix                     ( version )
 
@@ -103,14 +103,14 @@ main' iniVal =
 
   rcFile =
     do
-      f <- liftIO $ Text.IO.readFile ".hnixrc" `catch` handleMissing
+      f <- liftIO $ Text.readFile ".hnixrc" `catch` handleMissing
 
       traverse_
         (\case
           (prefixedCommand : xs) | Text.head prefixedCommand == commandPrefix ->
             do
               let
-                arguments = Text.unwords $ xs
+                arguments = Text.unwords xs
                 command = Text.tail prefixedCommand
               optMatcher command options arguments
           x -> cmd $ Text.unwords x
@@ -130,7 +130,7 @@ main' iniVal =
              -> Console.Options m
              -> Text
              -> m ()
-  optMatcher s [] _ = liftIO $ Text.IO.putStrLn $ "No such command :" <> s
+  optMatcher s [] _ = liftIO $ Text.putStrLn $ "No such command :" <> s
   optMatcher s ((x, m) : xs) args
     | s `Text.isPrefixOf` toText x = m $ toString args
     | otherwise = optMatcher s xs args
@@ -288,7 +288,7 @@ browse :: (MonadNix e t f m, MonadIO m)
 browse _ = do
   st <- get
   for_ (Data.HashMap.Lazy.toList $ replCtx st) $ \(k, v) -> do
-    liftIO $ Text.IO.putStr $ k <> " = "
+    liftIO $ Text.putStr $ k <> " = "
     printValue v
 
 -- | @:load@ command
@@ -299,9 +299,9 @@ load
   -> Repl e t f m ()
 load args =
   do
-    contents <- liftIO
-      $ Text.IO.readFile
-      $ trim args
+    contents <- liftIO $
+      Text.readFile $
+       trim args
     void $ exec True contents
  where
   trim = dropWhileEnd isSpace . dropWhile isSpace
@@ -554,7 +554,7 @@ help hs _ = do
   liftIO $ putStrLn "Available commands:\n"
   for_ hs $ \h ->
     liftIO .
-      Text.IO.putStrLn .
+      Text.putStrLn .
         Prettyprinter.renderStrict .
           Prettyprinter.layoutPretty Prettyprinter.defaultLayoutOptions $
             ":"

--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -199,7 +199,7 @@ foldNixPath z f =
       $ (fromInclude . stringIgnoreContext <$> dirs)
         <> maybe
             mempty
-            (uriAwareSplit)
+            uriAwareSplit
             mPath
         <> [ fromInclude $ "nix=" <> toText dataDir <> "/nix/corepkgs" ]
  where

--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -182,7 +182,7 @@ foldNixPath z f =
     mres <- lookupVar "__includes"
     dirs <-
       maybe
-        (pure mempty)
+        stub
         ((fromValue . Deeper) <=< demand)
         mres
     mPath    <- getEnvVar "NIX_PATH"
@@ -1687,7 +1687,7 @@ appendContextNix tx ty =
 
               getOutputs =
                 maybe
-                  (pure mempty)
+                  stub
                   (\ touts ->
                     do
                       outs <- demand touts

--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -889,6 +889,7 @@ unsafeDiscardStringContextNix mnv = do
   ns <- fromValue mnv
   toValue $ makeNixStringWithoutContext $ stringIgnoreContext ns
 
+-- | Evaluate `a` to WHNF to collect its topmost effect.
 seqNix
   :: MonadNix e t f m
   => NValue t f m
@@ -896,7 +897,7 @@ seqNix
   -> m (NValue t f m)
 seqNix a b = b <$ demand a
 
--- | We evaluate 'a' only for its effects, so data cycles are ignored.
+-- | Evaluate 'a' to NF to collect all of its effects, therefore data cycles are ignored.
 deepSeqNix
   :: MonadNix e t f m
   => NValue t f m

--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -1302,9 +1302,7 @@ concatListsNix
 concatListsNix =
   toValue . concat <=<
     traverse
-      (pure <=<
-        (fromValue @[NValue t f m]) <=< demand
-      )
+      (fromValue @[NValue t f m] <=< demand)
       <=< fromValue @[NValue t f m]
 
 concatMapNix

--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -894,7 +894,7 @@ seqNix
   => NValue t f m
   -> NValue t f m
   -> m (NValue t f m)
-seqNix a b = const (pure b) =<< demand a
+seqNix a b = b <$ demand a
 
 -- | We evaluate 'a' only for its effects, so data cycles are ignored.
 deepSeqNix

--- a/src/Nix/Convert.hs
+++ b/src/Nix/Convert.hs
@@ -204,10 +204,10 @@ instance ( Convertible e t f m
           (addPath p)
       NVSet' s _ ->
         maybe
-          (pure mempty)
+          stub
           fromValueMay
           (M.lookup "outPath" s)
-      _ -> pure mempty
+      _ -> stub
 
   fromValue = fromMayToValue (TString NoContext)
 
@@ -262,7 +262,7 @@ instance ( Convertible e t f m
   fromValueMay =
     \case
       Deeper (NVList' l) -> sequence <$> traverse fromValueMay l
-      _                  -> pure mempty
+      _                  -> stub
 
 
   fromValue = fromMayToDeeperValue TList
@@ -286,7 +286,7 @@ instance ( Convertible e t f m
   fromValueMay =
     \case
       Deeper (NVSet' s _) -> sequence <$> traverse fromValueMay s
-      _                   -> pure mempty
+      _                   -> stub
 
   fromValue = fromMayToDeeperValue TSet
 
@@ -311,7 +311,7 @@ instance ( Convertible e t f m
   fromValueMay =
     \case
       Deeper (NVSet' s p) -> fmap (, p) . sequence <$> traverse fromValueMay s
-      _                   -> pure mempty
+      _                   -> stub
 
   fromValue = fromMayToDeeperValue TSet
 
@@ -400,7 +400,11 @@ instance Convertible e t f m
 
 instance (Convertible e t f m, ToValue a m (NValue t f m))
   => ToValue (AttrSet a) m (Deeper (NValue' t f m (NValue t f m))) where
-  toValue s = (\ v s -> Deeper $ nvSet' s v) <$> traverse toValue s <*> pure mempty
+  toValue s =
+    liftA2
+      (\ v s -> Deeper $ nvSet' s v)
+      (traverse toValue s)
+      stub
 
 instance Convertible e t f m
   => ToValue (AttrSet (NValue t f m), AttrSet SourcePos) m

--- a/src/Nix/Convert.hs
+++ b/src/Nix/Convert.hs
@@ -171,9 +171,9 @@ instance Convertible e t f m
 
   fromValueMay =
     pure .
-    \case
-      NVConstant' (NInt b) -> pure b
-      _                    -> Nothing
+      \case
+        NVConstant' (NInt b) -> pure b
+        _                    -> Nothing
 
   fromValue = fromMayToValue TInt
 

--- a/src/Nix/Convert.hs
+++ b/src/Nix/Convert.hs
@@ -139,7 +139,7 @@ instance Convertible e t f m
   fromValueMay =
     pure .
       \case
-        NVConstant' NNull -> pure ()
+        NVConstant' NNull -> pass
         _                 -> mempty
 
   fromValue = fromMayToValue TNull

--- a/src/Nix/Convert.hs
+++ b/src/Nix/Convert.hs
@@ -11,7 +11,6 @@
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
-{-# LANGUAGE InstanceSigs #-}
 
 {-# OPTIONS_GHC -fno-warn-name-shadowing #-}
 

--- a/src/Nix/Effects.hs
+++ b/src/Nix/Effects.hs
@@ -439,7 +439,11 @@ parseStoreResult name res =
   logs = snd res
 
 addTextToStore :: (Framed e m, MonadStore m) => StorePathName -> Text -> Store.StorePathSet -> RepairFlag -> m StorePath
-addTextToStore a b c d = either throwError pure =<< addTextToStore' a b c d
+addTextToStore a b c d =
+  either
+    throwError
+    pure
+    =<< addTextToStore' a b c d
 
 addPath :: (Framed e m, MonadStore m) => FilePath -> m StorePath
 addPath p =

--- a/src/Nix/Effects/Basic.hs
+++ b/src/Nix/Effects/Basic.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TupleSections #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE ViewPatterns #-}
 

--- a/src/Nix/Eval.hs
+++ b/src/Nix/Eval.hs
@@ -172,7 +172,7 @@ eval (NAbs    params body) = do
   scope <- currentScopes :: m (Scopes m v)
   evalAbs params $ \arg k -> withScopes scope $ do
     args <- buildArgument params arg
-    pushScope args (k (fmap (withScopes scope . inform) args) body)
+    pushScope args (k (withScopes scope . inform <$> args) body)
 
 eval (NSynHole name) = synHole name
 

--- a/src/Nix/Eval.hs
+++ b/src/Nix/Eval.hs
@@ -429,7 +429,7 @@ evalSetterKeyName
   -> m (Maybe Text)
 evalSetterKeyName =
   \case
-    StaticKey k -> pure (pure k)
+    StaticKey k -> pure $ pure k
     DynamicKey k ->
       maybe
         mempty
@@ -447,7 +447,7 @@ assembleString =
       Indented   _ parts -> parts
       DoubleQuoted parts -> parts
  where
-  fromParts = fmap (fmap mconcat . sequence) . traverse go
+  fromParts xs = (mconcat <$>) . sequence <$> traverse go xs
 
   go =
     runAntiquoted
@@ -469,7 +469,7 @@ buildArgument params arg =
             inject =
               maybe
                 id
-                (\ n -> M.insert n $ const $ defer (withScopes scope arg))
+                (\ n -> M.insert n $ const $ defer $ withScopes scope arg)
                 m
           loebM
             (inject $
@@ -478,7 +478,8 @@ buildArgument params arg =
                   (ialignWith
                     (assemble scope isVariadic)
                     args
-                    (M.fromList s))
+                    $ M.fromList s
+                  )
             )
  where
   assemble

--- a/src/Nix/Eval.hs
+++ b/src/Nix/Eval.hs
@@ -208,7 +208,7 @@ attrSetAlter (k : ks) pos m p val =
       (\x ->
         do
           (st, sp) <- fromValue @(AttrSet v, AttrSet SourcePos) =<< x
-          recurse ((pure <=< demand) <$> st) sp
+          recurse (demand <$> st) sp
       )
       (M.lookup k m)
     )
@@ -359,7 +359,7 @@ evalBinds recursive binds =
             , pos
             , maybe
                 (attrMissing (key :| []) Nothing)
-                (pure <=< demand)
+                demand
                 =<< maybe
                     (withScopes scope $ lookupVar key)
                     (\ s ->

--- a/src/Nix/Eval.hs
+++ b/src/Nix/Eval.hs
@@ -303,7 +303,7 @@ evalBinds recursive binds =
         (\ (k, v) ->
           ( [k]
           , fromMaybe pos (M.lookup k p')
-          , pure =<< demand v
+          , demand v
           )
         ) <$>
         M.toList o'
@@ -403,9 +403,10 @@ evalSelect aset attr =
           | Just t <- M.lookup k s ->
             do
               list
-                (pure $ pure $ pure =<< demand t)
-                (\ (y : ys) -> (extract ?? (y :| ys)) =<< demand t)
+                (pure . pure)
+                (\ (y : ys) -> ((extract ?? (y :| ys)) =<<))
                 ks
+                $ demand t
           | otherwise -> Left . (, path) <$> toValue (s, p)
 
 -- | Evaluate a component of an attribute path in a context where we are

--- a/src/Nix/Expr/Strings.hs
+++ b/src/Nix/Expr/Strings.hs
@@ -59,25 +59,27 @@ unsplitLines = intercalate [Plain "\n"]
 stripIndent :: [Antiquoted Text r] -> NString r
 stripIndent [] = Indented 0 mempty
 stripIndent xs =
-  Indented minIndent
-    . removePlainEmpty
-    . mergePlain
-    . fmap snd
-    . dropWhileEnd cleanup
-    . (\ ys ->
-        zip
-          (list
-            Nothing
-            (pure . Unsafe.last)
-            <$> inits ys
-          )
-          ys
-      )
-    . unsplitLines
-    $ ls'
+  Indented
+    minIndent
+    (removePlainEmpty $
+      mergePlain $
+        (snd <$>) $
+          dropWhileEnd
+            cleanup
+            $ pairWithLast $ unsplitLines ls'
+    )
  where
+  pairWithLast ys =
+    zip
+      (list
+        Nothing
+        (pure . Unsafe.last)
+        <$> inits ys
+      )
+      ys
+
   ls        = stripEmptyOpening $ splitLines xs
-  ls'       = fmap (dropSpaces minIndent) ls
+  ls'       = dropSpaces minIndent <$> ls
 
   minIndent =
     list

--- a/src/Nix/Expr/Strings.hs
+++ b/src/Nix/Expr/Strings.hs
@@ -64,15 +64,14 @@ stripIndent xs =
     . mergePlain
     . fmap snd
     . dropWhileEnd cleanup
-    . (\ys -> zip
-        (fmap
+    . (\ ys ->
+        zip
           (list
             Nothing
             (pure . Unsafe.last)
+            <$> inits ys
           )
-          (inits ys)
-        )
-        ys
+          ys
       )
     . unsplitLines
     $ ls'
@@ -80,9 +79,11 @@ stripIndent xs =
   ls        = stripEmptyOpening $ splitLines xs
   ls'       = fmap (dropSpaces minIndent) ls
 
-  minIndent = case stripEmptyLines ls of
-    []         -> 0
-    nonEmptyLs -> minimum $ fmap (countSpaces . mergePlain) nonEmptyLs
+  minIndent =
+    list
+      0
+      (minimum . (countSpaces . mergePlain <$>))
+      (stripEmptyLines ls)
 
   stripEmptyLines = filter $ \case
     [Plain t] -> not $ T.null $ T.strip t

--- a/src/Nix/Expr/Types/Annotated.hs
+++ b/src/Nix/Expr/Types/Annotated.hs
@@ -166,7 +166,7 @@ deltaInfo :: SourcePos -> (Text, Int, Int)
 deltaInfo (SourcePos fp l c) = (toText fp, unPos l, unPos c)
 
 nNull :: NExprLoc
-nNull = Fix (Compose (Ann nullSpan (NConstant NNull)))
+nNull = Fix $ Compose $ Ann nullSpan $ NConstant NNull
 {-# inline nNull #-}
 
 nullSpan :: SrcSpan

--- a/src/Nix/Expr/Types/Annotated.hs
+++ b/src/Nix/Expr/Types/Annotated.hs
@@ -130,37 +130,37 @@ stripAnn :: AnnF ann f r -> f r
 stripAnn = annotated . getCompose
 
 nUnary :: Ann SrcSpan NUnaryOp -> NExprLoc -> NExprLoc
-nUnary (Ann s1 u) e1@(AnnE s2 _) = AnnE (s1 <> s2) (NUnary u e1)
+nUnary (Ann s1 u) e1@(AnnE s2 _) = AnnE (s1 <> s2) $ NUnary u e1
 nUnary _          _              = error "nUnary: unexpected"
 {-# inline nUnary #-}
 
 nBinary :: Ann SrcSpan NBinaryOp -> NExprLoc -> NExprLoc -> NExprLoc
 nBinary (Ann s1 b) e1@(AnnE s2 _) e2@(AnnE s3 _) =
-  AnnE (s1 <> s2 <> s3) (NBinary b e1 e2)
+  AnnE (s1 <> s2 <> s3) $ NBinary b e1 e2
 nBinary _ _ _ = error "nBinary: unexpected"
 
 nSelectLoc
   :: NExprLoc -> Ann SrcSpan (NAttrPath NExprLoc) -> Maybe NExprLoc -> NExprLoc
 nSelectLoc e1@(AnnE s1 _) (Ann s2 ats) d = case d of
-  Nothing               -> AnnE (s1 <> s2) (NSelect e1 ats Nothing)
-  Just e2@(AnnE s3 _) -> AnnE (s1 <> s2 <> s3) (NSelect e1 ats (pure e2))
+  Nothing               -> AnnE (s1 <> s2) $ NSelect e1 ats Nothing
+  Just e2@(AnnE s3 _) -> AnnE (s1 <> s2 <> s3) $ NSelect e1 ats $ pure e2
   _                     -> error "nSelectLoc: unexpected"
 nSelectLoc _ _ _ = error "nSelectLoc: unexpected"
 
 nHasAttr :: NExprLoc -> Ann SrcSpan (NAttrPath NExprLoc) -> NExprLoc
-nHasAttr e1@(AnnE s1 _) (Ann s2 ats) = AnnE (s1 <> s2) (NHasAttr e1 ats)
+nHasAttr e1@(AnnE s1 _) (Ann s2 ats) = AnnE (s1 <> s2) $ NHasAttr e1 ats
 nHasAttr _              _            = error "nHasAttr: unexpected"
 
 nApp :: NExprLoc -> NExprLoc -> NExprLoc
-nApp e1@(AnnE s1 _) e2@(AnnE s2 _) = AnnE (s1 <> s2) (NBinary NApp e1 e2)
+nApp e1@(AnnE s1 _) e2@(AnnE s2 _) = AnnE (s1 <> s2) $ NBinary NApp e1 e2
 nApp _              _              = error "nApp: unexpected"
 
 nAbs :: Ann SrcSpan (Params NExprLoc) -> NExprLoc -> NExprLoc
-nAbs (Ann s1 ps) e1@(AnnE s2 _) = AnnE (s1 <> s2) (NAbs ps e1)
+nAbs (Ann s1 ps) e1@(AnnE s2 _) = AnnE (s1 <> s2) $ NAbs ps e1
 nAbs _           _              = error "nAbs: unexpected"
 
 nStr :: Ann SrcSpan (NString NExprLoc) -> NExprLoc
-nStr (Ann s1 s) = AnnE s1 (NStr s)
+nStr (Ann s1 s) = AnnE s1 $ NStr s
 
 deltaInfo :: SourcePos -> (Text, Int, Int)
 deltaInfo (SourcePos fp l c) = (toText fp, unPos l, unPos c)

--- a/src/Nix/Lint.hs
+++ b/src/Nix/Lint.hs
@@ -177,8 +177,8 @@ merge context = go
     :: [NTypeF m (Symbolic m)]
     -> [NTypeF m (Symbolic m)]
     -> m [NTypeF m (Symbolic m)]
-  go []       _        = pure mempty
-  go _        []       = pure mempty
+  go []       _        = stub
+  go _        []       = stub
   go (x : xs) (y : ys) = case (x, y) of
     (TStr , TStr ) -> (TStr :) <$> go xs ys
     (TPath, TPath) -> (TPath :) <$> go xs ys

--- a/src/Nix/Pretty.hs
+++ b/src/Nix/Pretty.hs
@@ -342,14 +342,16 @@ prettyNValueProv
   => NValue t f m
   -> Doc ann
 prettyNValueProv v =
-  case citations @m @(NValue t f m) v of
-    [] -> prettyNVal
-    ps ->
+  list
+    prettyNVal
+    (\ ps ->
       fillSep
         [ prettyNVal
         , indent 2 $
-          "(" <> mconcat ("from: ":(prettyOriginExpr . _originExpr <$> ps)) <> ")"
+          "(" <> mconcat ("from: " : (prettyOriginExpr . _originExpr <$> ps)) <> ")"
         ]
+    )
+    (citations @m @(NValue t f m) v)
  where
   prettyNVal = prettyNValue v
 
@@ -366,12 +368,12 @@ prettyNThunk t =
   do
     let ps = citations @m @(NValue t f m) @t t
     v' <- prettyNValue <$> dethunk t
-    pure
-      $ fillSep
-          [ v'
-          , indent 2 $
-              "(" <> mconcat ( "thunk from: " : fmap (prettyOriginExpr . _originExpr) ps) <> ")"
-          ]
+    pure $
+      fillSep
+        [ v'
+        , indent 2 $
+          "(" <> mconcat ( "thunk from: " : (prettyOriginExpr . _originExpr <$> ps)) <> ")"
+        ]
 
 -- | This function is used only by the testing code.
 printNix :: forall t f m . MonadDataContext f m => NValue t f m -> String

--- a/src/Nix/Reduce.hs
+++ b/src/Nix/Reduce.hs
@@ -448,7 +448,7 @@ pruneTree opts =
       second $
         bool
           fmap
-          (\ f -> pure . maybe nNull f)
+          ((pure .) . maybe nNull)
           (reduceSets opts)  -- Reduce set members that aren't used; breaks if hasAttr is used
           (fromMaybe nNull)
 

--- a/src/Nix/Reduce.hs
+++ b/src/Nix/Reduce.hs
@@ -442,12 +442,18 @@ pruneTree opts =
 
   pruneParams :: Params (Maybe NExprLoc) -> Params NExprLoc
   pruneParams (Param n) = Param n
-  pruneParams (ParamSet xs b n)
-    | reduceSets opts = ParamSet
-      (fmap (second (pure . (maybe nNull (fromMaybe nNull)))) xs)
+  pruneParams (ParamSet xs b n) =
+    ParamSet
+      (second
+        (bool
+          fmap
+          (\ f -> pure . maybe nNull f)
+          (reduceSets opts)
+          (fromMaybe nNull)
+        ) <$> xs
+      )
       b
       n
-    | otherwise = ParamSet (fmap (second (fmap (fromMaybe nNull))) xs) b n
 
   pruneBinding :: Binding (Maybe NExprLoc) -> Maybe (Binding NExprLoc)
   pruneBinding (NamedVar _ Nothing _)           = Nothing

--- a/src/Nix/Reduce.hs
+++ b/src/Nix/Reduce.hs
@@ -455,11 +455,11 @@ pruneTree opts =
   pruneBinding :: Binding (Maybe NExprLoc) -> Maybe (Binding NExprLoc)
   pruneBinding (NamedVar _ Nothing _)           = Nothing
   pruneBinding (NamedVar xs (Just x) pos)       =
-    pure (NamedVar (NE.map pruneKeyName xs) x pos)
+    pure $ NamedVar (NE.map pruneKeyName xs) x pos
   pruneBinding (Inherit _                 [] _) = Nothing
   pruneBinding (Inherit (join -> Nothing) _  _)  = Nothing
   pruneBinding (Inherit (join -> m) xs pos)      =
-    pure (Inherit m (fmap pruneKeyName xs) pos)
+    pure $ Inherit m (pruneKeyName <$> xs) pos
 
 reducingEvalExpr
   :: (Framed e m, Has e Options, Exception r, MonadCatch m, MonadIO m)

--- a/src/Nix/Reduce.hs
+++ b/src/Nix/Reduce.hs
@@ -349,13 +349,10 @@ pruneTree :: MonadIO n => Options -> Flagged NExprLocF -> n (Maybe NExprLoc)
 pruneTree opts =
   foldFixM $
     \(FlaggedF (b, Compose x)) ->
-      do
-        used <- liftIO $ readIORef b
-        pure $
-          bool
-            Nothing
-            (Fix . Compose <$> traverse prune x)
-            used
+      bool
+        Nothing
+        (Fix . Compose <$> traverse prune x)
+        <$> liftIO (readIORef b)
  where
   prune :: NExprF (Maybe NExprLoc) -> Maybe (NExprF NExprLoc)
   prune = \case

--- a/src/Nix/Render/Frame.hs
+++ b/src/Nix/Render/Frame.hs
@@ -186,12 +186,14 @@ renderValueFrame level = fmap (: mempty) . \case
   Coercion       x y -> pure
     $ mconcat [desc, pretty (describeValue x), " to ", pretty (describeValue y)]
    where
-    desc | level <= Error = "Cannot coerce "
-         | otherwise      = "While coercing "
+    desc =
+      bool
+      "While coercing "
+      "Cannot coerce "
+      (level <= Error)
 
-  CoercionToJson v -> do
-    v' <- renderValue level "" "" v
-    pure $ "CoercionToJson " <> v'
+  CoercionToJson v ->
+    ("CoercionToJson " <>) <$> renderValue level "" "" v
   CoercionFromJson _j -> pure "CoercionFromJson"
   Expectation t v     -> do
     v' <- renderValue @_ @t @f @m level "" "" v

--- a/src/Nix/Render/Frame.hs
+++ b/src/Nix/Render/Frame.hs
@@ -248,6 +248,4 @@ renderNormalLoop level =
     (: mempty)
     . \case
       NormalLoop v ->
-        do
-          v' <- renderValue level "" "" v
-          pure $ "Infinite recursion during normalization forcing " <> v'
+        ("Infinite recursion during normalization forcing " <>) <$> renderValue level "" "" v

--- a/src/Nix/Render/Frame.hs
+++ b/src/Nix/Render/Frame.hs
@@ -195,9 +195,10 @@ renderValueFrame level = fmap (: mempty) . \case
   CoercionToJson v ->
     ("CoercionToJson " <>) <$> renderValue level "" "" v
   CoercionFromJson _j -> pure "CoercionFromJson"
-  Expectation t v     -> do
-    v' <- renderValue @_ @t @f @m level "" "" v
-    pure $ "Saw " <> v' <> " but expected " <> pretty (describeValue t)
+  Expectation t v     ->
+    (msg <>) <$> renderValue @_ @t @f @m level "" "" v
+   where
+    msg = "Expected " <> pretty (describeValue t) <> ", but saw "
 
 renderValue
   :: forall e t f m ann

--- a/src/Nix/Render/Frame.hs
+++ b/src/Nix/Render/Frame.hs
@@ -43,7 +43,7 @@ renderFrames
      )
   => Frames
   -> m (Doc ann)
-renderFrames []       = pure mempty
+renderFrames []       = stub
 renderFrames (x : xs) = do
   opts :: Options <- asks (view hasLens)
   frames          <- if
@@ -139,10 +139,10 @@ renderEvalFrame level f =
 
           [ renderLocation ann =<<
               renderExpr level "While evaluating" "Syntactic Hole" e
-          , pure $ pretty $ Text.show (_synHoleInfo_scope synfo)
+          , pure $ pretty $ Text.show $ _synHoleInfo_scope synfo
           ]
 
-      ForcingExpr _ _ -> pure mempty
+      ForcingExpr _ _ -> stub
 
 
 renderExpr

--- a/src/Nix/String/Coerce.hs
+++ b/src/Nix/String/Coerce.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE LambdaCase #-}
 
 module Nix.String.Coerce where
 

--- a/src/Nix/Type/Infer.hs
+++ b/src/Nix/Type/Infer.hs
@@ -574,7 +574,7 @@ instance
   Monad m
   => FromValue NixString (InferT s m) (Judgment s)
  where
-  fromValueMay _ = pure mempty
+  fromValueMay _ = stub
   fromValue _ = error "Unused"
 
 instance
@@ -587,7 +587,7 @@ instance
     do
       let sing _ = Judgment As.empty mempty
       pure $ pure (M.mapWithKey sing xs, mempty)
-  fromValueMay _ = pure mempty
+  fromValueMay _ = stub
   fromValue =
     pure .
       fromMaybe

--- a/src/Nix/Utils.hs
+++ b/src/Nix/Utils.hs
@@ -32,7 +32,7 @@ import           Debug.Trace as X
 trace :: String -> a -> a
 trace = const id
 traceM :: Monad m => String -> m ()
-traceM = const $ pure ()
+traceM = const pass
 #endif
 
 $(makeLensesBy (\n -> pure ("_" <> n)) ''Fix)

--- a/src/Nix/Utils.hs
+++ b/src/Nix/Utils.hs
@@ -231,3 +231,9 @@ dup x = (x, x)
 mapPair :: (a -> c, b -> d) -> (a,b) -> (c,d)
 mapPair ~(f,g) ~(a,b) = (f a, g b)
 {-# inline mapPair #-}
+
+-- After migration from the @relude@ - @relude: pass -> stub@
+-- | @pure mempty@: Short-curcuit, stub.
+stub :: (Applicative f, Monoid a) => f a
+stub = pure mempty
+{-# inline stub #-}

--- a/src/Nix/Utils.hs
+++ b/src/Nix/Utils.hs
@@ -75,7 +75,10 @@ lifted
   => ((a -> m (StT u b)) -> m (StT u b))
   -> (a -> u m b)
   -> u m b
-lifted f k = restoreT . pure =<< liftWith (\run -> f (run . k))
+lifted f k =
+  do
+    lftd <- liftWith (\run -> f (run . k))
+    restoreT $ pure lftd
 
 -- | Replace:
 --  @Pure a -> a@

--- a/src/Nix/Utils.hs
+++ b/src/Nix/Utils.hs
@@ -32,7 +32,7 @@ import           Debug.Trace as X
 trace :: String -> a -> a
 trace = const id
 traceM :: Monad m => String -> m ()
-traceM = const (pure ())
+traceM = const $ pure ()
 #endif
 
 $(makeLensesBy (\n -> pure ("_" <> n)) ''Fix)

--- a/src/Nix/Value.hs
+++ b/src/Nix/Value.hs
@@ -204,7 +204,11 @@ sequenceNValueF transform = \case
   NVStrF      s  -> pure $ NVStrF s
   NVPathF     p  -> pure $ NVPathF p
   NVListF     l  -> NVListF <$> sequenceA l
-  NVSetF     s p -> NVSetF <$> sequenceA s <*> pure p
+  NVSetF     s p ->
+    liftA2
+      NVSetF
+      (sequenceA s)
+      (pure p)
   NVClosureF p g -> pure $ NVClosureF p (transform <=< g)
   NVBuiltinF s g -> pure $ NVBuiltinF s (transform <=< g)
 
@@ -223,7 +227,11 @@ bindNValueF transform f = \case
   NVStrF      s  -> pure $ NVStrF s
   NVPathF     p  -> pure $ NVPathF p
   NVListF     l  -> NVListF <$> traverse f l
-  NVSetF     s p -> NVSetF <$> traverse f s <*> pure p
+  NVSetF     s p ->
+    liftA2
+      NVSetF
+      (traverse f s)
+      (pure p)
   NVClosureF p g -> pure $ NVClosureF p (transform . f <=< g)
   NVBuiltinF s g -> pure $ NVBuiltinF s (transform . f <=< g)
 

--- a/src/Nix/Value.hs
+++ b/src/Nix/Value.hs
@@ -727,7 +727,7 @@ valueType =
 
 
 -- | Describe type value
-describeValue :: ValueType -> String
+describeValue :: ValueType -> Text
 describeValue =
   \case
     TInt               -> "an integer"
@@ -745,7 +745,7 @@ describeValue =
 
 showValueType :: (MonadThunk t m (NValue t f m), Comonad f)
   => NValue t f m
-  -> m String
+  -> m Text
 showValueType (Pure t) = showValueType =<< force t
 showValueType (Free (NValue' (extract -> v))) =
   pure $ describeValue $ valueType v

--- a/src/Nix/Value/Equal.hs
+++ b/src/Nix/Value/Equal.hs
@@ -38,17 +38,17 @@ checkComparable
   -> m ()
 checkComparable x y =
   case (x, y) of
-    (NVConstant (NFloat _), NVConstant (NInt   _)) -> pure ()
-    (NVConstant (NInt   _), NVConstant (NFloat _)) -> pure ()
-    (NVConstant (NInt   _), NVConstant (NInt   _)) -> pure ()
-    (NVConstant (NFloat _), NVConstant (NFloat _)) -> pure ()
-    (NVStr       _        , NVStr       _        ) -> pure ()
-    (NVPath      _        , NVPath      _        ) -> pure ()
+    (NVConstant (NFloat _), NVConstant (NInt   _)) -> pass
+    (NVConstant (NInt   _), NVConstant (NFloat _)) -> pass
+    (NVConstant (NInt   _), NVConstant (NInt   _)) -> pass
+    (NVConstant (NFloat _), NVConstant (NFloat _)) -> pass
+    (NVStr       _        , NVStr       _        ) -> pass
+    (NVPath      _        , NVPath      _        ) -> pass
     _                                              -> throwError $ Comparison x y
 
 -- | Checks whether two containers are equal, using the given item equality
 --   predicate. If there are any item slots that don't match between the two
---   containers, the result will be False.
+--   containers, the result will be @False@.
 alignEqM
   :: (Align f, Traversable f, Monad m)
   => (a -> b -> m Bool)

--- a/src/Nix/Value/Equal.hs
+++ b/src/Nix/Value/Equal.hs
@@ -83,15 +83,12 @@ isDerivationM f m =
   maybe
     (pure False)
     (\ t ->
-      do
-        mres <- f t
-
-        maybe
-          -- We should probably really make sure the context is empty here
-          -- but the C++ implementation ignores it.
-          (pure False)
-          (pure . (==) "derivation" . stringIgnoreContext)
-          mres
+      maybe
+        -- We should probably really make sure the context is empty here
+        -- but the C++ implementation ignores it.
+        False
+        ((==) "derivation" . stringIgnoreContext)
+        <$> f t
     )
     (HashMap.Lazy.lookup "type" m)
 

--- a/src/Nix/Value/Equal.hs
+++ b/src/Nix/Value/Equal.hs
@@ -57,10 +57,7 @@ alignEqM
   -> m Bool
 alignEqM eq fa fb =
   fmap
-    (either
-      (const False)
-      (const True)
-    )
+    isRight
     $ runExceptT $
       do
         pairs <-

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -71,7 +71,7 @@ ensureNixpkgsCanParse =
             -- Parse and deepseq the resulting expression tree, to ensure the
             -- parser is fully executed.
             _ <- consider file (parseNixFileLoc file) $ Exc.evaluate . force
-            pure ()
+            pass
     v -> fail $ "Unexpected parse from default.nix: " <> show v
  where
   getExpr   k m = let Just (Just r) = lookup k m in r

--- a/tests/NixLanguageTests.hs
+++ b/tests/NixLanguageTests.hs
@@ -101,7 +101,7 @@ assertParse _opts file =
     x <- parseNixFileLoc file
     either
       (\ err -> assertFailure $ "Failed to parse " <> file <> ":\n" <> show err)
-      (const $ pure ())  -- pure $! runST $ void $ lint opts expr
+      (const pass)  -- pure $! runST $ void $ lint opts expr
       x
 
 assertParseFail :: Options -> FilePath -> Assertion
@@ -109,7 +109,7 @@ assertParseFail opts file = do
   eres <- parseNixFileLoc file
   catch
       (either
-        (const $ pure ())
+        (const pass)
         (\ expr ->
           do
             _ <- pure $! runST $ void $ lint opts expr
@@ -117,7 +117,7 @@ assertParseFail opts file = do
         )
         eres
       )
-      $ \(_ :: SomeException) -> pure ()
+      $ \(_ :: SomeException) -> pass
 
 assertLangOk :: Options -> FilePath -> Assertion
 assertLangOk opts file = do
@@ -141,8 +141,8 @@ assertEval _opts files = do
     []                 -> () <$ hnixEvalFile opts (name <> ".nix")
     [".exp"         ]  -> assertLangOk opts name
     [".exp.xml"     ]  -> assertLangOkXml opts name
-    [".exp.disabled"]  -> pure ()
-    [".exp-disabled"]  -> pure ()
+    [".exp.disabled"]  -> pass
+    [".exp-disabled"]  -> pass
     [".exp", ".flags"] -> do
       liftIO $ setEnv "NIX_PATH" "lang/dir4:lang/dir5"
       flags <- Text.readFile (name <> ".flags")
@@ -168,7 +168,7 @@ assertEval _opts files = do
   fixup []                          = mempty
 
 assertEvalFail :: FilePath -> Assertion
-assertEvalFail file = catch ?? (\(_ :: SomeException) -> pure ()) $ do
+assertEvalFail file = catch ?? (\(_ :: SomeException) -> pass) $ do
   time       <- liftIO getCurrentTime
   evalResult <- printNix <$> hnixEvalFile (defaultOptions time) file
   evalResult `seq`

--- a/tests/ParserTests.hs
+++ b/tests/ParserTests.hs
@@ -393,7 +393,7 @@ assertParseFile file expected =
 assertParseFail :: Text -> Assertion
 assertParseFail str =
   either
-    (const $ pure ())
+    (const pass)
     (\ r ->
       assertFailure $ toString $ "Unexpected success parsing `" <> str <> ":\nParsed value: " <> show r
     )

--- a/tests/PrettyParseTests.hs
+++ b/tests/PrettyParseTests.hs
@@ -21,6 +21,7 @@ import           Nix.Atoms
 import           Nix.Expr
 import           Nix.Parser
 import           Nix.Pretty
+import           Nix.Utils
 import           Prettyprinter
 import           Test.Tasty
 import           Test.Tasty.Hedgehog
@@ -93,7 +94,7 @@ genParams = Gen.choice
       ParamSet
       (Gen.list (Range.linear 0 10) (liftA2 (,) asciiText $ Gen.maybe genExpr))
       Gen.bool
-      (Gen.choice [pure mempty, pure <$> asciiText])
+      (Gen.choice [stub, pure <$> asciiText])
   ]
 
 genAtom :: Gen NAtom


### PR DESCRIPTION
In refactor streak, this is the last bunch of refactors.
Further moving to more challenging & pressing questions. After their assortment, since these long sequences of reactors & self-merges started feeling risqué, the streak of test writing would be beneficial.

  * monad-law clean-ups: `(pure . f =<< a -> <$>)`, `(pure . f <=< -> <$>)`.
  * monoid law: `(pure <=< ->)`.
  * some easy remaining `-> Text` migrations.
  * Builtins: seqNix: `(const (pure b) <=< -> b <$)` - deduced as equivalent transformation. `seqNix` was implemented & behaves as in GHC & was/is lazy in the first argument when used.
  * `(pure () -> pass)` && `(pure empty -> stub)`, as they are used everywhere to return a base stub case/short-circuit algorithms, `pass & stub` hence `Relude` already defined `pass = pure ()`, they can be merged together after migration to new base.
  * some layouts for easier reading of the code.