### PR TITLE
Updating deps

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -189,6 +189,7 @@ let
     overrides = self: super: {
 
       ref-tf = super.ref-tf_0_5;
+      semialign = super.semialign_1_2;
       relude = super.relude_1_0_0_1;
 
     };

--- a/default.nix
+++ b/default.nix
@@ -189,6 +189,7 @@ let
     overrides = self: super: {
 
       ref-tf = super.ref-tf_0_5;
+      relude = super.relude_1_0_0_1;
 
     };
 

--- a/hnix.cabal
+++ b/hnix.cabal
@@ -502,7 +502,6 @@ executable hnix
     , serialise
     , template-haskell
     , time
-    , transformers
     , unordered-containers
   mixins:
       base hiding (Prelude)
@@ -565,7 +564,6 @@ test-suite hnix-tests
     , serialise
     , template-haskell
     , time
-    , transformers
     , unix
     , unordered-containers
   default-extensions:
@@ -602,7 +600,6 @@ benchmark hnix-benchmarks
     , serialise
     , template-haskell
     , time
-    , transformers
     , unordered-containers
   default-extensions:
     OverloadedStrings

--- a/hnix.cabal
+++ b/hnix.cabal
@@ -441,7 +441,6 @@ library
     , regex-tdfa >= 1.2.3 && < 1.4
     , relude >= 0.7.0 && < 1.1.0
     , scientific >= 0.3.6 && < 0.4
-    , semialign-indexed >= 1 && < 1.2
     , semialign >= 1 && < 1.3
     , serialise >= 0.2.1 && < 0.3
     , some >= 1.0.1 && < 1.1

--- a/hnix.cabal
+++ b/hnix.cabal
@@ -439,7 +439,7 @@ library
     , process >= 1.6.3 && < 1.7
     , ref-tf >= 0.5 && < 0.6
     , regex-tdfa >= 1.2.3 && < 1.4
-    , relude >= 0.7.0 && < 1.0.0
+    , relude >= 0.7.0 && < 1.1.0
     , scientific >= 0.3.6 && < 0.4
     , semialign >= 1 && < 1.2
     , semialign-indexed >= 1 && < 1.2

--- a/hnix.cabal
+++ b/hnix.cabal
@@ -485,7 +485,6 @@ executable hnix
   build-depends:
       aeson
     , base
-    , base16-bytestring
     , bytestring
     , comonad
     , containers
@@ -548,7 +547,6 @@ test-suite hnix-tests
       Diff
     , Glob
     , base
-    , base16-bytestring
     , bytestring
     , containers
     , data-fix
@@ -601,7 +599,6 @@ benchmark hnix-benchmarks
   ghc-options: -Wall
   build-depends:
       base
-    , base16-bytestring
     , bytestring
     , containers
     , criterion

--- a/hnix.cabal
+++ b/hnix.cabal
@@ -503,7 +503,6 @@ executable hnix
     , repline >= 0.4.0.0 && < 0.5
     , serialise
     , template-haskell
-    , text
     , time
     , transformers
     , unordered-containers
@@ -569,7 +568,6 @@ test-suite hnix-tests
     , tasty-th
     , serialise
     , template-haskell
-    , text
     , time
     , transformers
     , unix
@@ -609,7 +607,6 @@ benchmark hnix-benchmarks
     , relude
     , serialise
     , template-haskell
-    , text
     , time
     , transformers
     , unordered-containers

--- a/hnix.cabal
+++ b/hnix.cabal
@@ -502,7 +502,6 @@ executable hnix
     , serialise
     , template-haskell
     , time
-    , unordered-containers
   mixins:
       base hiding (Prelude)
     , relude (Relude as Prelude)
@@ -565,7 +564,6 @@ test-suite hnix-tests
     , template-haskell
     , time
     , unix
-    , unordered-containers
   default-extensions:
     OverloadedStrings
   if flag(optimize)
@@ -600,7 +598,6 @@ benchmark hnix-benchmarks
     , serialise
     , template-haskell
     , time
-    , unordered-containers
   default-extensions:
     OverloadedStrings
   if flag(optimize)

