### PR TITLE
More refactors

### DIFF
--- a/hnix.cabal
+++ b/hnix.cabal
@@ -407,7 +407,7 @@ library
     , base >= 4.12 && < 5
     , base16-bytestring >= 0.1.1 && < 1.1
     , binary >= 0.8.5 && < 0.9
-    , bytestring >= 0.10.8 && < 0.11
+    , bytestring >= 0.10.8 && < 0.12
     , comonad >= 5.0.4 && < 5.1
     , containers >= 0.5.11.0 && < 0.7
     , data-fix >= 0.3.0 && < 0.4

--- a/src/Nix/Cited/Basic.hs
+++ b/src/Nix/Cited/Basic.hs
@@ -16,7 +16,6 @@ import           Prelude                 hiding ( force )
 import           Control.Comonad                ( Comonad )
 import           Control.Comonad.Env            ( ComonadEnv )
 import           Control.Monad.Catch     hiding ( catchJust )
-import           Data.Fix
 import           Nix.Cited
 import           Nix.Eval                      as Eval
 import           Nix.Exec
@@ -64,13 +63,12 @@ instance ( Has e Options
 
         -- Gather the current evaluation context at the time of thunk
         -- creation, and record it along with the thunk.
-        let go (fromException ->
-                    Just (EvaluatingExpr scope
-                              (Fix (Compose (Ann s e))))) =
-                let e' = Compose (Ann s (Nothing <$ e))
-                in [Provenance scope e']
-            go _ = mempty
-            ps = concatMap (go . frame) frames
+        let
+          go (fromException -> Just (EvaluatingExpr scope (AnnE s e))) =
+            let e' = Compose (Ann s (Nothing <$ e)) in
+            [Provenance scope e']
+          go _ = mempty
+          ps = concatMap (go . frame) frames
 
         Cited . NCited ps <$> thunk mv
       )

--- a/src/Nix/Eval.hs
+++ b/src/Nix/Eval.hs
@@ -15,7 +15,6 @@ module Nix.Eval where
 import           Control.Monad                  ( foldM )
 import           Control.Monad.Fix              ( MonadFix )
 import           Data.Semialign.Indexed         ( ialignWith )
-import           Data.Fix                       ( Fix(Fix) )
 import qualified Data.HashMap.Lazy             as M
 import           Data.List                      ( partition )
 import           Data.These                     ( These(..) )
@@ -496,7 +495,7 @@ buildArgument params arg =
 
 addSourcePositions
   :: (MonadReader e m, Has e SrcSpan) => Transform NExprLocF (m a)
-addSourcePositions f v@(Fix (Compose (Ann ann _))) =
+addSourcePositions f v@(AnnE ann _) =
   local (set hasLens ann) $ f v
 
 addStackFrames

--- a/src/Nix/Expr/Types.hs
+++ b/src/Nix/Expr/Types.hs
@@ -108,6 +108,8 @@ data Params r
   --
   -- > Param "x"                                  ~  x
   | ParamSet !(ParamSet r) !Bool !(Maybe VarName)
+  --  2021-05-15: NOTE: Seems like we should flip the ParamSet, so partial application kicks in for Bool?
+  --  2021-05-15: NOTE: '...' variadic property probably needs a Bool synonym.
   -- ^ Explicit parameters (argument must be a set). Might specify a name to
   -- bind to the set in the function body. The bool indicates whether it is
   -- variadic or not.
@@ -432,6 +434,8 @@ data NExprF r
   -- > NBinary NPlus x y                           ~  x + y
   -- > NBinary NApp  f x                           ~  f x
   | NSelect !r !(NAttrPath r) !(Maybe r)
+  --  2021-05-15: NOTE: Default value should be first argument to leverage partial application.
+  -- Cascading change diff is not that big.
   -- ^ Dot-reference into an attribute set, optionally providing an
   -- alternative if the key doesn't exist.
   --

--- a/src/Nix/Expr/Types/Annotated.hs
+++ b/src/Nix/Expr/Types/Annotated.hs
@@ -84,6 +84,7 @@ data Ann ann a = Ann
 
 type AnnF ann f = Compose (Ann ann) f
 
+-- | Pattern: @Fix (Compose (Ann _ _))@.
 pattern AnnE
   :: forall ann (g :: * -> *)
   . ann

--- a/src/Nix/Expr/Types/Annotated.hs
+++ b/src/Nix/Expr/Types/Annotated.hs
@@ -175,17 +175,14 @@ nullSpan = SrcSpan nullPos nullPos
 
 -- | Pattern systems for matching on NExprLocF constructions.
 
-pattern NSym_ :: SrcSpan -> VarName -> NExprLocF r
-pattern NSym_ ann x = Compose (Ann ann (NSym x))
-
-pattern NSynHole_ :: SrcSpan -> Text -> NExprLocF r
-pattern NSynHole_ ann x = Compose (Ann ann (NSynHole x))
-
 pattern NConstant_ :: SrcSpan -> NAtom -> NExprLocF r
 pattern NConstant_ ann x = Compose (Ann ann (NConstant x))
 
 pattern NStr_ :: SrcSpan -> NString r -> NExprLocF r
 pattern NStr_ ann x = Compose (Ann ann (NStr x))
+
+pattern NSym_ :: SrcSpan -> VarName -> NExprLocF r
+pattern NSym_ ann x = Compose (Ann ann (NSym x))
 
 pattern NList_ :: SrcSpan -> [r] -> NExprLocF r
 pattern NList_ ann x = Compose (Ann ann (NList x))
@@ -198,6 +195,12 @@ pattern NLiteralPath_ ann x = Compose (Ann ann (NLiteralPath x))
 
 pattern NEnvPath_ :: SrcSpan -> FilePath -> NExprLocF r
 pattern NEnvPath_ ann x = Compose (Ann ann (NEnvPath x))
+
+pattern NUnary_ :: SrcSpan -> NUnaryOp -> r -> NExprLocF r
+pattern NUnary_ ann op x = Compose (Ann ann (NUnary op x))
+
+pattern NBinary_ :: SrcSpan -> NBinaryOp -> r -> r -> NExprLocF r
+pattern NBinary_ ann op x y = Compose (Ann ann (NBinary op x y))
 
 pattern NSelect_ :: SrcSpan -> r -> NAttrPath r -> Maybe r -> NExprLocF r
 pattern NSelect_ ann x p v = Compose (Ann ann (NSelect x p v))
@@ -220,8 +223,5 @@ pattern NWith_ ann x y = Compose (Ann ann (NWith x y))
 pattern NAssert_ :: SrcSpan -> r -> r -> NExprLocF r
 pattern NAssert_ ann x y = Compose (Ann ann (NAssert x y))
 
-pattern NUnary_ :: SrcSpan -> NUnaryOp -> r -> NExprLocF r
-pattern NUnary_ ann op x = Compose (Ann ann (NUnary op x))
-
-pattern NBinary_ :: SrcSpan -> NBinaryOp -> r -> r -> NExprLocF r
-pattern NBinary_ ann op x y = Compose (Ann ann (NBinary op x y))
+pattern NSynHole_ :: SrcSpan -> Text -> NExprLocF r
+pattern NSynHole_ ann x = Compose (Ann ann (NSynHole x))

--- a/src/Nix/Expr/Types/Annotated.hs
+++ b/src/Nix/Expr/Types/Annotated.hs
@@ -225,3 +225,4 @@ pattern NAssert_ ann x y = Compose (Ann ann (NAssert x y))
 
 pattern NSynHole_ :: SrcSpan -> Text -> NExprLocF r
 pattern NSynHole_ ann x = Compose (Ann ann (NSynHole x))
+{-# complete NConstant_, NStr_, NSym_, NList_, NSet_, NLiteralPath_, NEnvPath_, NUnary_, NBinary_, NSelect_, NHasAttr_, NAbs_, NLet_, NIf_, NWith_, NAssert_, NSynHole_ #-}

--- a/src/Nix/Expr/Types/Annotated.hs
+++ b/src/Nix/Expr/Types/Annotated.hs
@@ -85,6 +85,8 @@ data Ann ann a = Ann
 type AnnF ann f = Compose (Ann ann) f
 
 -- | Pattern: @Fix (Compose (Ann _ _))@.
+-- Fix composes units of (annotations & the annotated) into one object.
+-- Giving annotated expression.
 pattern AnnE
   :: forall ann (g :: * -> *)
   . ann

--- a/src/Nix/Expr/Types/Annotated.hs
+++ b/src/Nix/Expr/Types/Annotated.hs
@@ -74,6 +74,13 @@ instance Hashable ann => Hashable1 (Ann ann)
 #ifdef MIN_VERSION_serialise
 instance (Serialise ann, Serialise a) => Serialise (Ann ann a)
 #endif
+pattern AnnE
+  :: forall ann (g :: * -> *)
+  . ann
+  -> g (Fix (Compose (Ann ann) g))
+  -> Fix (Compose (Ann ann) g)
+pattern AnnE ann a = Fix (Compose (Ann ann a))
+{-# complete AnnE #-}
 
 instance NFData ann => NFData1 (Ann ann)
 
@@ -119,9 +126,6 @@ instance Serialise r => Serialise (Compose (Ann SrcSpan) NExprF r) where
   decode = (Compose .) . Ann <$> decode <*> decode
 #endif
 
-pattern AnnE :: forall ann (g :: * -> *). ann
-             -> g (Fix (Compose (Ann ann) g)) -> Fix (Compose (Ann ann) g)
-pattern AnnE ann a = Fix (Compose (Ann ann a))
 
 stripAnnotation :: Functor f => Fix (AnnF ann f) -> Fix f
 stripAnnotation = unfoldFix (annotated . getCompose . unFix)
@@ -131,33 +135,26 @@ stripAnn = annotated . getCompose
 
 nUnary :: Ann SrcSpan NUnaryOp -> NExprLoc -> NExprLoc
 nUnary (Ann s1 u) e1@(AnnE s2 _) = AnnE (s1 <> s2) $ NUnary u e1
-nUnary _          _              = error "nUnary: unexpected"
 {-# inline nUnary #-}
 
 nBinary :: Ann SrcSpan NBinaryOp -> NExprLoc -> NExprLoc -> NExprLoc
 nBinary (Ann s1 b) e1@(AnnE s2 _) e2@(AnnE s3 _) =
   AnnE (s1 <> s2 <> s3) $ NBinary b e1 e2
-nBinary _ _ _ = error "nBinary: unexpected"
 
 nSelectLoc
   :: NExprLoc -> Ann SrcSpan (NAttrPath NExprLoc) -> Maybe NExprLoc -> NExprLoc
 nSelectLoc e1@(AnnE s1 _) (Ann s2 ats) d = case d of
   Nothing               -> AnnE (s1 <> s2) $ NSelect e1 ats Nothing
   Just e2@(AnnE s3 _) -> AnnE (s1 <> s2 <> s3) $ NSelect e1 ats $ pure e2
-  _                     -> error "nSelectLoc: unexpected"
-nSelectLoc _ _ _ = error "nSelectLoc: unexpected"
 
 nHasAttr :: NExprLoc -> Ann SrcSpan (NAttrPath NExprLoc) -> NExprLoc
 nHasAttr e1@(AnnE s1 _) (Ann s2 ats) = AnnE (s1 <> s2) $ NHasAttr e1 ats
-nHasAttr _              _            = error "nHasAttr: unexpected"
 
 nApp :: NExprLoc -> NExprLoc -> NExprLoc
 nApp e1@(AnnE s1 _) e2@(AnnE s2 _) = AnnE (s1 <> s2) $ NBinary NApp e1 e2
-nApp _              _              = error "nApp: unexpected"
 
 nAbs :: Ann SrcSpan (Params NExprLoc) -> NExprLoc -> NExprLoc
 nAbs (Ann s1 ps) e1@(AnnE s2 _) = AnnE (s1 <> s2) $ NAbs ps e1
-nAbs _           _              = error "nAbs: unexpected"
 
 nStr :: Ann SrcSpan (NString NExprLoc) -> NExprLoc
 nStr (Ann s1 s) = AnnE s1 $ NStr s

--- a/src/Nix/Parser.hs
+++ b/src/Nix/Parser.hs
@@ -623,20 +623,20 @@ opWithLoc name op f =
         {- dbg (toString name) $ -}
         operator name
 
-    pure $ f (Ann ann op)
+    pure $ f $ Ann ann op
 
 binaryN :: Text -> NBinaryOp -> (NOperatorDef, Operator (ParsecT Void Text (State SourcePos)) NExprLoc)
 binaryN name op =
-  (NBinaryDef name op NAssocNone, InfixN (opWithLoc name op nBinary))
+  (NBinaryDef name op NAssocNone, InfixN $ opWithLoc name op nBinary)
 binaryL :: Text -> NBinaryOp -> (NOperatorDef, Operator (ParsecT Void Text (State SourcePos)) NExprLoc)
 binaryL name op =
-  (NBinaryDef name op NAssocLeft, InfixL (opWithLoc name op nBinary))
+  (NBinaryDef name op NAssocLeft, InfixL $ opWithLoc name op nBinary)
 binaryR :: Text -> NBinaryOp -> (NOperatorDef, Operator (ParsecT Void Text (State SourcePos)) NExprLoc)
 binaryR name op =
-  (NBinaryDef name op NAssocRight, InfixR (opWithLoc name op nBinary))
+  (NBinaryDef name op NAssocRight, InfixR $ opWithLoc name op nBinary)
 prefix :: Text -> NUnaryOp -> (NOperatorDef, Operator (ParsecT Void Text (State SourcePos)) NExprLoc)
 prefix name op =
-  (NUnaryDef name op, Prefix (manyUnaryOp (opWithLoc name op nUnary)))
+  (NUnaryDef name op, Prefix $ manyUnaryOp $ opWithLoc name op nUnary)
 -- postfix name op = (NUnaryDef name op,
 --                    Postfix (opWithLoc name op nUnary))
 
@@ -717,7 +717,7 @@ getUnaryOperator = (m Map.!)
         zipWith
           buildEntry
           [1 ..]
-          (nixOperators (fail "unused"))
+          (nixOperators $ fail "unused")
 
   buildEntry i =
     concatMap $
@@ -734,7 +734,7 @@ getBinaryOperator = (m Map.!)
         zipWith
           buildEntry
           [1 ..]
-          (nixOperators (fail "unused"))
+          (nixOperators $ fail "unused")
 
   buildEntry i =
     concatMap $
@@ -752,7 +752,7 @@ getSpecialOperator o         = m Map.! o
         zipWith
           buildEntry
           [1 ..]
-          (nixOperators (fail "unused"))
+          (nixOperators $ fail "unused")
 
   buildEntry i =
     concatMap $

--- a/src/Nix/Parser.hs
+++ b/src/Nix/Parser.hs
@@ -49,9 +49,7 @@ import           Prelude                 hiding ( some
                                                 )
 import           Data.Foldable                  ( foldr1 )
 
-import           Control.Monad                  ( liftM2
-                                                , msum
-                                                )
+import           Control.Monad                  ( msum )
 import           Control.Monad.Combinators.Expr ( makeExprParser
                                                 , Operator( Postfix
                                                           , InfixN
@@ -91,6 +89,11 @@ import           Text.Megaparsec.Char           ( space1
                                                 )
 import qualified Text.Megaparsec.Char.Lexer    as Lexer
 
+-- | Different to @isAlphaNum@
+isAlphanumeric :: Char -> Bool
+isAlphanumeric x = isAlpha x || isDigit x
+{-# inline isAlphanumeric #-}
+
 infixl 3 <+>
 (<+>) :: MonadPlus m => m a -> m a -> m a
 (<+>) = mplus
@@ -100,11 +103,12 @@ infixl 3 <+>
 nixExpr :: Parser NExprLoc
 nixExpr =
   makeExprParser
-    nixTerm $ snd <<$>>
+    nixTerm $
+      snd <<$>>
         nixOperators nixSelector
 
 antiStart :: Parser Text
-antiStart = symbol "${" <?> show ("${" :: String)
+antiStart = symbol "${" <?> "${"
 
 nixAntiquoted :: Parser a -> Parser (Antiquoted a NExprLoc)
 nixAntiquoted p =
@@ -121,19 +125,20 @@ nixSelect :: Parser NExprLoc -> Parser NExprLoc
 nixSelect term =
   do
     res <-
-      build
-      <$> term
-      <*> optional
-        ( (,)
-        <$> (selDot *> nixSelector)
-        <*> optional (reserved "or" *> nixTerm)
+      liftA2 build
+        term
+        (optional $
+          liftA2 (,)
+            (selDot *> nixSelector)
+            (optional $ reserved "or" *> nixTerm)
         )
     continues <- optional $ lookAhead selDot
 
     maybe
-      (pure res)
-      (const $ nixSelect (pure res))
+      id
+      (const nixSelect)
       continues
+      (pure res)
  where
   build
     :: NExprLoc
@@ -143,9 +148,10 @@ nixSelect term =
     -> NExprLoc
   build t mexpr =
     maybe
-      t
-      (uncurry (nSelectLoc t))
+      id
+      (\ expr t -> (uncurry $ nSelectLoc t) expr)
       mexpr
+      t
 
 nixSelector :: Parser (Ann SrcSpan (NAttrPath NExprLoc))
 nixSelector =
@@ -217,7 +223,7 @@ nixList = annotateLocation1 (brackets (NList <$> many nixTerm) <?> "list")
 
 pathChar :: Char -> Bool
 pathChar x =
-  isAlpha x || isDigit x || (`elem` ("._-+~" :: String)) x
+  isAlphanumeric x || (`elem` ("._-+~" :: String)) x
 
 slash :: Parser Char
 slash =
@@ -238,10 +244,17 @@ nixSearchPath =
     )
 
 pathStr :: Parser FilePath
-pathStr = lexeme $ liftM2
-  (<>)
-  (many (satisfy pathChar))
-  (Prelude.concat <$> some (liftM2 (:) slash (some (satisfy pathChar))))
+pathStr =
+  lexeme $
+    liftA2 (<>)
+      (many $ satisfy pathChar)
+      (concat <$>
+        some
+          (liftA2 (:)
+            slash
+            (some $ satisfy pathChar)
+          )
+      )
 
 nixPath :: Parser NExprLoc
 nixPath = annotateLocation1 (try (mkPathF False <$> pathStr) <?> "path")
@@ -251,9 +264,9 @@ nixLet = annotateLocation1
   (reserved "let" *> (letBody <+> letBinders) <?> "let block")
  where
   letBinders =
-    NLet
-    <$> nixBinders
-    <*> (reserved "in" *> nixToplevelForm)
+    liftA2 NLet
+      nixBinders
+      (reserved "in" *> nixToplevelForm)
   -- Let expressions `let {..., body = ...}' are just desugared
   -- into `(rec {..., body = ...}).body'.
   letBody    = (\x -> NSelect x (StaticKey "body" :| mempty) Nothing) <$> aset
@@ -261,31 +274,34 @@ nixLet = annotateLocation1
 
 nixIf :: Parser NExprLoc
 nixIf = annotateLocation1
-  (NIf
-  <$> (reserved "if" *> nixExpr)
-  <*> (reserved "then" *> nixToplevelForm)
-  <*> (reserved "else" *> nixToplevelForm)
+  (liftA3 NIf
+    (reserved "if"   *> nixExpr        )
+    (reserved "then" *> nixToplevelForm)
+    (reserved "else" *> nixToplevelForm)
   <?> "if"
   )
 
 nixAssert :: Parser NExprLoc
 nixAssert = annotateLocation1
-  (NAssert
-  <$> (reserved "assert" *> nixToplevelForm)
-  <*> (semi *> nixToplevelForm)
+  (liftA2 NAssert
+    (reserved "assert" *> nixToplevelForm)
+    (semi              *> nixToplevelForm)
   <?> "assert"
   )
 
 nixWith :: Parser NExprLoc
 nixWith = annotateLocation1
-  (NWith
-  <$> (reserved "with" *> nixToplevelForm)
-  <*> (semi *> nixToplevelForm)
+  (liftA2 NWith
+    (reserved "with" *> nixToplevelForm)
+    (semi            *> nixToplevelForm)
   <?> "with"
   )
 
 nixLambda :: Parser NExprLoc
-nixLambda = nAbs <$> annotateLocation (try argExpr) <*> nixToplevelForm
+nixLambda =
+  liftA2 nAbs
+    (annotateLocation $ try argExpr)
+    nixToplevelForm
 
 nixString :: Parser NExprLoc
 nixString = nStr <$> annotateLocation nixString'
@@ -296,16 +312,14 @@ nixUri = lexeme $ annotateLocation1 $ try $ do
   protocol <- many $
     satisfy $
       \ x ->
-        isAlpha x
-        || isDigit x
+        isAlphanumeric x
         || (`elem` ("+-." :: String)) x
   _       <- string ":"
   address <-
     some $
       satisfy $
         \ x ->
-          isAlpha x
-          || isDigit x
+          isAlphanumeric x
           || (`elem` ("%/?:@&=+$,-_.!~*'" :: String)) x
   pure $ NStr $ DoubleQuoted
     [Plain $ toText $ start : protocol ++ ':' : address]
@@ -324,7 +338,7 @@ nixString' = lexeme (doubleQuoted <+> indented <?> "string")
       )
       <?> "double quoted string"
 
-  doubleQ      = void (char '"')
+  doubleQ      = void $ char '"'
   doubleEscape = Plain . singleton <$> (char '\\' *> escapeCode)
 
   indented :: Parser (NString NExprLoc)
@@ -392,21 +406,18 @@ argExpr =
     try $
       do
         name               <- identifier <* symbol "@"
-        (variadic, params) <- params
-        pure $ ParamSet params variadic (pure name)
+        (params, variadic) <- params
+        pure $ ParamSet params variadic $ pure name
 
   -- Parameters named by an identifier on the right, or none (`{x, y} @ args`)
   atRight =
     do
-      (variadic, params) <- params
+      (params, variadic) <- params
       name               <- optional $ symbol "@" *> identifier
       pure $ ParamSet params variadic name
 
   -- Return the parameters set.
-  params =
-    do
-      (args, dotdots) <- braces getParams
-      pure (dotdots, args)
+  params = braces getParams
 
   -- Collects the parameters within curly braces. Returns the parameters and
   -- a boolean indicating if the parameters are variadic.
@@ -417,17 +428,22 @@ argExpr =
     -- Otherwise, attempt to parse an argument, optionally with a
     -- default. If this fails, then return what has been accumulated
     -- so far.
-    go acc = ((acc, True) <$ symbol "...") <+> getMore acc
+    go acc = ((acc, True) <$ symbol "...") <+> getMore
+     where
+      getMore =
+        -- Could be nothing, in which just return what we have so far.
+        option (acc, False) $
+          do
+            -- Get an argument name and an optional default.
+            pair <-
+              liftA2 (,)
+                identifier
+                (optional $ question *> nixToplevelForm)
 
-    getMore acc =
-      -- Could be nothing, in which just return what we have so far.
-      option (acc, False) $
-        do
-          -- Get an argument name and an optional default.
-          pair <- liftM2 (,) identifier (optional $ question *> nixToplevelForm)
+            let args = acc <> [pair]
 
-          -- Either return this, or attempt to get a comma and restart.
-          option (acc <> [pair], False) $ comma *> go (acc <> [pair])
+            -- Either return this, or attempt to get a comma and restart.
+            option (args, False) $ comma *> go args
 
 nixBinders :: Parser [Binding NExprLoc]
 nixBinders = (inherit <+> namedVar) `endBy` semi where
@@ -438,17 +454,17 @@ nixBinders = (inherit <+> namedVar) `endBy` semi where
       try $ string "inherit" *> lookAhead (void (satisfy reservedEnd))
       p <- getSourcePos
       x <- whiteSpace *> optional scope
-      Inherit x
-        <$> many keyName
-        <*> pure p
+      liftA2 (Inherit x)
+        (many keyName)
+        (pure p)
         <?> "inherited binding"
   namedVar =
     do
       p <- getSourcePos
-      NamedVar
-        <$> (annotated <$> nixSelector)
-        <*> (equals *> nixToplevelForm)
-        <*> pure p
+      liftA3 NamedVar
+        (annotated <$> nixSelector)
+        (equals *> nixToplevelForm)
+        (pure p)
         <?> "variable binding"
   scope = nixParens <?> "inherit scope"
 
@@ -509,13 +525,13 @@ reserved n =
 identifier :: Parser Text
 identifier = lexeme $ try $ do
   ident <-
-    cons
-    <$> satisfy (\x -> isAlpha x || x == '_')
-    <*> takeWhileP mempty identLetter
-  guard (not (ident `HashSet.member` reservedNames))
+    liftA2 cons
+      (satisfy (\x -> isAlpha x || x == '_'))
+      (takeWhileP mempty identLetter)
+  guard $ not $ ident `HashSet.member` reservedNames
   pure ident
  where
-  identLetter x = isAlpha x || isDigit x || x == '_' || x == '\'' || x == '-'
+  identLetter x = isAlphanumeric x || x == '_' || x == '\'' || x == '-'
 
 -- We restrict the type of 'parens' and 'brackets' here because if they were to
 -- take a @Parser NExprLoc@ argument they would parse additional text which
@@ -584,8 +600,8 @@ data NAssoc = NAssocNone | NAssocLeft | NAssocRight
   deriving (Eq, Ord, Generic, Typeable, Data, Show, NFData)
 
 data NOperatorDef
-  = NUnaryDef Text NUnaryOp
-  | NBinaryDef Text NBinaryOp NAssoc
+  = NUnaryDef   Text NUnaryOp
+  | NBinaryDef  Text NBinaryOp  NAssoc
   | NSpecialDef Text NSpecialOp NAssoc
   deriving (Eq, Ord, Generic, Typeable, Data, Show, NFData)
 

--- a/src/Nix/Reduce.hs
+++ b/src/Nix/Reduce.hs
@@ -373,7 +373,7 @@ pruneTree opts =
         (reduceSets opts)  -- Reduce set members that aren't used; breaks if hasAttr is used
         binds
 
-    NLet binds (Just body@(Fix (Compose (Ann _ x)))) ->
+    NLet binds (Just body@(AnnE _ x)) ->
       pure $
         list
           x
@@ -384,8 +384,8 @@ pruneTree opts =
       pure $ NSelect aset (NE.map pruneKeyName attr) (join alt)
 
     -- These are the only short-circuiting binary operators
-    NBinary NAnd (Just (Fix (Compose (Ann _ larg)))) _ -> pure larg
-    NBinary NOr  (Just (Fix (Compose (Ann _ larg)))) _ -> pure larg
+    NBinary NAnd (Just (AnnE _ larg)) _ -> pure larg
+    NBinary NOr  (Just (AnnE _ larg)) _ -> pure larg
 
     -- If the function was never called, it means its argument was in a
     -- thunk that was forced elsewhere.
@@ -399,18 +399,18 @@ pruneTree opts =
     NBinary op (Just larg) Nothing -> pure $ NBinary op larg nNull
 
     -- If the scope of a with was never referenced, it's not needed
-    NWith Nothing (Just (Fix (Compose (Ann _ body)))) -> pure body
+    NWith Nothing (Just (AnnE _ body)) -> pure body
 
     NAssert Nothing _ ->
       fail "How can an assert be used, but its condition not?"
 
-    NAssert _ (Just (Fix (Compose (Ann _ body)))) -> pure body
+    NAssert _ (Just (AnnE _ body)) -> pure body
     NAssert (Just cond) _ -> pure $ NAssert cond nNull
 
     NIf Nothing _ _ -> fail "How can an if be used, but its condition not?"
 
-    NIf _ Nothing (Just (Fix (Compose (Ann _ f)))) -> pure f
-    NIf _ (Just (Fix (Compose (Ann _ t)))) Nothing -> pure t
+    NIf _ Nothing (Just (AnnE _ f)) -> pure f
+    NIf _ (Just (AnnE _ t)) Nothing -> pure t
 
     x                     -> sequence x
 

--- a/src/Nix/Render/Frame.hs
+++ b/src/Nix/Render/Frame.hs
@@ -72,7 +72,7 @@ framePos
   -> Maybe SourcePos
 framePos (NixFrame _ f)
   | Just (e :: EvalFrame m v) <- fromException f = case e of
-    EvaluatingExpr _ (Fix (Compose (Ann (SrcSpan beg _) _))) -> pure beg
+    EvaluatingExpr _ (AnnE (SrcSpan beg _) _) -> pure beg
     _ -> Nothing
   | otherwise = Nothing
 
@@ -108,7 +108,7 @@ renderEvalFrame level f =
   do
     opts :: Options <- asks (view hasLens)
     case f of
-      EvaluatingExpr scope e@(Fix (Compose (Ann ann _))) ->
+      EvaluatingExpr scope e@(AnnE ann _) ->
         do
           let
             scopeInfo =
@@ -121,7 +121,7 @@ renderEvalFrame level f =
             $ renderLocation ann =<<
                 renderExpr level "While evaluating" "Expression" e
 
-      ForcingExpr _scope e@(Fix (Compose (Ann ann _))) | thunks opts ->
+      ForcingExpr _scope e@(AnnE ann _) | thunks opts ->
         fmap
           (: mempty)
           $ renderLocation ann =<<
@@ -135,7 +135,7 @@ renderEvalFrame level f =
 
       SynHole synfo ->
         sequence $
-          let e@(Fix (Compose (Ann ann _))) = _synHoleInfo_expr synfo in
+          let e@(AnnE ann _) = _synHoleInfo_expr synfo in
 
           [ renderLocation ann =<<
               renderExpr level "While evaluating" "Syntactic Hole" e
@@ -152,7 +152,7 @@ renderExpr
   -> Text
   -> NExprLoc
   -> m (Doc ann)
-renderExpr _level longLabel shortLabel e@(Fix (Compose (Ann _ x))) = do
+renderExpr _level longLabel shortLabel e@(AnnE _ x) = do
   opts :: Options <- asks (view hasLens)
   let rendered
           | verbose opts >= DebugInfo =

--- a/src/Nix/Type/Assumption.hs
+++ b/src/Nix/Type/Assumption.hs
@@ -1,3 +1,5 @@
+-- | Basing on the Nix (Hindley–Milner) type system (that provides decidable type inference):
+-- gathering assumptions (inference evidence) about polymorphic types.
 module Nix.Type.Assumption
   ( Assumption(..)
   , empty
@@ -24,16 +26,27 @@ empty :: Assumption
 empty = Assumption mempty
 
 extend :: Assumption -> (Name, Type) -> Assumption
-extend (Assumption a) (x, s) = Assumption ((x, s) : a)
+extend (Assumption a) (x, s) =
+  Assumption $
+    (x, s) : a
 
 remove :: Assumption -> Name -> Assumption
-remove (Assumption a) var = Assumption (filter (\(n, _) -> n /= var) a)
+remove (Assumption a) var =
+  Assumption $
+    filter
+      (\(n, _) -> n /= var)
+      a
 
 lookup :: Name -> Assumption -> [Type]
-lookup key (Assumption a) = fmap snd (filter (\(n, _) -> n == key) a)
+lookup key (Assumption a) =
+  snd <$>
+    filter
+      (\(n, _) -> n == key)
+      a
 
 merge :: Assumption -> Assumption -> Assumption
-merge (Assumption a) (Assumption b) = Assumption (a <> b)
+merge (Assumption a) (Assumption b) =
+  Assumption $ a <> b
 
 mergeAssumptions :: [Assumption] -> Assumption
 mergeAssumptions = foldl' merge empty
@@ -42,4 +55,4 @@ singleton :: Name -> Type -> Assumption
 singleton x y = Assumption [(x, y)]
 
 keys :: Assumption -> [Name]
-keys (Assumption a) = fmap fst a
+keys (Assumption a) = fst <$> a

--- a/src/Nix/Type/Type.hs
+++ b/src/Nix/Type/Type.hs
@@ -1,3 +1,6 @@
+-- | The basis of the Nix type system (type-level).
+--   Based on the Hindley–Milner type system.
+--   Therefore -> from this the type inference follows.
 module Nix.Type.Type where
 
 import           Prelude                 hiding ( Type, TVar )
@@ -8,19 +11,27 @@ type Name = Text
 
 -- | Hindrey-Milner type interface
 
+-- | Type variable in the Nix type system.
 newtype TVar = TV Text
   deriving (Show, Eq, Ord)
 
+-- | The basic type definitions in the Nix type system (type-level code).
 data Type
-  = TVar TVar                -- type variable
-  | TCon Text                -- known type
-  | TSet Bool (AttrSet Type) -- heterogeneous map, bool if variadic
-  | TList [Type]             -- heterogeneous list
-  | (:~>) Type Type          -- type -> type
-  | TMany [Type]             -- variant type
+  = TVar TVar                -- ^ Type variable in the Nix type system.
+  | TCon Text                -- ^ Concrete (non-polymorphic, constant) type in the Nix type system.
+  | TSet Bool (AttrSet Type) -- ^ Heterogeneous map in the Nix type system. @True@ -> variadic.
+  | TList [Type]             -- ^ Heterogeneous list in the Nix type system.
+  | (:~>) Type Type          -- ^ Type arrow (@Type -> Type@) in the Nix type system.
+  | TMany [Type]             -- ^ Variant type (term). Since relating to Nix type system, more precicely -
+                             --   dynamic types in dynamicly typed language (which is Nix).
   deriving (Show, Eq, Ord)
 
-data Scheme = Forall [TVar] Type -- forall a b. a -> b
+infixr 1 :~>
+
+-- | Hindley–Milner type system uses "scheme" term for "polytypes".
+--   Types containing @forall@ quantifiers: @forall a . a@.
+--   Note: HM allows only top-level @forall@ quantification, so no @RankNTypes@ in it.
+data Scheme = Forall [TVar] Type -- ^ @Forall [TVar] Type@: the Nix type system @forall vars. type@.
   deriving (Show, Eq, Ord)
 
 -- This models a set that unifies with any other set.
@@ -30,12 +41,11 @@ typeSet = TSet True mempty
 typeList :: Type
 typeList = TList mempty
 
-infixr 1 :~>
-
 typeFun :: [Type] -> Type
 -- Please, replace with safe analog to `foldr1`
 typeFun = foldr1 (:~>)
 
+-- | Concrete types in the Nix type system.
 typeInt, typeFloat, typeBool, typeString, typePath, typeNull :: Type
 typeInt    = TCon "integer"
 typeFloat  = TCon "float"

--- a/src/Nix/Value.hs
+++ b/src/Nix/Value.hs
@@ -193,7 +193,7 @@ instance Foldable (NValueF p m) where
 
 -- ** Traversable
 
--- | @traverse@
+-- | @sequence@
 sequenceNValueF
   :: (Functor n, Monad m, Applicative n)
   => (forall x . n x -> m x)
@@ -312,7 +312,7 @@ instance Comonad f => Show1 (NValue' t f m) where
 
 -- ** Traversable
 
--- | @traverse@
+-- | @sequence@
 sequenceNValue'
   :: (Functor n, Traversable f, Monad m, Applicative n)
   => (forall x . n x -> m x)
@@ -534,7 +534,7 @@ iterNValueM
   -> NValue t f m
   -> n r
 iterNValueM transform k f =
-    iterM f <=< go . fmap (\t -> k t (iterNValueM transform k f))
+    iterM f <=< go . ((\t -> k t $ iterNValueM transform k f) <$>)
   where
     go (Pure x) = Pure <$> x
     go (Free fa) = Free <$> bindNValue' transform go fa
@@ -548,7 +548,7 @@ hoistNValue
   -> (forall x . m x -> n x)
   -> NValue t f m
   -> NValue t f n
-hoistNValue run lft = hoistFree (hoistNValue' run lft)
+hoistNValue run lft = hoistFree $ hoistNValue' run lft
 {-# inline hoistNValue #-}
 
 -- ** MonadTrans

--- a/src/Nix/Value/Equal.hs
+++ b/src/Nix/Value/Equal.hs
@@ -15,8 +15,8 @@ import           Prelude                 hiding ( Comparison
                                                 , force
                                                 )
 import           Nix.Utils
-import           Control.Comonad
-import           Control.Monad.Free
+import           Control.Comonad                ( Comonad(extract))
+import           Control.Monad.Free             ( Free(Pure,Free) )
 import           Control.Monad.Trans.Except     ( throwE )
 import           Data.Semialign                 ( Align
                                                 , Semialign(align)
@@ -156,10 +156,8 @@ compareAttrSetsM f eq lm rm =
         r <- isDerivationM f rm
         case r of
           True
-            | Just lp <- HashMap.Lazy.lookup "outPath" lm, Just rp <- HashMap.Lazy.lookup "outPath" rm ->
-                eq
-                  lp
-                  rp
+            | Just lp <- HashMap.Lazy.lookup "outPath" lm,
+              Just rp <- HashMap.Lazy.lookup "outPath" rm -> eq lp rp
           _ -> compareAttrs
       )
       l
@@ -173,7 +171,7 @@ compareAttrSets
   -> AttrSet t
   -> Bool
 compareAttrSets f eq lm rm = runIdentity
-  $ compareAttrSetsM (Identity . f) (\x y -> Identity (eq x y)) lm rm
+  $ compareAttrSetsM (Identity . f) (\x y -> Identity $ eq x y) lm rm
 
 valueEqM
   :: (MonadThunk t m (NValue t f m), Comonad f)


### PR DESCRIPTION
Once started organizing, it is hard to stop.

Somehow forgot to `bytestring 0.11`, thought we updated to it.

During it found & made a couple of small optimizations here and there.

And left notes for future to introduce breaking changes to provide more optimization. Some `NExprF` arguments need reordering (for performance) & synonymizing (for readability) (it is a close topic to the https://github.com/haskell-nix/hnix/issues/377).