### PR TITLE
Refactors 2021-05-27 

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -49,6 +49,9 @@
   * `Nix.Normal`
     * add `thunkVal` literal & use it where appropriate `{deThunk, removeEffects}`
       
+  * `Nix.Thunk.Basic`:
+    * export `deferred`
+
 
 ### [(diff)](https://github.com/haskell-nix/hnix/compare/0.13.0.1...0.13.1#files_bucket) 0.13.1 (2021-05-22)
   * [(link)](https://github.com/haskell-nix/hnix/pull/936/files) `Nix.Parser`: `annotateLocation`: Fix source location preservation.

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -39,8 +39,11 @@ Breaking:
   * `Nix.Normal`
     * add `thunkVal` literal & use it where appropriate `{deThunk, removeEffects}`
     * rename `opaque(,->Val)`, indicate that it is a literal.
-       
-
+  
+  * `Nix.Thunk`:
+    * `class MonadThunkId m => MonadThunk{,F} t m a`:
+      * rename `query(M->){,F}`
+      
 
 ### [(diff)](https://github.com/haskell-nix/hnix/compare/0.13.0.1...0.13.1#files_bucket) 0.13.1 (2021-05-22)
   * [(link)](https://github.com/haskell-nix/hnix/pull/936/files) `Nix.Parser`: `annotateLocation`: Fix source location preservation.

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,10 +3,19 @@
 
 ## [(diff)](https://github.com/haskell-nix/hnix/compare/0.13.1...master#files_bucket) WIP
 
-Breaking:
+* Breaking:
 
   * `Nix.Effects`:
     * rm `pathExits` in favour of `doesPathExist` (in `Nix.Render`: `class MonadFile`: `doesPathExist`)
+
+  * `Nix.Var`: was found being superflous ([report](https://github.com/haskell-nix/hnix/issues/946)), so reduced. use `Control.Monad.Ref` instead.
+
+  * `Nix.Normal`
+    * rename `opaque(,->Val)`, indicate that it is a literal.
+  
+  * `Nix.Thunk`:
+    * `class MonadThunkId m => MonadThunk{,F} t m a`:
+      * rename `query(M->){,F}`
 
 * Additional:
 
@@ -25,6 +34,7 @@ Breaking:
   * `Nix.Type.Env`:
     * added instances:
       * `Env`: `{Semigroup,Monoid,One}`
+  
   * `Nix`:
     * changed argument order:
       * `nixEval`:
@@ -38,11 +48,6 @@ Breaking:
         
   * `Nix.Normal`
     * add `thunkVal` literal & use it where appropriate `{deThunk, removeEffects}`
-    * rename `opaque(,->Val)`, indicate that it is a literal.
-  
-  * `Nix.Thunk`:
-    * `class MonadThunkId m => MonadThunk{,F} t m a`:
-      * rename `query(M->){,F}`
       
 
 ### [(diff)](https://github.com/haskell-nix/hnix/compare/0.13.0.1...0.13.1#files_bucket) 0.13.1 (2021-05-22)

--- a/hnix.cabal
+++ b/hnix.cabal
@@ -400,7 +400,9 @@ library
       base hiding (Prelude)
     , relude (Relude as Prelude)
     , relude
-  ghc-options: -Wall -fprint-potential-instances
+  ghc-options:
+    -Wall
+    -fprint-potential-instances
   build-depends:
       aeson >= 1.4.2 && < 1.6
     , array >= 0.4 && < 0.6
@@ -485,7 +487,10 @@ library
   if flag(optimize)
     default-extensions:
       ApplicativeDo
-    ghc-options: -fexpose-all-unfoldings -fspecialise-aggressively -O2
+    ghc-options:
+      -O2
+      -fexpose-all-unfoldings
+      -fspecialise-aggressively
   -- if !flag(profiling)
   --   build-depends:
   --       ghc-datasize
@@ -500,7 +505,8 @@ executable hnix
     Paths_hnix
   autogen-modules:
     Paths_hnix
-  ghc-options: -Wall
+  ghc-options:
+    -Wall
   build-depends:
       aeson
     , base
@@ -547,7 +553,10 @@ executable hnix
   if flag(optimize)
     default-extensions:
       ApplicativeDo
-    ghc-options: -fexpose-all-unfoldings -fspecialise-aggressively -O2
+    ghc-options:
+      -O2
+      -fexpose-all-unfoldings
+      -fspecialise-aggressively
   if impl(ghc < 8.10)
     -- GHC < 8.10 comes with haskeline < 0.8, which we don't support.
     -- To simplify CI, we just disable the component.
@@ -571,7 +580,9 @@ test-suite hnix-tests
     , relude
   hs-source-dirs:
     tests
-  ghc-options: -Wall -threaded
+  ghc-options:
+    -Wall
+    -threaded
   build-depends:
       Diff
     , Glob
@@ -620,7 +631,10 @@ test-suite hnix-tests
   if flag(optimize)
     default-extensions:
       ApplicativeDo
-    ghc-options: -fexpose-all-unfoldings -fspecialise-aggressively -O2
+    ghc-options:
+      -O2
+      -fexpose-all-unfoldings
+      -fspecialise-aggressively
   default-language: Haskell2010
 
 benchmark hnix-benchmarks
@@ -634,7 +648,8 @@ benchmark hnix-benchmarks
       base hiding (Prelude)
     , relude (Relude as Prelude)
     , relude
-  ghc-options: -Wall
+  ghc-options:
+    -Wall
   build-depends:
       base
     , criterion
@@ -668,5 +683,8 @@ benchmark hnix-benchmarks
   if flag(optimize)
     default-extensions:
       ApplicativeDo
-    ghc-options: -fexpose-all-unfoldings -fspecialise-aggressively -O2
+    ghc-options:
+      -O2
+      -fexpose-all-unfoldings
+      -fspecialise-aggressively
   default-language: Haskell2010

--- a/main/Main.hs
+++ b/main/Main.hs
@@ -10,9 +10,10 @@ import           Control.Comonad                ( extract )
 import qualified Control.DeepSeq               as Deep
 import qualified Control.Exception             as Exc
 import           GHC.Err                        ( errorWithoutStackTrace )
+import           Control.Monad.Free
+import           Control.Monad.Ref              ( MonadRef(readRef) )
 import           Control.Monad.Catch
 import           System.IO                      ( hPutStrLn, getContents )
-import           Control.Monad.Free
 import qualified Data.HashMap.Lazy             as M
 import qualified Data.Map                      as Map
 import           Data.Maybe                     ( fromJust )
@@ -29,7 +30,6 @@ import           Nix.Standard
 import           Nix.Thunk.Basic
 import qualified Nix.Type.Env                  as Env
 import qualified Nix.Type.Infer                as HM
-import           Nix.Var
 import           Nix.Value.Monad
 import           Options.Applicative     hiding ( ParserResult(..) )
 import           Prettyprinter           hiding ( list )
@@ -184,7 +184,7 @@ main =
                           path         = prefix <> k
                           (_, descend) = filterEntry path k
 
-                        val <- readVar @(StandardT (StdIdT IO)) ref
+                        val <- readRef @(StandardT (StdIdT IO)) ref
                         case val of
                           Computed _    -> pure (k, Nothing)
                           _ ->

--- a/main/Main.hs
+++ b/main/Main.hs
@@ -28,7 +28,8 @@ import           Nix.Json
 import           Nix.Options.Parser
 import           Nix.Standard
 import           Nix.Thunk.Basic
-import qualified Nix.Type.Env                  as Env
+import           Nix.Type.Env                   ( Env(..) )
+import           Nix.Type.Type                  ( Scheme )
 import qualified Nix.Type.Infer                as HM
 import           Nix.Value.Monad
 import           Options.Applicative     hiding ( ParserResult(..) )
@@ -103,7 +104,7 @@ main =
               either
                 (\ err -> errorWithoutStackTrace $ "Type error: " <> PS.ppShow err)
                 (\ ty  -> liftIO $ putStrLn $ "Type of expression: " <> PS.ppShow
-                  (fromJust $ Map.lookup "it" $ Env.types ty)
+                  (fromJust $ Map.lookup "it" (coerce ty :: Map Text [Scheme]))
                 )
                 (HM.inferTop mempty [("it", stripAnnotation expr')])
 

--- a/main/Main.hs
+++ b/main/Main.hs
@@ -105,7 +105,7 @@ main =
                 (\ ty  -> liftIO $ putStrLn $ "Type of expression: " <> PS.ppShow
                   (fromJust $ Map.lookup "it" $ Env.types ty)
                 )
-                (HM.inferTop Env.empty [("it", stripAnnotation expr')])
+                (HM.inferTop mempty [("it", stripAnnotation expr')])
 
                 -- liftIO $ putStrLn $ runST $
                 --     runLintM opts . renderSymbolic =<< lint opts expr

--- a/main/Main.hs
+++ b/main/Main.hs
@@ -43,7 +43,7 @@ main :: IO ()
 main =
   do
     time <- getCurrentTime
-    opts <- execParser (nixOptionsInfo time)
+    opts <- execParser $ nixOptionsInfo time
 
     runWithBasicEffectsIO opts $ execContentsFilesOrRepl opts
 
@@ -278,7 +278,4 @@ main =
         do
           putStrLn $ "Wrote sifted expression tree to " <> path
           writeFile path $ show $ prettyNix $ stripAnnotation expr'
-      either
-        throwM
-        pure
-        eres
+      either throwM pure eres

--- a/main/Repl.hs
+++ b/main/Repl.hs
@@ -208,7 +208,7 @@ exec update source = do
       -- import qualified Nix.Type.Env                  as Env
       -- import           Nix.Type.Infer
       --
-      -- let tyctx' = inferTop Env.empty [("repl", stripAnnotation expr)]
+      -- let tyctx' = inferTop mempty [("repl", stripAnnotation expr)]
       -- liftIO $ print tyctx'
 
       mVal <- lift $ lift $ try $ pushScope (replCtx st) (evalExprLoc expr)

--- a/main/Repl.hs
+++ b/main/Repl.hs
@@ -225,7 +225,7 @@ exec update source = do
 
             -- If the result value is a set, update our context with it
             case val of
-              NVSet xs _ -> put st { replCtx = Data.HashMap.Lazy.union xs (replCtx st) }
+              NVSet xs _ -> put st { replCtx = xs <> replCtx st }
               _          -> pass
 
           pure $ pure val

--- a/src/Nix.hs
+++ b/src/Nix.hs
@@ -60,7 +60,7 @@ nixEval
   -> Maybe FilePath
   -> Fix g
   -> m a
-nixEval transform alg mpath = withNixContext mpath . adi alg transform
+nixEval transform alg mpath = withNixContext mpath . adi transform alg
 
 -- | Evaluate a nix expression in the default context
 nixEvalExpr

--- a/src/Nix/Atoms.hs
+++ b/src/Nix/Atoms.hs
@@ -3,9 +3,7 @@
 
 module Nix.Atoms where
 
-#ifdef MIN_VERSION_serialise
 import           Codec.Serialise                ( Serialise )
-#endif
 
 import           Data.Data                      ( Data)
 import           Data.Fixed                     ( mod' )
@@ -48,9 +46,7 @@ data NAtom
     , Hashable
     )
 
-#ifdef MIN_VERSION_serialise
 instance Serialise NAtom
-#endif
 
 instance Binary NAtom
 instance ToJSON NAtom

--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -1407,7 +1407,7 @@ findFileNix nvaset nvfilepath =
     case (aset, filePath) of
       (NVList x, NVStr ns) ->
         do
-          mres <- findPath @t @f @m x (toString (stringIgnoreContext ns))
+          mres <- findPath @t @f @m x $ toString $ stringIgnoreContext ns
 
           pure $ nvPath mres
 

--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -1202,6 +1202,16 @@ throwNix mnv =
 
     throwError . ErrorCall . toString $ stringIgnoreContext ns
 
+-- | Implementation of Nix @import@ clause.
+--
+-- Because Nix @import@s work strictly
+-- (import gets fully evaluated befor bringing it into the scope it was called from)
+-- - that property raises a requirement for execution phase of the interpreter go into evaluation phase
+-- & then also go into parsing phase on the imports.
+-- So it is not possible (more precise - not practical) to do a full parse Nix code phase fully & then go into evaluation phase.
+-- As it is not possible to "import them lazily", as import is strict & it is not possible to establish
+-- what imports whould be needed up until where it would be determined & they import strictly
+--
 importNix
   :: forall e t f m . MonadNix e t f m => NValue t f m -> m (NValue t f m)
 importNix = scopedImportNix $ nvSet mempty mempty

--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -730,7 +730,7 @@ substringNix start len str =
 attrNamesNix
   :: forall e t f m . MonadNix e t f m => NValue t f m -> m (NValue t f m)
 attrNamesNix =
-  (fmap getDeeper . toValue . fmap makeNixStringWithoutContext . sort . M.keys)
+  (fmap (coerce :: CoerceDeeperToNValue t f m) . toValue . fmap makeNixStringWithoutContext . sort . M.keys)
   <=< fromValue @(AttrSet (NValue t f m))
 
 attrValuesNix
@@ -1441,7 +1441,7 @@ readDirNix nvpath =
         detectFileTypes
         items
 
-    getDeeper <$> toValue (M.fromList itemsWithTypes)
+    (coerce :: CoerceDeeperToNValue t f m) <$> toValue (M.fromList itemsWithTypes)
 
 fromJSONNix
   :: forall e t f m . MonadNix e t f m => NValue t f m -> m (NValue t f m)

--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -959,7 +959,7 @@ genericClosureNix c =
         ss <- fromValue @[NValue t f m] =<< demand startSet
         op <- demand operator
 
-        toValue @[NValue t f m] =<< snd <$> go op S.empty ss
+        toValue @[NValue t f m] =<< snd <$> go op mempty ss
  where
   go
     :: NValue t f m

--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -319,7 +319,7 @@ splitMatches numDropped (((_, (start, len)) : captures) : mts) haystack =
       (s >= 0)
 
 thunkStr :: Applicative f => ByteString -> NValue t f m
-thunkStr s = nvStr $ makeNixStringWithoutContext $ decodeUtf8 s
+thunkStr s = nvStrWithoutContext $ decodeUtf8 s
 
 elemAt :: [a] -> Int -> Maybe a
 elemAt ls i =
@@ -432,7 +432,7 @@ nixPathNix =
           <> rest
     )
  where
-  mkNvStr = nvStr . makeNixStringWithoutContext . toText
+  mkNvStr = nvStrWithoutContext . toText
 
 toStringNix :: MonadNix e t f m => NValue t f m -> m (NValue t f m)
 toStringNix = toValue <=< coerceToString callFunc DontCopyToStore CoerceAny
@@ -602,7 +602,7 @@ splitVersionNix v =
     version <- fromStringNoContext =<< fromValue v
     pure $
       nvList $
-        nvStr . makeNixStringWithoutContext . versionComponentToString <$>
+        nvStrWithoutContext . versionComponentToString <$>
           splitVersion version
 
 compareVersionsNix
@@ -647,7 +647,7 @@ parseDrvNameNix drvname =
         ]
 
  where
-  mkNVStr = nvStr . makeNixStringWithoutContext
+  mkNVStr = nvStrWithoutContext
 
 matchNix
   :: forall e t f m
@@ -774,7 +774,7 @@ mapAttrsNix f xs =
 
       applyFunToKeyVal (key, val) =
         do
-          runFunForKey <- callFunc f $ nvStr $ makeNixStringWithoutContext key
+          runFunForKey <- callFunc f $ nvStrWithoutContext key
           callFunc runFunForKey val
 
     newVals <-
@@ -1460,7 +1460,7 @@ fromJSONNix nvjson =
   jsonToNValue = \case
     A.Object m -> nvSet mempty <$> traverse jsonToNValue m
     A.Array  l -> nvList <$> traverse jsonToNValue (V.toList l)
-    A.String s -> pure $ nvStr $ makeNixStringWithoutContext s
+    A.String s -> pure $ nvStrWithoutContext s
     A.Number n ->
       pure $
         nvConstant $
@@ -1611,7 +1611,7 @@ currentSystemNix =
     os   <- getCurrentSystemOS
     arch <- getCurrentSystemArch
 
-    pure $ nvStr $ makeNixStringWithoutContext $ arch <> "-" <> os
+    pure $ nvStrWithoutContext $ arch <> "-" <> os
 
 currentTimeNix :: MonadNix e t f m => m (NValue t f m)
 currentTimeNix =
@@ -1802,7 +1802,7 @@ builtinsList = sequence
   , add2 Normal   "sort"             sortNix
   , add2 Normal   "split"            splitNix
   , add  Normal   "splitVersion"     splitVersionNix
-  , add0 Normal   "storeDir"         (pure $ nvStr $ makeNixStringWithoutContext "/nix/store")
+  , add0 Normal   "storeDir"         (pure $ nvStrWithoutContext "/nix/store")
   --, add  Normal   "storePath"        storePath
   , add' Normal   "stringLength"     (arity1 $ Text.length . stringIgnoreContext)
   , add' Normal   "sub"              (arity2 ((-) @Integer))
@@ -1910,7 +1910,7 @@ withNixContext mpath action =
     base            <- builtins
     opts :: Options <- asks $ view hasLens
     let
-      i = nvList $ nvStr . makeNixStringWithoutContext . toText <$> include opts
+      i = nvList $ nvStrWithoutContext . toText <$> include opts
 
     pushScope
       (one ("__includes", i))

--- a/src/Nix/Cache.hs
+++ b/src/Nix/Cache.hs
@@ -15,9 +15,7 @@ import           Nix.Expr.Types.Annotated
 import qualified Data.Compact                  as C
 import qualified Data.Compact.Serialize        as C
 #endif
-#ifdef MIN_VERSION_serialise
 import qualified Codec.Serialise               as S
-#endif
 
 readCache :: FilePath -> IO NExprLoc
 readCache path = do
@@ -28,15 +26,11 @@ readCache path = do
     (\ expr -> pure $ C.getCompact expr)
     eres
 #else
-#ifdef MIN_VERSION_serialise
   eres <- S.deserialiseOrFail <$> BS.readFile path
   either
     (\ err  -> fail $ "Error reading cache file: " <> show err)
     pure
     eres
-#else
-    fail "readCache not implemented for this platform"
-#endif
 #endif
 
 writeCache :: FilePath -> NExprLoc -> IO ()
@@ -44,9 +38,5 @@ writeCache path expr =
 #ifdef USE_COMPACT
   C.writeCompact path =<< C.compact expr
 #else
-#ifdef MIN_VERSION_serialise
   BS.writeFile path (S.serialise expr)
-#else
-  fail "writeCache not implemented for this platform"
-#endif
 #endif

--- a/src/Nix/Cited.hs
+++ b/src/Nix/Cited.hs
@@ -25,7 +25,8 @@ data Provenance m v =
     }
     deriving (Generic, Typeable, Show)
 
-data NCited m v a = NCited
+data NCited m v a =
+  NCited
     { _provenance :: [Provenance m v]
     , _cited      :: a
     }
@@ -33,7 +34,7 @@ data NCited m v a = NCited
 
 instance Applicative (NCited m v) where
   pure = NCited mempty
-  NCited xs f <*> NCited ys x = NCited (xs <> ys) (f x)
+  (<*>) (NCited xs f) (NCited ys x) = NCited (xs <> ys) (f x)
 
 instance Comonad (NCited m v) where
   duplicate p = NCited (_provenance p) p

--- a/src/Nix/Cited/Basic.hs
+++ b/src/Nix/Cited/Basic.hs
@@ -71,8 +71,8 @@ instance ( Has e Options
   thunkId :: Cited u f m t -> ThunkId m
   thunkId (Cited (NCited _ t)) = thunkId @_ @m t
 
-  queryM :: m v -> Cited u f m t -> m v
-  queryM m (Cited (NCited _ t)) = queryM m t
+  query :: m v -> Cited u f m t -> m v
+  query m (Cited (NCited _ t)) = query m t
 
   -- | The ThunkLoop exception is thrown as an exception with MonadThrow,
   --   which does not capture the current stack frame information to provide
@@ -101,8 +101,8 @@ instance ( Has e Options
          )
   => MonadThunkF (Cited u f m t) m v where
 
-  queryMF :: (v -> m r) -> m r -> Cited u f m t -> m r
-  queryMF k m (Cited (NCited _ t)) = queryMF k m t
+  queryF :: (v -> m r) -> m r -> Cited u f m t -> m r
+  queryF k m (Cited (NCited _ t)) = queryF k m t
 
   forceF :: (v -> m r) -> Cited u f m t -> m r
   forceF k (Cited (NCited ps t)) = handleDisplayProvenance ps $ forceF k t

--- a/src/Nix/Cited/Basic.hs
+++ b/src/Nix/Cited/Basic.hs
@@ -95,7 +95,7 @@ instance
             -- creation, and record it along with the thunk.
             let
               go (fromException -> Just (EvaluatingExpr scope (AnnE s e))) =
-                let e' = Compose $ Ann s (Nothing <$ e) in
+                let e' = AnnFP s (Nothing <$ e) in
                 [Provenance scope e']
               go _ = mempty
               ps = concatMap (go . frame) frames
@@ -182,6 +182,6 @@ displayProvenance
 displayProvenance =
   list
     id
-    (\ (Provenance scope e@(Compose (Ann s _)) : _) ->
+    (\ (Provenance scope e@(AnnFP s _) : _) ->
       withFrame Info $ ForcingExpr scope $ wrapExprLoc s e
     )

--- a/src/Nix/Cited/Basic.hs
+++ b/src/Nix/Cited/Basic.hs
@@ -20,7 +20,7 @@ import           Nix.Thunk
 import           Nix.Utils
 import           Nix.Value
 
-newtype Cited t f m a = Cited { getCited :: NCited m (NValue t f m) a }
+newtype Cited t f m a = Cited (NCited m (NValue t f m) a)
   deriving
     ( Generic
     , Typeable
@@ -32,7 +32,10 @@ newtype Cited t f m a = Cited { getCited :: NCited m (NValue t f m) a }
     , ComonadEnv [Provenance m (NValue t f m)]
     )
 
-instance HasCitations1 m (NValue t f m) (Cited t f m) where
+instance
+  HasCitations1 m (NValue t f m) (Cited t f m)
+ where
+
   citations1 (Cited c) = citations c
   addProvenance1 x (Cited c) = Cited $ addProvenance x c
 

--- a/src/Nix/Cited/Basic.hs
+++ b/src/Nix/Cited/Basic.hs
@@ -21,6 +21,9 @@ import           Nix.Thunk
 import           Nix.Utils
 import           Nix.Value
 
+
+-- * data type @Cited@
+
 newtype Cited t f m a = Cited (NCited m (NValue t f m) a)
   deriving
     ( Generic
@@ -32,6 +35,9 @@ newtype Cited t f m a = Cited (NCited m (NValue t f m) a)
     , Comonad
     , ComonadEnv [Provenance m (NValue t f m)]
     )
+
+
+-- ** Helpers
 
 -- | @Cited@ pattern.
 -- > pattern CitedP m a = Cited (NCited m a)
@@ -53,6 +59,8 @@ cite
   -> m (Cited t f m a)
 cite v = fmap (Cited . NCited v)
 
+
+-- ** instances
 
 instance
   HasCitations1 m (NValue t f m) (Cited t f m)
@@ -117,7 +125,7 @@ instance
   further (CitedP ps t) = cite ps $ further t
 
 
--- * Kleisli functor HOFs
+-- ** Kleisli functor HOFs
 
 -- Please, do not use MonadThunkF for MonadThunk, later uses more straight-forward specialized line of functions.
 instance
@@ -144,7 +152,7 @@ instance
   furtherF k (CitedP ps t) = cite ps $ furtherF k t
 
 
--- ** Utils
+-- * Representation
 
 handleDisplayProvenance
   :: (MonadCatch m

--- a/src/Nix/Convert.hs
+++ b/src/Nix/Convert.hs
@@ -27,11 +27,14 @@ import           Nix.Frames
 import           Nix.String
 import           Nix.Value
 import           Nix.Value.Monad
-import           Nix.Thunk
+import           Nix.Thunk                      ( MonadThunk(force) )
 import           Nix.Utils
 
-newtype Deeper a = Deeper { getDeeper :: a }
+newtype Deeper a = Deeper a
   deriving (Typeable, Functor, Foldable, Traversable)
+
+type CoerceDeeperToNValue t f m = Deeper (NValue t f m) -> NValue t f m
+type CoerceDeeperToNValue' t f m = Deeper (NValue' t f m (NValue t f m)) -> NValue' t f m (NValue t f m)
 
 {-
 
@@ -83,7 +86,7 @@ fromMayToDeeperValue t v =
   do
     v' <- fromValueMay v
     maybe
-      (throwError $ Expectation @t @f @m t $ Free $ getDeeper v)
+      (throwError $ Expectation @t @f @m t $ Free $ (coerce :: CoerceDeeperToNValue' t f m) v)
       pure
       v'
 
@@ -313,8 +316,8 @@ instance ( Convertible e t f m
          , FromValue a m (NValue' t f m (NValue t f m))
          )
   => FromValue a m (Deeper (NValue' t f m (NValue t f m))) where
-  fromValueMay = fromValueMay . getDeeper
-  fromValue    = fromValue . getDeeper
+  fromValueMay = fromValueMay . (coerce :: CoerceDeeperToNValue' t f m)
+  fromValue    = fromValue . (coerce :: CoerceDeeperToNValue' t f m)
 
 
 -- * ToValue

--- a/src/Nix/Convert.hs
+++ b/src/Nix/Convert.hs
@@ -211,7 +211,7 @@ instance Convertible e t f m
   => FromValue ByteString m (NValue' t f m (NValue t f m)) where
 
   fromValueMay =
-    pure.
+    pure .
       \case
         NVStr' ns -> encodeUtf8 <$> getStringNoContext  ns
         _         -> mempty

--- a/src/Nix/Effects.hs
+++ b/src/Nix/Effects.hs
@@ -449,4 +449,4 @@ addPath p =
     =<< addToStore (toText $ takeFileName p) p True False
 
 toFile_ :: (Framed e m, MonadStore m) => FilePath -> String -> m StorePath
-toFile_ p contents = addTextToStore (toText p) (toText contents) HS.empty False
+toFile_ p contents = addTextToStore (toText p) (toText contents) mempty False

--- a/src/Nix/Effects.hs
+++ b/src/Nix/Effects.hs
@@ -105,13 +105,9 @@ class
 instance MonadIntrospect IO where
   recursiveSize =
 #ifdef MIN_VERSION_ghc_datasize
-#if MIN_VERSION_ghc_datasize(0,2,0)
     recursiveSize
 #else
-      \_ -> pure 0
-#endif
-#else
-      \_ -> pure 0
+    \_ -> pure 0
 #endif
 
 deriving

--- a/src/Nix/Effects/Basic.hs
+++ b/src/Nix/Effects/Basic.hs
@@ -31,9 +31,7 @@ import           Nix.Value
 import           Nix.Value.Monad
 
 #ifdef MIN_VERSION_ghc_datasize
-#if MIN_VERSION_ghc_datasize(0,2,0)
 import           GHC.DataSize
-#endif
 #endif
 
 defaultMakeAbsolutePath :: MonadNix e t f m => FilePath -> m FilePath

--- a/src/Nix/Effects/Derivation.hs
+++ b/src/Nix/Effects/Derivation.hs
@@ -273,7 +273,7 @@ defaultDerivationStrict val = do
         pure $ drv
           { inputs
           , outputs = outputs'
-          , env = ifNotJsonModEnv $ Map.union outputs'
+          , env = ifNotJsonModEnv $ (outputs' <>)
           }
 
     drvPath <- pathToText <$> writeDerivation drv'

--- a/src/Nix/Effects/Derivation.hs
+++ b/src/Nix/Effects/Derivation.hs
@@ -71,7 +71,7 @@ parsePath p = case Store.parsePath "/nix/store" (encodeUtf8 p) of
 writeDerivation :: (Framed e m, MonadStore m) => Derivation -> m Store.StorePath
 writeDerivation drv@Derivation{inputs, name} = do
   let (inputSrcs, inputDrvs) = inputs
-  references <- Set.fromList <$> traverse parsePath (Set.toList $ Set.union inputSrcs $ Set.fromList $ Map.keys inputDrvs)
+  references <- Set.fromList <$> traverse parsePath (Set.toList $ inputSrcs <> Set.fromList (Map.keys inputDrvs))
   path <- addTextToStore (Text.append name ".drv") (unparseDrv drv) (S.fromList $ Set.toList references) False
   parsePath $ toText $ unStorePath path
 

--- a/src/Nix/Eval.hs
+++ b/src/Nix/Eval.hs
@@ -571,4 +571,4 @@ evalContent
   :: MonadNixEval v m
   => AnnF ann NExprF (m v)
   -> m v
-evalContent = eval . annotated . getCompose
+evalContent = eval . stripAnn

--- a/src/Nix/Eval.hs
+++ b/src/Nix/Eval.hs
@@ -398,7 +398,7 @@ evalBinds recursive binds =
 
   moveOverridesLast = uncurry (<>) . partition
     (\case
-      NamedVar (StaticKey "__overrides" :| []) _ _pos -> False
+      NamedVar (StaticKey "__overrides" :| []) _ _ -> False
       _ -> True
     )
 
@@ -557,14 +557,7 @@ framedEvalExprLoc
   => NExprLoc
   -> m v
 framedEvalExprLoc =
-  adi evalContent addMetaInfo
-
--- | Takes annotated expression. Strip from annotation. Evaluate.
-evalContent
-  :: MonadNixEval v m
-  => AnnF ann NExprF (m v)
-  -> m v
-evalContent = eval . annotated . getCompose
+  adi addMetaInfo evalContent
 
 -- | Add source postionss & frame context system.
 addMetaInfo
@@ -572,3 +565,10 @@ addMetaInfo
   . (Framed e m, Scoped v m, Has e SrcSpan, Typeable m, Typeable v)
   => TransformF NExprLoc (m a)
 addMetaInfo = addStackFrames @v . addSourcePositions
+
+-- | Takes annotated expression. Strip from annotation. Evaluate.
+evalContent
+  :: MonadNixEval v m
+  => AnnF ann NExprF (m v)
+  -> m v
+evalContent = eval . annotated . getCompose

--- a/src/Nix/Exec.hs
+++ b/src/Nix/Exec.hs
@@ -538,8 +538,8 @@ evalExprLoc expr =
           Eval.framedEvalExprLoc
           (join . (`runReaderT` (0 :: Int)) .
             adi
-              (addTracing Eval.evalContent)
               (raise Eval.addMetaInfo)
+              (addTracing Eval.evalContent)
           )
           (tracing opts)
     pTracedAdi expr

--- a/src/Nix/Exec.hs
+++ b/src/Nix/Exec.hs
@@ -303,7 +303,7 @@ callFunc fun arg =
       NVBuiltin name f    ->
         do
           span <- currentPos
-          withFrame Info ((Calling @m @(NValue t f m)) name span) (f arg)
+          withFrame Info ((Calling @m @(NValue t f m)) name span) $ f arg -- Is this cool?
       (NVSet m _) | Just f <- M.lookup "__functor" m ->
         (`callFunc` arg) =<< (`callFunc` fun') =<< demand f
       _x -> throwError $ ErrorCall $ "Attempt to call non-function: " <> show _x
@@ -319,11 +319,11 @@ execUnaryOp scope span op arg = do
   case arg of
     NVConstant c ->
       case (op, c) of
-        (NNeg, NInt i  ) -> unaryOp $ NInt (-i)
-        (NNeg, NFloat f) -> unaryOp $ NFloat (-f)
-        (NNot, NBool b ) -> unaryOp $ NBool (not b)
+        (NNeg, NInt   i) -> unaryOp $ NInt   (  - i)
+        (NNeg, NFloat f) -> unaryOp $ NFloat (  - f)
+        (NNot, NBool  b) -> unaryOp $ NBool  (not b)
         _seq ->
-          throwError $  ErrorCall $ "unsupported argument type for unary operator " <> show _seq
+          throwError $ ErrorCall $ "unsupported argument type for unary operator " <> show _seq
     _x ->
       throwError $ ErrorCall $ "argument to unary operator must evaluate to an atomic type: " <> show _x
  where
@@ -338,7 +338,6 @@ execBinaryOp
   -> NValue t f m
   -> m (NValue t f m)
   -> m (NValue t f m)
-
 execBinaryOp scope span op lval rarg =
   case op of
     NEq   -> helperEq id

--- a/src/Nix/Exec.hs
+++ b/src/Nix/Exec.hs
@@ -43,14 +43,10 @@ import           Nix.Value
 import           Nix.Value.Equal
 import           Nix.Value.Monad
 import           Prettyprinter
-#ifdef MIN_VERSION_pretty_show
 import qualified Text.Show.Pretty              as PS
-#endif
 
 #ifdef MIN_VERSION_ghc_datasize
-#if MIN_VERSION_ghc_datasize(0,2,0)
 import           GHC.DataSize
-#endif
 #endif
 
 type MonadCited t f m =
@@ -514,11 +510,7 @@ addTracing k v = do
           if verbose opts >= Chatty
             then
               pretty $
-#ifdef MIN_VERSION_pretty_show
                 PS.ppShow $ void x
-#else
-                show $ void x
-#endif
             else prettyNix $ Fix $ Fix (NSym "?") <$ x
         msg x = pretty ("eval: " <> replicate depth ' ') <> x
       loc <- renderLocation span $ msg rendered <> " ...\n"

--- a/src/Nix/Exec.hs
+++ b/src/Nix/Exec.hs
@@ -408,7 +408,7 @@ execBinaryOpForced scope span op lval rval = case op of
 
   NUpdate ->
     case (lval, rval) of
-      (NVSet ls lp, NVSet rs rp) -> pure $ nvSetP prov (rp `M.union` lp) (rs `M.union` ls)
+      (NVSet ls lp, NVSet rs rp) -> pure $ nvSetP prov (rp <> lp) (rs <> ls)
       (NVSet ls lp, NVConstant NNull) -> pure $ nvSetP prov lp ls
       (NVConstant NNull, NVSet rs rp) -> pure $ nvSetP prov rp rs
       _ -> unsupportedTypes

--- a/src/Nix/Expr/Shorthands.hs
+++ b/src/Nix/Expr/Shorthands.hs
@@ -131,8 +131,8 @@ mkDots e [] = e
 mkDots (Fix (NSelect e keys' x)) keys =
   -- Special case: if the expression in the first argument is already
   -- a dotted expression, just extend it.
-  Fix (NSelect e (keys' <> fmap (StaticKey ?? Nothing) keys) x)
-mkDots e keys = Fix $ NSelect e (fmap (StaticKey ?? Nothing) keys) Nothing
+  Fix (NSelect e (keys' <> fmap (`StaticKey` Nothing) keys) x)
+mkDots e keys = Fix $ NSelect e (fmap (`StaticKey` Nothing) keys) Nothing
 -}
 
 -- | An `inherit` clause without an expression to pull from.

--- a/src/Nix/Expr/Types.hs
+++ b/src/Nix/Expr/Types.hs
@@ -19,10 +19,8 @@
 -- <https://web.archive.org/web/20201112031804/https://alessandrovermeulen.me/2013/07/13/the-difference-between-shallow-and-deep-embedding/>
 module Nix.Expr.Types where
 
-#ifdef MIN_VERSION_serialise
 import qualified Codec.Serialise                as Serialise
 import           Codec.Serialise                ( Serialise )
-#endif
 import           Control.DeepSeq
 import           Data.Aeson
 import           Data.Aeson.TH
@@ -91,9 +89,7 @@ instance NFData1 Binding
 
 instance Hashable1 Binding
 
-#ifdef MIN_VERSION_serialise
 instance Serialise r => Serialise (Binding r)
-#endif
 
 
 -- ** @Params@
@@ -122,9 +118,7 @@ instance Hashable1 Params
 
 instance NFData1 Params
 
-#ifdef MIN_VERSION_serialise
 instance Serialise r => Serialise (Params r)
-#endif
 
 instance IsString (Params r) where
   fromString = Param . fromString
@@ -163,9 +157,7 @@ instance Hashable2 Antiquoted where
 
 instance NFData v => NFData1 (Antiquoted v)
 
-#ifdef MIN_VERSION_serialise
 instance (Serialise v, Serialise r) => Serialise (Antiquoted v r)
-#endif
 
 
 -- ** @NString@
@@ -198,9 +190,7 @@ instance Hashable1 NString
 
 instance NFData1 NString
 
-#ifdef MIN_VERSION_serialise
 instance Serialise r => Serialise (NString r)
-#endif
 
 -- | For the the 'IsString' instance, we use a plain doublequoted string.
 instance IsString (NString r) where
@@ -240,7 +230,6 @@ data NKeyName r
   -- > StaticKey "x"                                     ~  x
   deriving (Eq, Ord, Generic, Typeable, Data, Show, Read, NFData, Hashable)
 
-#ifdef MIN_VERSION_serialise
 instance Serialise r => Serialise (NKeyName r)
 
 instance Serialise Pos where
@@ -257,7 +246,6 @@ instance Serialise SourcePos where
       Serialise.decode
       Serialise.decode
       Serialise.decode
-#endif
 
 instance Hashable Pos where
   hashWithSalt salt = hashWithSalt salt . unPos
@@ -345,9 +333,7 @@ data NUnaryOp
   deriving (Eq, Ord, Enum, Bounded, Generic, Typeable, Data, Show, Read,
             NFData, Hashable)
 
-#ifdef MIN_VERSION_serialise
 instance Serialise NUnaryOp
-#endif
 
 
 -- ** @NBinaryOp@
@@ -375,9 +361,7 @@ data NBinaryOp
   deriving (Eq, Ord, Enum, Bounded, Generic, Typeable, Data, Show, Read,
             NFData, Hashable)
 
-#ifdef MIN_VERSION_serialise
 instance Serialise NBinaryOp
-#endif
 
 
 -- ** @NRecordType@
@@ -390,9 +374,7 @@ data NRecordType
   deriving (Eq, Ord, Enum, Bounded, Generic, Typeable, Data, Show, Read,
             NFData, Hashable)
 
-#ifdef MIN_VERSION_serialise
 instance Serialise NRecordType
-#endif
 
 -- * @NExprF@ - Nix expressions, base functor
 
@@ -487,9 +469,7 @@ data NExprF r
 
 instance NFData1 NExprF
 
-#ifdef MIN_VERSION_serialise
 instance Serialise r => Serialise (NExprF r)
-#endif
 
 -- | We make an `IsString` for expressions, where the string is interpreted
 -- as an identifier. This is the most common use-case...
@@ -509,9 +489,7 @@ instance Hashable1 NExprF
 -- | The monomorphic expression type is a fixed point of the polymorphic one.
 type NExpr = Fix NExprF
 
-#ifdef MIN_VERSION_serialise
 instance Serialise NExpr
-#endif
 
 instance TH.Lift NExpr where
   lift =

--- a/src/Nix/Expr/Types.hs
+++ b/src/Nix/Expr/Types.hs
@@ -518,7 +518,10 @@ instance TH.Lift NExpr where
     TH.dataToExpQ
       (\b ->
         do
-          -- Binding on constructor ensures type match and gives type inference to TH
+          -- Binding on constructor ensures type match and gives type inference to TH.
+          -- Reflection is the ability of a process to examine, introspect, and modify its own structure and behavior.
+          -- Reflection is a key strategy in metaprogramming.
+          -- <https://en.wikipedia.org/wiki/Reflective_programming>
           HRefl <-
             eqTypeRep
               (Reflection.typeRep @Text)

--- a/src/Nix/Expr/Types/Annotated.hs
+++ b/src/Nix/Expr/Types/Annotated.hs
@@ -16,9 +16,7 @@ module Nix.Expr.Types.Annotated
   )
 where
 
-#ifdef MIN_VERSION_serialise
 import           Codec.Serialise
-#endif
 import           Control.DeepSeq
 import           Data.Aeson                     ( ToJSON(..)
                                                 , FromJSON(..)
@@ -63,9 +61,7 @@ instance Binary SrcSpan
 instance ToJSON SrcSpan
 instance FromJSON SrcSpan
 
-#ifdef MIN_VERSION_serialise
 instance Serialise SrcSpan
-#endif
 
 -- * data type @Ann@
 
@@ -123,31 +119,25 @@ $(deriveShow2 ''Ann)
 $(deriveJSON1 defaultOptions ''Ann)
 $(deriveJSON2 defaultOptions ''Ann)
 
-#ifdef MIN_VERSION_serialise
 instance (Serialise ann, Serialise a) => Serialise (Ann ann a)
-#endif
 
 -- ** @NExprLoc{,F}@ - annotated Nix expression
 
 type NExprLocF = AnnF SrcSpan NExprF
 
-#ifdef MIN_VERSION_serialise
 instance Serialise r => Serialise (NExprLocF r) where
   encode (AnnFP ann a) = encode ann <> encode a
   decode =
     liftA2 AnnFP
       decode
       decode
-#endif
 
 instance Binary r => Binary (NExprLocF r)
 
 -- | Annotated Nix expression (each subexpression direct to its source location).
 type NExprLoc = Fix NExprLocF
 
-#ifdef MIN_VERSION_serialise
 instance Serialise NExprLoc
-#endif
 
 instance Binary NExprLoc
 

--- a/src/Nix/Expr/Types/Annotated.hs
+++ b/src/Nix/Expr/Types/Annotated.hs
@@ -82,15 +82,23 @@ data Ann ann a = Ann
 
 type AnnF ann f = Compose (Ann ann) f
 
+-- | Pattern: @(Compose (Ann _ _))@.
+pattern AnnFP
+  :: ann
+  -> f a
+  -> Compose (Ann ann) f a
+pattern AnnFP ann f = Compose (Ann ann f)
+{-# complete AnnFP #-}
+
 -- | Pattern: @Fix (Compose (Ann _ _))@.
 -- Fix composes units of (annotations & the annotated) into one object.
 -- Giving annotated expression.
 pattern AnnE
-  :: forall ann (g :: * -> *)
+  :: forall ann (f :: * -> *)
   . ann
-  -> g (Fix (AnnF ann g))
-  -> Fix (AnnF ann g)
-pattern AnnE ann a = Fix (Compose (Ann ann a))
+  -> f (Fix (AnnF ann f))
+  -> Fix (AnnF ann f)
+pattern AnnE ann a = Fix (AnnFP ann a)
 {-# complete AnnE #-}
 
 annToAnnF :: Ann ann (f (Fix (AnnF ann f))) -> Fix (AnnF ann f)
@@ -125,9 +133,9 @@ type NExprLocF = AnnF SrcSpan NExprF
 
 #ifdef MIN_VERSION_serialise
 instance Serialise r => Serialise (NExprLocF r) where
-  encode (Compose (Ann ann a)) = encode ann <> encode a
+  encode (AnnFP ann a) = encode ann <> encode a
   decode =
-    liftA2 ((Compose .) . Ann)
+    liftA2 AnnFP
       decode
       decode
 #endif
@@ -197,53 +205,53 @@ nullSpan = SrcSpan nullPos nullPos
 -- | Pattern systems for matching on NExprLocF constructions.
 
 pattern NConstant_ :: SrcSpan -> NAtom -> NExprLocF r
-pattern NConstant_ ann x = Compose (Ann ann (NConstant x))
+pattern NConstant_ ann x = AnnFP ann (NConstant x)
 
 pattern NStr_ :: SrcSpan -> NString r -> NExprLocF r
-pattern NStr_ ann x = Compose (Ann ann (NStr x))
+pattern NStr_ ann x = AnnFP ann (NStr x)
 
 pattern NSym_ :: SrcSpan -> VarName -> NExprLocF r
-pattern NSym_ ann x = Compose (Ann ann (NSym x))
+pattern NSym_ ann x = AnnFP ann (NSym x)
 
 pattern NList_ :: SrcSpan -> [r] -> NExprLocF r
-pattern NList_ ann x = Compose (Ann ann (NList x))
+pattern NList_ ann x = AnnFP ann (NList x)
 
 pattern NSet_ :: SrcSpan -> NRecordType -> [Binding r] -> NExprLocF r
-pattern NSet_ ann recur x = Compose (Ann ann (NSet recur x))
+pattern NSet_ ann recur x = AnnFP ann (NSet recur x)
 
 pattern NLiteralPath_ :: SrcSpan -> FilePath -> NExprLocF r
-pattern NLiteralPath_ ann x = Compose (Ann ann (NLiteralPath x))
+pattern NLiteralPath_ ann x = AnnFP ann (NLiteralPath x)
 
 pattern NEnvPath_ :: SrcSpan -> FilePath -> NExprLocF r
-pattern NEnvPath_ ann x = Compose (Ann ann (NEnvPath x))
+pattern NEnvPath_ ann x = AnnFP ann (NEnvPath x)
 
 pattern NUnary_ :: SrcSpan -> NUnaryOp -> r -> NExprLocF r
-pattern NUnary_ ann op x = Compose (Ann ann (NUnary op x))
+pattern NUnary_ ann op x = AnnFP ann (NUnary op x)
 
 pattern NBinary_ :: SrcSpan -> NBinaryOp -> r -> r -> NExprLocF r
-pattern NBinary_ ann op x y = Compose (Ann ann (NBinary op x y))
+pattern NBinary_ ann op x y = AnnFP ann (NBinary op x y)
 
 pattern NSelect_ :: SrcSpan -> r -> NAttrPath r -> Maybe r -> NExprLocF r
-pattern NSelect_ ann x p v = Compose (Ann ann (NSelect x p v))
+pattern NSelect_ ann x p v = AnnFP ann (NSelect x p v)
 
 pattern NHasAttr_ :: SrcSpan -> r -> NAttrPath r -> NExprLocF r
-pattern NHasAttr_ ann x p = Compose (Ann ann (NHasAttr x p))
+pattern NHasAttr_ ann x p = AnnFP ann (NHasAttr x p)
 
 pattern NAbs_ :: SrcSpan -> Params r-> r -> NExprLocF r
-pattern NAbs_ ann x b = Compose (Ann ann (NAbs x b))
+pattern NAbs_ ann x b = AnnFP ann (NAbs x b)
 
 pattern NLet_ :: SrcSpan -> [Binding r] -> r -> NExprLocF r
-pattern NLet_ ann x b = Compose (Ann ann (NLet x b))
+pattern NLet_ ann x b = AnnFP ann (NLet x b)
 
 pattern NIf_ :: SrcSpan -> r -> r -> r -> NExprLocF r
-pattern NIf_ ann c t e = Compose (Ann ann (NIf c t e))
+pattern NIf_ ann c t e = AnnFP ann (NIf c t e)
 
 pattern NWith_ :: SrcSpan -> r -> r -> NExprLocF r
-pattern NWith_ ann x y = Compose (Ann ann (NWith x y))
+pattern NWith_ ann x y = AnnFP ann (NWith x y)
 
 pattern NAssert_ :: SrcSpan -> r -> r -> NExprLocF r
-pattern NAssert_ ann x y = Compose (Ann ann (NAssert x y))
+pattern NAssert_ ann x y = AnnFP ann (NAssert x y)
 
 pattern NSynHole_ :: SrcSpan -> Text -> NExprLocF r
-pattern NSynHole_ ann x = Compose (Ann ann (NSynHole x))
+pattern NSynHole_ ann x = AnnFP ann (NSynHole x)
 {-# complete NConstant_, NStr_, NSym_, NList_, NSet_, NLiteralPath_, NEnvPath_, NUnary_, NBinary_, NSelect_, NHasAttr_, NAbs_, NLet_, NIf_, NWith_, NAssert_, NSynHole_ #-}

--- a/src/Nix/Fresh.hs
+++ b/src/Nix/Fresh.hs
@@ -20,7 +20,7 @@ import           Control.Monad.Ref    ( MonadAtomicRef(..)
 
 import           Nix.Thunk
 
-
+--  2021-06-02: NOTE: Remove singleton newtype accessor in favour of free coerce
 newtype FreshIdT i m a = FreshIdT { unFreshIdT :: ReaderT (Ref m i) m a }
   deriving
     ( Functor

--- a/src/Nix/Fresh/Basic.hs
+++ b/src/Nix/Fresh/Basic.hs
@@ -33,7 +33,7 @@ instance (MonadEffects t f m, MonadDataContext f m)
   findEnvPath      = lift . findEnvPath @t @f @m
   findPath vs path = do
     i <- FreshIdT ask
-    let vs' = fmap (unliftNValue (runFreshIdT i)) vs
+    let vs' = unliftNValue (runFreshIdT i) <$> vs
     lift $ findPath @t @f @m vs' path
   importPath path = do
     i <- FreshIdT ask

--- a/src/Nix/Lint.hs
+++ b/src/Nix/Lint.hs
@@ -484,8 +484,8 @@ lint opts expr =
       pushScopes
         basis
         (adi
-          Eval.evalContent
           Eval.addSourcePositions
+          Eval.evalContent
           expr
         )
 

--- a/src/Nix/Normal.hs
+++ b/src/Nix/Normal.hs
@@ -166,8 +166,8 @@ stubCycles =
  where
   Free (NValue' cyc) = opaqueVal
 
-thunkVal :: Applicative f => NValue t f m
-thunkVal = nvStr $ makeNixStringWithoutContext "<thunk>"
+thunkStubVal :: Applicative f => NValue t f m
+thunkStubVal = nvStr $ makeNixStringWithoutContext thunkStubText
 
 removeEffects
   :: (MonadThunk t m (NValue t f m), MonadDataContext f m)
@@ -177,11 +177,11 @@ removeEffects =
   iterNValueM
     id
     --  2021-02-25: NOTE: Please, unflip this up the stack
-    (\ t f -> f =<< query (pure thunkVal) t)
+    (\ t f -> f =<< query (pure thunkStubVal) t)
     (fmap Free . sequenceNValue' id)
 
 dethunk
   :: (MonadThunk t m (NValue t f m), MonadDataContext f m)
   => t
   -> m (NValue t f m)
-dethunk = removeEffects <=< query (pure thunkVal)
+dethunk = removeEffects <=< query (pure thunkStubVal)

--- a/src/Nix/Normal.hs
+++ b/src/Nix/Normal.hs
@@ -177,11 +177,11 @@ removeEffects =
   iterNValueM
     id
     --  2021-02-25: NOTE: Please, unflip this up the stack
-    (\ t f -> f =<< queryM (pure thunkVal) t)
+    (\ t f -> f =<< query (pure thunkVal) t)
     (fmap Free . sequenceNValue' id)
 
 dethunk
   :: (MonadThunk t m (NValue t f m), MonadDataContext f m)
   => t
   -> m (NValue t f m)
-dethunk = removeEffects <=< queryM (pure thunkVal)
+dethunk = removeEffects <=< query (pure thunkVal)

--- a/src/Nix/Normal.hs
+++ b/src/Nix/Normal.hs
@@ -19,7 +19,6 @@ import           Data.Set                  ( member
                                            )
 import           Nix.Cited
 import           Nix.Frames
-import           Nix.String
 import           Nix.Thunk
 import           Nix.Value
 
@@ -156,7 +155,7 @@ stubCycles
   -> NValue t f m
 stubCycles =
   iterNValue
-    (\t _ ->
+    (\_ t ->
       Free $
         NValue' $
           foldr

--- a/src/Nix/Normal.hs
+++ b/src/Nix/Normal.hs
@@ -143,7 +143,7 @@ normalForm_
 normalForm_ t = void $ normalizeValue t
 
 opaqueVal :: Applicative f => NValue t f m
-opaqueVal = nvStr $ makeNixStringWithoutContext "<cycle>"
+opaqueVal = nvStrWithoutContext "<cycle>"
 
 -- | Detect cycles & stub them.
 stubCycles
@@ -169,7 +169,7 @@ stubCycles =
   Free (NValue' cyc) = opaqueVal
 
 thunkStubVal :: Applicative f => NValue t f m
-thunkStubVal = nvStr $ makeNixStringWithoutContext thunkStubText
+thunkStubVal = nvStrWithoutContext thunkStubText
 
 -- | Check if thunk @t@ is computed,
 -- then bind it into first arg.

--- a/src/Nix/Pretty.hs
+++ b/src/Nix/Pretty.hs
@@ -53,7 +53,7 @@ mkNixDoc o d = NixDoc { withoutParens = d, rootOp = o, wasPath = False }
 --   behaves as if its root operator had a precedence higher than all
 --   other operators (including function application).
 simpleExpr :: Doc ann -> NixDoc ann
-simpleExpr = mkNixDoc (OperatorInfo minBound NAssocNone "simple expr")
+simpleExpr = mkNixDoc $ OperatorInfo minBound NAssocNone "simple expr"
 
 pathExpr :: Doc ann -> NixDoc ann
 pathExpr d = (simpleExpr d) { wasPath = True }
@@ -195,7 +195,7 @@ prettyOriginExpr
   -> Doc ann
 prettyOriginExpr = withoutParens . go
  where
-  go = exprFNixDoc . annotated . getCompose . fmap render
+  go = exprFNixDoc . stripAnn . fmap render
 
   render :: Maybe (NValue t f m) -> NixDoc ann
   render Nothing = simpleExpr "_"
@@ -235,8 +235,11 @@ exprFNixDoc = \case
         ]
    where
     opInfo = getBinaryOperator op
-    f x | associativity opInfo /= x = opInfo { associativity = NAssocNone }
-        | otherwise                 = opInfo
+    f x =
+      bool
+        opInfo
+        (opInfo { associativity = NAssocNone })
+        (associativity opInfo /= x)
   NUnary op r1 ->
     mkNixDoc
       opInfo

--- a/src/Nix/Pretty.hs
+++ b/src/Nix/Pretty.hs
@@ -374,7 +374,7 @@ prettyNThunk t =
 printNix :: forall t f m . MonadDataContext f m => NValue t f m -> String
 printNix = iterNValue (\_ _ -> thk) phi
  where
-  thk = "<thunk>"
+  thk = toString thunkStubText
 
   phi :: NValue' t f m String -> String
   phi (NVConstant' a ) = toString $ atomText a

--- a/src/Nix/Pretty.hs
+++ b/src/Nix/Pretty.hs
@@ -307,7 +307,7 @@ exprFNixDoc = \case
 
 
 valueToExpr :: forall t f m . MonadDataContext f m => NValue t f m -> NExpr
-valueToExpr = iterNValue (\_ _ -> thk) (Fix . phi)
+valueToExpr = iterNValueByDiscardWith thk (Fix . phi)
  where
   thk = Fix . NSym $ "<expr>"
 
@@ -372,7 +372,7 @@ prettyNThunk t =
 
 -- | This function is used only by the testing code.
 printNix :: forall t f m . MonadDataContext f m => NValue t f m -> String
-printNix = iterNValue (\_ _ -> thk) phi
+printNix = iterNValueByDiscardWith thk phi
  where
   thk = toString thunkStubText
 

--- a/src/Nix/Reduce.hs
+++ b/src/Nix/Reduce.hs
@@ -283,14 +283,14 @@ reduce (NLet_ ann binds body) =
 
     -- let names = gatherNames body'
     -- binds' <- traverse sequence binds <&> \b -> flip filter b $ \case
-    --     NamedVar (StaticKey name _ :| mempty) _ ->
+    --     NamedVar (StaticKey name _ :| []) _ ->
     --         name `S.member` names
     --     _ -> True
     pure $ Fix $ NLet_ ann binds' body'
     -- where
     --   go m [] = pure m
     --   go m (x:xs) = case x of
-    --       NamedVar (StaticKey name _ :| mempty) def -> do
+    --       NamedVar (StaticKey name _ :| []) def -> do
     --           v <- pushScope m def
     --           go (M.insert name v m) xs
     --       _ -> go m xs

--- a/src/Nix/Render/Frame.hs
+++ b/src/Nix/Render/Frame.hs
@@ -26,9 +26,7 @@ import           Nix.Value
 import           Prettyprinter       hiding ( list )
 import qualified Text.Show                 as Text
 import           Text.Megaparsec.Pos        ( sourcePosPretty)
-#ifdef MIN_VERSION_pretty_show
 import qualified Text.Show.Pretty          as PS
-#endif
 
 renderFrames
   :: forall v t f e m ann
@@ -153,11 +151,7 @@ renderExpr _level longLabel shortLabel e@(AnnE _ x) = do
   opts :: Options <- asks (view hasLens)
   let rendered
           | verbose opts >= DebugInfo =
-#ifdef MIN_VERSION_pretty_show
               pretty (PS.ppShow (stripAnnotation e))
-#else
-              pretty (show (stripAnnotation e))
-#endif
           | verbose opts >= Chatty = prettyNix (stripAnnotation e)
           | otherwise = prettyNix (Fix (Fix (NSym "<?>") <$ x))
   pure $

--- a/src/Nix/Standard.hs
+++ b/src/Nix/Standard.hs
@@ -132,11 +132,11 @@ instance
     -> m (StdThunk m)
   thunk = fmap (StdThunk . StdCited) . thunk
 
-  queryM
+  query
     :: m (StdValue m)
     ->    StdThunk m
     -> m (StdValue m)
-  queryM b = queryM b . _stdCited . _stdThunk
+  query b = query b . _stdCited . _stdThunk
 
   force
     ::    StdThunk m
@@ -166,14 +166,14 @@ instance
   )
   => MonadThunkF (StdThunk m) m (StdValue m) where
 
-  queryMF
+  queryF
     :: ( StdValue m
        -> m r
        )
     -> m r
     -> StdThunk m
     -> m r
-  queryMF k b x = queryMF k b (_stdCited (_stdThunk x))
+  queryF k b x = queryF k b (_stdCited (_stdThunk x))
 
   forceF
     :: ( StdValue m

--- a/src/Nix/Standard.hs
+++ b/src/Nix/Standard.hs
@@ -67,7 +67,7 @@ type StdValue' m = NValue' (StdThunk m) (StdCited m) m (StdValue m)
 type StdValue m = NValue (StdThunk m) (StdCited m) m
 
 instance Show (StdThunk m) where
-  show _ = "<thunk>"
+  show _ = toString thunkStubText
 
 instance HasCitations1 m (StdValue m) (StdCited m) where
   citations1 (StdCited c) = citations1 c

--- a/src/Nix/Standard.hs
+++ b/src/Nix/Standard.hs
@@ -9,7 +9,7 @@
 
 module Nix.Standard where
 
-import           Control.Applicative
+import           Prelude hiding                 ( force )
 import           Control.Comonad                ( Comonad )
 import           Control.Comonad.Env            ( ComonadEnv )
 import           Control.Monad.Catch            ( MonadThrow
@@ -21,7 +21,9 @@ import           Control.Monad.Fail             ( MonadFail )
 #endif
 import           Control.Monad.Free             ( Free(Pure, Free) )
 import           Control.Monad.Reader           ( MonadFix )
-import           Control.Monad.Ref              ( MonadAtomicRef )
+import           Control.Monad.Ref              ( MonadRef(newRef)
+                                                , MonadAtomicRef
+                                                )
 import qualified Text.Show
 import           Nix.Cited
 import           Nix.Cited.Basic
@@ -41,8 +43,6 @@ import           Nix.Utils                      ( free )
 import           Nix.Utils.Fix1                 ( Fix1T(Fix1T) )
 import           Nix.Value
 import           Nix.Value.Monad
-import           Nix.Var
-import Prelude hiding (force)
 
 
 newtype StdCited m a =
@@ -345,7 +345,7 @@ runWithBasicEffects opts =
   go . (`evalStateT` mempty) . (`runReaderT` newContext opts) . runStandardT
  where
   go action = do
-    i <- newVar (1 :: Int)
+    i <- newRef (1 :: Int)
     runFreshIdT i action
 
 runWithBasicEffectsIO :: Options -> StandardT (StdIdT IO) a -> IO a

--- a/src/Nix/String/Coerce.hs
+++ b/src/Nix/String/Coerce.hs
@@ -12,9 +12,7 @@ import           Nix.Value
 import           Nix.Value.Monad
 
 #ifdef MIN_VERSION_ghc_datasize
-#if MIN_VERSION_ghc_datasize(0,2,0)
 import           GHC.DataSize
-#endif
 #endif
 
 -- | Data type to avoid boolean blindness on what used to be called coerceMore

--- a/src/Nix/String/Coerce.hs
+++ b/src/Nix/String/Coerce.hs
@@ -110,12 +110,13 @@ coerceToString call ctsm clevel = go
       err v = throwError $ ErrorCall $ "Expected a string, but saw: " <> show v
       castToNixString = pure . makeNixStringWithoutContext
 
-  nixStringUnwords = intercalateNixString (makeNixStringWithoutContext " ")
+  nixStringUnwords = intercalateNixString $ makeNixStringWithoutContext " "
 
   storePathToNixString :: StorePath -> NixString
-  storePathToNixString sp = makeNixStringWithSingletonContext
-    t
-    (StringContext t DirectPath)
+  storePathToNixString sp =
+    makeNixStringWithSingletonContext
+      t
+      (StringContext t DirectPath)
    where
     t = toText $ unStorePath sp
 

--- a/src/Nix/TH.hs
+++ b/src/Nix/TH.hs
@@ -48,39 +48,35 @@ freeVars e = case unFix e of
   (NLiteralPath _               ) -> mempty
   (NEnvPath     _               ) -> mempty
   (NUnary       _    expr       ) -> freeVars expr
-  (NBinary      _    left right ) -> Set.union (freeVars left) (freeVars right)
+  (NBinary      _    left right ) -> ((<>) `on` freeVars) left right
   (NSelect      expr path orExpr) ->
     Set.unions
       [ freeVars expr
       , pathFree path
       , maybe mempty freeVars orExpr
       ]
-  (NHasAttr expr            path) -> Set.union (freeVars expr) (pathFree path)
+  (NHasAttr expr            path) -> freeVars expr <> pathFree path
   (NAbs     (Param varname) expr) -> Set.delete varname (freeVars expr)
   (NAbs (ParamSet set _ varname) expr) ->
-    Set.union
-      -- Include all free variables from the expression and the default arguments
-      (freeVars expr)
-      -- But remove the argument name if existing, and all arguments in the parameter set
+    -- Include all free variables from the expression and the default arguments
+    freeVars expr <>
+    -- But remove the argument name if existing, and all arguments in the parameter set
+    Set.difference
+      (Set.unions $ freeVars <$> mapMaybe snd set)
       (Set.difference
-        (Set.unions $ freeVars <$> mapMaybe snd set)
-        (Set.difference
-          (maybe mempty one varname)
-          (Set.fromList $ fmap fst set)
-        )
+        (maybe mempty one varname)
+        (Set.fromList $ fmap fst set)
       )
   (NLet         bindings expr   ) ->
-    Set.union
-      (freeVars expr)
-      (Set.difference
-        (bindFreeVars bindings)
-        (bindDefs  bindings)
-      )
+    freeVars expr <>
+    Set.difference
+      (bindFreeVars bindings)
+      (bindDefs  bindings)
   (NIf          cond th   el    ) -> Set.unions $ freeVars <$> [cond, th, el]
   -- Evaluation is needed to find out whether x is a "real" free variable in `with y; x`, we just include it
   -- This also makes sense because its value can be overridden by `x: with y; x`
-  (NWith        set  expr       ) -> Set.union (freeVars set      ) (freeVars expr)
-  (NAssert      assertion expr  ) -> Set.union (freeVars assertion) (freeVars expr)
+  (NWith        set  expr       ) -> ((<>) `on` freeVars) set expr
+  (NAssert      assertion expr  ) -> ((<>) `on` freeVars) assertion expr
   (NSynHole     _               ) -> mempty
 
  where
@@ -100,7 +96,7 @@ freeVars e = case unFix e of
     bind1Free :: Binding NExpr -> Set VarName
     bind1Free (Inherit  Nothing     keys _) = Set.fromList $ mapMaybe staticKey keys
     bind1Free (Inherit (Just scope) _    _) = freeVars scope
-    bind1Free (NamedVar path        expr _) = Set.union (pathFree path) (freeVars expr)
+    bind1Free (NamedVar path        expr _) = pathFree path <> freeVars expr
 
   staticKey :: NKeyName r -> Maybe VarName
   staticKey (StaticKey  varname) = pure varname

--- a/src/Nix/TH.hs
+++ b/src/Nix/TH.hs
@@ -65,7 +65,7 @@ freeVars e = case unFix e of
       (Set.unions $ freeVars <$> mapMaybe snd set)
       (Set.difference
         (maybe mempty one varname)
-        (Set.fromList $ fmap fst set)
+        (Set.fromList $ fst <$> set)
       )
   (NLet         bindings expr   ) ->
     freeVars expr <>

--- a/src/Nix/Thunk.hs
+++ b/src/Nix/Thunk.hs
@@ -68,14 +68,17 @@ class
   => MonadThunk t m a | t -> m, t -> a
  where
 
-  -- | Return an identifier for the thunk unless it is a pure value (i.e.,
-  --   strictly an encapsulation of some 'a' without any additional
-  --   structure). For pure values represented as thunks, returns mempty.
+  -- | Return thunk ID.
   thunkId  :: t -> ThunkId m
 
+  -- | Create new thunk
   thunk    :: m a -> m t
 
-  queryM   :: m a -> t -> m a
+  -- | Non-blocking query.
+  --   If thunk got computed
+  --   then return its value
+  --   otherwise return default value (1st arg).
+  query   :: m a -> t -> m a
   force    :: t -> m a
   forceEff :: t -> m a
 
@@ -90,7 +93,7 @@ class
 class
   MonadThunkF t m a | t -> m, t -> a
  where
-  queryMF   :: (a   -> m r) -> m r -> t -> m r
+  queryF   :: (a   -> m r) -> m r -> t -> m r
   forceF    :: (a   -> m r) -> t   -> m r
   forceEffF :: (a   -> m r) -> t   -> m r
   furtherF  :: (m a -> m a) -> t   -> m t

--- a/src/Nix/Thunk.hs
+++ b/src/Nix/Thunk.hs
@@ -108,3 +108,8 @@ instance Show ThunkLoop where
   show (ThunkLoop i) = toString $ "ThunkLoop " <> i
 
 instance Exception ThunkLoop
+
+-- ** Utils
+
+thunkStubText :: Text
+thunkStubText = "<thunk>"

--- a/src/Nix/Thunk/Basic.hs
+++ b/src/Nix/Thunk/Basic.hs
@@ -88,7 +88,7 @@ instance (Eq v, Eq (ThunkId m)) => Eq (NThunkF m v) where
   Thunk x _ _ == Thunk y _ _ = x == y
 
 instance Show (NThunkF m v) where
-  show Thunk{} = "<thunk>"
+  show Thunk{} = toString thunkStubText
 
 type MonadBasicThunk m = (MonadThunkId m, MonadAtomicRef m)
 

--- a/src/Nix/Thunk/Basic.hs
+++ b/src/Nix/Thunk/Basic.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE UndecidableInstances #-}
-
+{-# OPTIONS_GHC -Wno-unused-do-bind #-}
 
 
 module Nix.Thunk.Basic
@@ -107,12 +107,10 @@ instance (MonadBasicThunk m, MonadCatch m)
         (newVar $ Deferred action)
 
   query :: m v -> NThunkF m v -> m v
-  query n (Thunk _ _ ref) =
+  query vStub (Thunk _ _ lTValRef) =
     do
-      deferred
-        pure
-        (const n)
-        =<< readVar ref
+      v <- readVar lTValRef
+      deferred pure (const vStub) v
 
   force :: NThunkF m v -> m v
   force = forceMain

--- a/src/Nix/Thunk/Basic.hs
+++ b/src/Nix/Thunk/Basic.hs
@@ -7,6 +7,7 @@
 module Nix.Thunk.Basic
   ( NThunkF(..)
   , Deferred(..)
+  , deferred
   , MonadBasicThunk
   ) where
 

--- a/src/Nix/Thunk/Basic.hs
+++ b/src/Nix/Thunk/Basic.hs
@@ -106,10 +106,8 @@ instance (MonadBasicThunk m, MonadCatch m)
       freshThunkId <- freshId
       Thunk freshThunkId <$> newVar False <*> newVar (Deferred action)
 
-  -- | Non-blocking query, return value if @Computed@,
-  -- return first argument otherwise.
-  queryM :: m v -> NThunkF m v -> m v
-  queryM n (Thunk _ _ ref) =
+  query :: m v -> NThunkF m v -> m v
+  query n (Thunk _ _ ref) =
     do
       deferred
         pure
@@ -175,12 +173,12 @@ forceMain (Thunk n thunkRef thunkValRef) =
 instance (MonadBasicThunk m, MonadCatch m)
   => MonadThunkF (NThunkF m v) m v where
 
-  queryMF
+  queryF
     :: (v -> m r)
     -> m r
     -> NThunkF m v
     -> m r
-  queryMF k n (Thunk _ thunkRef thunkValRef) =
+  queryF k n (Thunk _ thunkRef thunkValRef) =
     do
       lockedIt <- lockThunk thunkRef
       bool

--- a/src/Nix/Type/Env.hs
+++ b/src/Nix/Type/Env.hs
@@ -27,11 +27,13 @@ import qualified Data.Map                      as Map
 
 -- * Typing Environment
 
-newtype Env = TypeEnv { types :: Map.Map Name [Scheme] }
+newtype Env = TypeEnv (Map.Map Name [Scheme])
   deriving (Eq, Show)
 
 instance Semigroup Env where
-  (<>) = merge
+  -- | Right-biased merge (override). Analogous to @//@ in @Nix@
+  -- Since nature of environment is to update & grow.
+  (<>) = mergeRight
 
 instance Monoid Env where
   mempty = empty
@@ -44,19 +46,22 @@ empty :: Env
 empty = TypeEnv mempty
 
 extend :: Env -> (Name, [Scheme]) -> Env
-extend env (x, s) = env { types = Map.insert x s (types env) }
+extend env (x, s) = TypeEnv $ Map.insert x s $ coerce env
 
 remove :: Env -> Name -> Env
 remove (TypeEnv env) var = TypeEnv $ Map.delete var env
 
 extends :: Env -> [(Name, [Scheme])] -> Env
-extends env xs = env { types = Map.fromList xs `Map.union` types env }
+extends env xs = TypeEnv $ Map.fromList xs `Map.union` coerce env
 
 lookup :: Name -> Env -> Maybe [Scheme]
 lookup key (TypeEnv tys) = Map.lookup key tys
 
 merge :: Env -> Env -> Env
 merge (TypeEnv a) (TypeEnv b) = TypeEnv $ a `Map.union` b
+
+mergeRight :: Env -> Env -> Env
+mergeRight (TypeEnv a) (TypeEnv b) = TypeEnv $ b `Map.union` a
 
 mergeEnvs :: [Env] -> Env
 mergeEnvs = foldl' (<>) mempty

--- a/src/Nix/Type/Env.hs
+++ b/src/Nix/Type/Env.hs
@@ -52,16 +52,16 @@ remove :: Env -> Name -> Env
 remove (TypeEnv env) var = TypeEnv $ Map.delete var env
 
 extends :: Env -> [(Name, [Scheme])] -> Env
-extends env xs = TypeEnv $ Map.fromList xs `Map.union` coerce env
+extends env xs = TypeEnv $ Map.fromList xs <> coerce env
 
 lookup :: Name -> Env -> Maybe [Scheme]
 lookup key (TypeEnv tys) = Map.lookup key tys
 
 merge :: Env -> Env -> Env
-merge (TypeEnv a) (TypeEnv b) = TypeEnv $ a `Map.union` b
+merge (TypeEnv a) (TypeEnv b) = TypeEnv $ a <> b
 
 mergeRight :: Env -> Env -> Env
-mergeRight (TypeEnv a) (TypeEnv b) = TypeEnv $ b `Map.union` a
+mergeRight (TypeEnv a) (TypeEnv b) = TypeEnv $ b <> a
 
 mergeEnvs :: [Env] -> Env
 mergeEnvs = foldl' (<>) mempty

--- a/src/Nix/Type/Infer.hs
+++ b/src/Nix/Type/Infer.hs
@@ -202,7 +202,7 @@ compose :: Subst -> Subst -> Subst
 Subst s1 `compose` Subst s2 =
   Subst $
     apply (Subst s1) <$>
-      (s2 `Map.union` s1)
+      (s2 <> s1)
 
 -- * class @Substitutable@
 

--- a/src/Nix/Type/Infer.hs
+++ b/src/Nix/Type/Infer.hs
@@ -72,7 +72,6 @@ import           Nix.Type.Env
 import qualified Nix.Type.Env                  as Env
 import           Nix.Type.Type
 import           Nix.Value.Monad
-import           Nix.Var
 
 
 normalizeScheme :: Scheme -> Scheme
@@ -645,7 +644,7 @@ instance ActiveTypeVars a => ActiveTypeVars [a] where
 
 type MonadInfer m
   = ({- MonadThunkId m,-}
-     MonadVar m, MonadFix m)
+     MonadAtomicRef m, MonadFix m)
 
 -- | Run the inference monad
 runInfer' :: MonadInfer m => InferT s m a -> m (Either InferError a)
@@ -659,7 +658,7 @@ runInfer :: (forall s . InferT s (FreshIdT Int (ST s)) a) -> Either InferError a
 runInfer m =
   runST $
     do
-      i <- newVar (1 :: Int)
+      i <- newRef (1 :: Int)
       runFreshIdT i $ runInfer' m
 
 inferType

--- a/src/Nix/Type/Infer.hs
+++ b/src/Nix/Type/Infer.hs
@@ -443,7 +443,7 @@ instance MonadInfer m
 
   thunk = fmap JThunk . thunk
 
-  queryM b (JThunk x) = queryM b x
+  query b (JThunk x) = query b x
 
   -- If we have a thunk loop, we just don't know the type.
   force (JThunk t) = catch (force t)

--- a/src/Nix/Type/Infer.hs
+++ b/src/Nix/Type/Infer.hs
@@ -610,7 +610,7 @@ instance FreeTypeVars Type where
   ftv (TVar a   ) = one a
   ftv (TSet _ a ) = Set.unions $ ftv <$> M.elems a
   ftv (TList a  ) = Set.unions $ ftv <$> a
-  ftv (t1 :~> t2) = ftv t1 `Set.union` ftv t2
+  ftv (t1 :~> t2) = ftv t1 <> ftv t2
   ftv (TMany ts ) = Set.unions $ ftv <$> ts
 
 instance FreeTypeVars TVar where
@@ -620,10 +620,10 @@ instance FreeTypeVars Scheme where
   ftv (Forall as t) = ftv t `Set.difference` Set.fromList as
 
 instance FreeTypeVars a => FreeTypeVars [a] where
-  ftv = foldr (Set.union . ftv) mempty
+  ftv = foldr ((<>) . ftv) mempty
 
 instance (Ord a, FreeTypeVars a) => FreeTypeVars (Set.Set a) where
-  ftv = foldr (Set.union . ftv) mempty
+  ftv = foldr ((<>) . ftv) mempty
 
 -- * class @ActiveTypeVars@
 
@@ -633,12 +633,12 @@ class ActiveTypeVars a where
 -- ** Instances
 
 instance ActiveTypeVars Constraint where
-  atv (EqConst      t1 t2   ) = ftv t1 `Set.union` ftv t2
-  atv (ImpInstConst t1 ms t2) = ftv t1 `Set.union` (ftv ms `Set.intersection` ftv t2)
-  atv (ExpInstConst t  s    ) = ftv t  `Set.union` ftv s
+  atv (EqConst      t1 t2   ) = ftv t1 <> ftv t2
+  atv (ImpInstConst t1 ms t2) = ftv t1 <> (ftv ms `Set.intersection` ftv t2)
+  atv (ExpInstConst t  s    ) = ftv t  <> ftv s
 
 instance ActiveTypeVars a => ActiveTypeVars [a] where
-  atv = foldr (Set.union . atv) mempty
+  atv = foldr ((<>) . atv) mempty
 
 -- * Other
 

--- a/src/Nix/Utils.hs
+++ b/src/Nix/Utils.hs
@@ -101,6 +101,9 @@ freeToFix f = go
       f
       $ Fix . (go <$>)
 
+-- | Replace:
+--  @a -> Pure a@
+--  @Fix -> Free@
 fixToFree :: Functor f => Fix f -> Free f a
 fixToFree = Free . go
  where
@@ -115,32 +118,13 @@ fixToFree = Free . go
 --   in this case through behavior.
 adi
   :: Functor f
-  => Alg f a
-  -> Transform f a
-  -> Fix f
-  -> a
-adi f g = g $ f . (adi f g <$>) . unFix
-
-adi'
-  :: Functor f
   => Transform f a
   -> Alg f a
   -> Fix f
   -> a
-adi' g f = g $ f . (adi' g f <$>) . unFix
+adi g f = g $ f . (adi g f <$>) . unFix
 
 adiM
-  :: ( Traversable t
-     , Monad m
-     )
-  => AlgM t m a
-  -> Transform t (m a)
-  -> Fix t
-  -> m a
-adiM f g = g $ f <=< traverse (adiM f g) . unFix
-
-
-adiM'
   :: ( Traversable t
      , Monad m
      )
@@ -148,7 +132,8 @@ adiM'
   -> AlgM t m a
   -> Fix t
   -> m a
-adiM' g f = g $ f <=< traverse (adiM' g f) . unFix
+adiM g f = g $ f <=< traverse (adiM g f) . unFix
+
 
 class Has a b where
   hasLens :: Lens' a b

--- a/src/Nix/Utils.hs
+++ b/src/Nix/Utils.hs
@@ -49,11 +49,13 @@ type AlgM f m a = f a -> m a
 -- | Do according transformation.
 --
 -- It is a transformation of a recursion scheme.
-type Transform f a = (Fix f -> a) -> Fix f -> a
+-- See @TransformF@.
+type Transform f a = TransformF (Fix f) a
 -- | Do according transformation.
 --
--- It is a transformation of a recursion scheme.
--- See @Transform@.
+-- It is a transformation between functors.
+-- ...
+-- You got me, it is a natural transformation.
 type TransformF f a = (f -> a) -> f -> a
 
 loeb :: Functor f => f (f a -> a) -> f a
@@ -111,19 +113,42 @@ fixToFree = Free . go
 --   Essentially, it does for evaluation what recursion schemes do for
 --   representation: allows threading layers through existing structure, only
 --   in this case through behavior.
-adi :: Functor f => (f a -> a) -> ((Fix f -> a) -> Fix f -> a) -> Fix f -> a
+adi
+  :: Functor f
+  => Alg f a
+  -> Transform f a
+  -> Fix f
+  -> a
 adi f g = g $ f . (adi f g <$>) . unFix
 
-adi' :: Functor f => ((Fix f -> a) -> Fix f -> a) -> (f a -> a) -> Fix f -> a
+adi'
+  :: Functor f
+  => Transform f a
+  -> Alg f a
+  -> Fix f
+  -> a
 adi' g f = g $ f . (adi' g f <$>) . unFix
 
 adiM
-  :: (Traversable t, Monad m)
-  => (t a -> m a)
-  -> ((Fix t -> m a) -> Fix t -> m a)
+  :: ( Traversable t
+     , Monad m
+     )
+  => AlgM t m a
+  -> Transform t (m a)
   -> Fix t
   -> m a
 adiM f g = g $ f <=< traverse (adiM f g) . unFix
+
+
+adiM'
+  :: ( Traversable t
+     , Monad m
+     )
+  => Transform t (m a)
+  -> AlgM t m a
+  -> Fix t
+  -> m a
+adiM' g f = g $ f <=< traverse (adiM' g f) . unFix
 
 class Has a b where
   hasLens :: Lens' a b

--- a/src/Nix/Value.hs
+++ b/src/Nix/Value.hs
@@ -599,6 +599,11 @@ nvStr :: Applicative f
   -> NValue t f m
 nvStr = Free . nvStr'
 
+nvStrWithoutContext :: Applicative f
+  => Text
+  -> NValue t f m
+nvStrWithoutContext = nvStr . makeNixStringWithoutContext
+
 
 -- | Life of a Haskell FilePath to the life of a Nix path
 nvPath :: Applicative f

--- a/src/Nix/Value.hs
+++ b/src/Nix/Value.hs
@@ -528,12 +528,12 @@ iterNValue k f = iter f . fmap (\t -> k t $ iterNValue k f)
 iterNValueM
   :: (MonadDataContext f m, Monad n)
   => (forall x . n x -> m x)
-  -> (t -> (NValue t f m -> n r) -> n r)
+  -> ((NValue t f m -> n r) -> t -> n r)
   -> (NValue' t f m (n r) -> n r)
   -> NValue t f m
   -> n r
 iterNValueM transform k f =
-    iterM f <=< go . ((\t -> k t $ iterNValueM transform k f) <$>)
+    iterM f <=< go . (k (iterNValueM transform k f) <$>)
   where
     go (Pure x) = Pure <$> x
     go (Free fa) = Free <$> bindNValue' transform go fa

--- a/src/Nix/Value.hs
+++ b/src/Nix/Value.hs
@@ -513,18 +513,26 @@ type NValue t f m = Free (NValue' t f m) t
 
 -- ** Free
 
--- | @iter@
+-- | HOF of @iter@ from @Free@
 iterNValue
   :: forall t f m r
    . MonadDataContext f m
-  => (t -> (NValue t f m -> r) -> r)
+  => ((Free (NValue' t f m) t -> r) -> t -> r)
   -> (NValue' t f m r -> r)
-  -> NValue t f m
+  -> Free (NValue' t f m) t
   -> r
-iterNValue k f = iter f . fmap (\t -> k t $ iterNValue k f)
+iterNValue k f = iter f . fmap (k (iterNValue k f))
+
+iterNValueByDiscardWith
+  :: MonadDataContext f m
+  => r
+  -> (NValue' t f m r -> r)
+  -> Free (NValue' t f m) t
+  -> r
+iterNValueByDiscardWith dflt = iterNValue (\ _ _ -> dflt)
 
 
--- | @iter@ for monadic values
+-- | HOF of @iterM@ from @Free@
 iterNValueM
   :: (MonadDataContext f m, Monad n)
   => (forall x . n x -> m x)

--- a/src/Nix/Var.hs
+++ b/src/Nix/Var.hs
@@ -3,17 +3,9 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 
 {-# OPTIONS_GHC -Wno-orphans #-}
+{-# OPTIONS_GHC -Wno-unused-top-binds #-}
 
-
-module Nix.Var
-  ( Var
-  , MonadVar
-  , eqVar
-  , newVar
-  , readVar
-  , writeVar
-  , atomicModifyVar
-  )
+module Nix.Var ()
 where
 
 import           Control.Monad.Ref
@@ -23,24 +15,8 @@ import           Type.Reflection    ( (:~:)(Refl) )
 
 import           Unsafe.Coerce      ( unsafeCoerce )
 
-type Var m = Ref m
-
-type MonadVar m = MonadAtomicRef m
-
 eqVar :: GEq (Ref m) => Ref m a -> Ref m a -> Bool
 eqVar a b = isJust $ geq a b
-
-newVar :: MonadRef m => a -> m (Ref m a)
-newVar = newRef
-
-readVar :: MonadRef m => Ref m a -> m a
-readVar = readRef
-
-writeVar :: MonadRef m => Ref m a -> a -> m ()
-writeVar = writeRef
-
-atomicModifyVar :: MonadAtomicRef m => Ref m a -> (a -> (a, b)) -> m b
-atomicModifyVar = atomicModifyRef
 
 --TODO: Upstream GEq instances
 -- Upstream thread: https://github.com/haskellari/some/pull/34

--- a/src/Nix/Var.hs
+++ b/src/Nix/Var.hs
@@ -5,7 +5,16 @@
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 
-module Nix.Var where
+module Nix.Var
+  ( Var
+  , MonadVar
+  , eqVar
+  , newVar
+  , readVar
+  , writeVar
+  , atomicModifyVar
+  )
+where
 
 import           Control.Monad.Ref
 import           Data.GADT.Compare  ( GEq(..) )

--- a/src/Nix/Var.hs
+++ b/src/Nix/Var.hs
@@ -27,7 +27,7 @@ type Var m = Ref m
 
 type MonadVar m = MonadAtomicRef m
 
-eqVar :: forall m a . GEq (Ref m) => Ref m a -> Ref m a -> Bool
+eqVar :: GEq (Ref m) => Ref m a -> Ref m a -> Bool
 eqVar a b = isJust $ geq a b
 
 newVar :: MonadRef m => a -> m (Ref m a)

--- a/src/Nix/Var.hs
+++ b/src/Nix/Var.hs
@@ -34,17 +34,17 @@ atomicModifyVar :: MonadAtomicRef m => Ref m a -> (a -> (a, b)) -> m b
 atomicModifyVar = atomicModifyRef
 
 --TODO: Upstream GEq instances
---  2021-02-25: NOTE: Currently, upstreaming would require adding a dependency on the according packages.
+-- Upstream thread: https://github.com/haskellari/some/pull/34
 instance GEq IORef where
-  a `geq` b =
-    bool
-      Nothing
-      (pure $ unsafeCoerce Refl)
-      (a == unsafeCoerce b)
+  geq = gEqual
 
 instance GEq (STRef s) where
-  a `geq` b =
-    bool
-      Nothing
-      (pure $ unsafeCoerce Refl)
-      (a == unsafeCoerce b)
+  geq = gEqual
+
+-- | Simply a helper function
+gEqual :: Eq a => a -> b -> Maybe c
+gEqual a b =
+  bool
+    Nothing
+    (pure $ unsafeCoerce Refl)
+    (a == unsafeCoerce b)

--- a/src/Nix/XML.hs
+++ b/src/Nix/XML.hs
@@ -17,7 +17,7 @@ import           Text.XML.Light                 ( Element(Element)
                                                 )
 
 toXML :: forall t f m . MonadDataContext f m => NValue t f m -> NixString
-toXML = runWithStringContext . fmap pp . iterNValue (\_ _ -> cyc) phi
+toXML = runWithStringContext . fmap pp . iterNValueByDiscardWith cyc phi
  where
   cyc = pure $ mkEVal "string" "<expr>"
 


### PR DESCRIPTION
I've switched to "pre 0.9" type of ChangeLog.

Huge release `0.13` - tested the waters & showed from reality that we do not need to maintain that kind of open API and so that volume of ChangeLog, as those who use HNix as a library (mainly DHall) - use `Shorthands` module & that is pretty much all, and all others were notified & not showed-up to show any concerns.

People were notified in ChangeLog & the channel & I frequently talk about that we need to close the API to be able to not keep & dump that volume of changelog & "major API (no one uses) functionality breakage releases" on ourselves (me) & users, and there is no other way to make reorganization to form multiple packages, multiple packages - is a major breakage anyway, we would need to untie uncycle all dependencies between created packages & that in itself can be a big effort.

So, in short - do not see need from users, the point or the possibility to keep a changelog during that volume of breakage & reorganization.

As always, if someone would need help - happy to help to migrate.

This is needed to save everyone's efforts upfront: ["Internal" modules is a mistake](http://nikita-volkov.github.io/internal-convention-is-a-mistake/)

That is why I stand for #823, package splitting would save a lot of effort for maintainers & for users.