### PR TITLE
Fix CPP on Instances.TH.Lift import

### DIFF
--- a/src/Nix/Expr/Types.hs
+++ b/src/Nix/Expr/Types.hs
@@ -54,7 +54,7 @@ import           Text.Read.Deriving
 import           Text.Show.Deriving
 import qualified Type.Reflection               as Reflection
 import           Type.Reflection                ( eqTypeRep )
-#if !MIN_VERSION_base(4,13,0)
+#if !MIN_VERSION_text(1,2,4)
 -- NOTE: Remove package @th-lift-instances@ removing this
 import           Instances.TH.Lift              ()  -- importing Lift Text fo GHC 8.6
 #endif


### PR DESCRIPTION
This prevents a build error with GHC 8.10.1 and 8.10.2 which bundle
text-1.2.3.2:

    src/Nix/Expr/Types.hs:497:21: error:
        • Could not deduce (TH.Lift Text) arising from a use of ‘TH.lift’
          from the context: Data b
            bound by a type expected by the context:
                       forall b. Data b => b -> Maybe (TH.Q TH.Exp)
            at src/Nix/Expr/Types.hs:(490,7)-(498,7)
          or from: b ~ Text
            bound by a pattern with constructor:
                       HRefl :: forall k1 (a :: k1). a :~~: a,
                     in a pattern binding in
                          a 'do' block
            at src/Nix/Expr/Types.hs:493:11-15
        • In the expression: TH.lift b
          In the first argument of ‘pure’, namely
            ‘[| $(TH.lift b) |]
             pending(rn) [<splice, TH.lift b>]’
          In a stmt of a 'do' block:
            pure
              [| $(TH.lift b) |]
              pending(rn) [<splice, TH.lift b>]
        |
    497 |           pure [| $(TH.lift b) |]
        |                     ^^^^^^^^^

I had noticed the build failure in the Hackage build matrix: https://matrix.hackage.haskell.org/#/package/hnix/0.13.0/ghc-8.10.1@1620752895