### PR TITLE
Correct lower bound on semialign

### DIFF
--- a/hnix.cabal
+++ b/hnix.cabal
@@ -443,7 +443,7 @@ library
     , regex-tdfa >= 1.2.3 && < 1.4
     , relude >= 1.0.0 && < 1.1.0
     , scientific >= 0.3.6 && < 0.4
-    , semialign >= 1 && < 1.3
+    , semialign >= 1.2 && < 1.3
     , serialise >= 0.2.1 && < 0.3
     , some >= 1.0.1 && < 1.1
     , split >= 0.2.3 && < 0.3


### PR DESCRIPTION
before 1.2 it didn't expose the Data.Semialign.Indexed module