--- a/hnix.cabal
+++ b/hnix.cabal
@@ -485,7 +485,6 @@ executable hnix
   build-depends:
       aeson
     , base
-    , bytestring
     , comonad
     , containers
     , data-fix
@@ -547,7 +546,6 @@ test-suite hnix-tests
       Diff
     , Glob
     , base
-    , bytestring
     , containers
     , data-fix
     , deepseq
@@ -599,7 +597,6 @@ benchmark hnix-benchmarks
   ghc-options: -Wall
   build-depends:
       base
-    , bytestring
     , containers
     , criterion
     , data-fix

--- a/hnix.cabal
+++ b/hnix.cabal
@@ -546,7 +546,6 @@ test-suite hnix-tests
     , base
     , containers
     , data-fix
-    , deepseq
     , directory
     , exceptions
     , filepath
@@ -597,7 +596,6 @@ benchmark hnix-benchmarks
     , containers
     , criterion
     , data-fix
-    , deepseq
     , exceptions
     , filepath
     , hnix

--- a/hnix.cabal
+++ b/hnix.cabal
@@ -441,8 +441,8 @@ library
     , regex-tdfa >= 1.2.3 && < 1.4
     , relude >= 0.7.0 && < 1.1.0
     , scientific >= 0.3.6 && < 0.4
-    , semialign >= 1 && < 1.2
     , semialign-indexed >= 1 && < 1.2
+    , semialign >= 1 && < 1.3
     , serialise >= 0.2.1 && < 0.3
     , some >= 1.0.1 && < 1.1
     , split >= 0.2.3 && < 0.3

--- a/hnix.cabal
+++ b/hnix.cabal
@@ -587,7 +587,6 @@ benchmark hnix-benchmarks
   ghc-options: -Wall
   build-depends:
       base
-    , containers
     , criterion
     , data-fix
     , exceptions

--- a/hnix.cabal
+++ b/hnix.cabal
@@ -493,7 +493,6 @@ executable hnix
     , free
     , haskeline >= 0.8.0.0 && < 0.9
     , hnix
-    , mtl
     , optparse-applicative
     , pretty-show
     , prettyprinter
@@ -552,7 +551,6 @@ test-suite hnix-tests
     , hedgehog
     , hnix
     , megaparsec
-    , mtl
     , neat-interpolation
     , optparse-applicative
     , pretty-show
@@ -599,7 +597,6 @@ benchmark hnix-benchmarks
     , exceptions
     , filepath
     , hnix
-    , mtl
     , optparse-applicative
     , relude
     , serialise

--- a/hnix.cabal
+++ b/hnix.cabal
@@ -452,7 +452,7 @@ library
     --   * orphan instances for TH missing instances
     -- aka Lift Text, Bytestring, Vector, Containers,
     -- we use Lift Text particulrarly for GHC 8.6
-    , th-lift-instances
+    , th-lift-instances >= 0.1 && < 0.2
     , text >= 1.2.3 && < 1.3
     , these >= 1.0.1 && < 1.2
     , time >= 1.8.0 && < 1.9 || >= 1.9.3 && < 1.10

--- a/tests/EvalTests.hs
+++ b/tests/EvalTests.hs
@@ -8,6 +8,7 @@
 
 module EvalTests (tests, genEvalCompareTests) where
 
+import           Prelude hiding (lookupEnv)
 import           Control.Monad.Catch
 import           Data.List ((\\))
 import qualified Data.Set as S

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -4,6 +4,7 @@
 
 module Main where
 
+import           Prelude hiding (lookupEnv)
 import           Relude.Unsafe (read)
 import qualified Control.Exception as Exc
 import           GHC.Err (errorWithoutStackTrace)


### PR DESCRIPTION
Relude previous history: #900, #902 & 1.0 changelog: https://hackage.haskell.org/package/relude-1.0.0.1/changelog.

`base16-bytestring` used only in library.

`semialign-indexed` deprecated.

Removed some imports of packages that are not used (at least directly) in executable/tests/bench.

Added Nixpkgs overrides according to new versions & revision. The same would must be done after HNix release in the Nixpkgs derivation declaration.

etc.
