### PR TITLE
cabal: dep: hnix-store-{core,remote} (0.4->0.5)

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -93,7 +93,7 @@
 #   , nixos-20.03  # Last stable release, gets almost no updates to recipes, gets only required backports
 #   ...
 #   }
-, rev ? "65d6153aec85c8cb46023f0a7248628f423ca4ee"
+, rev ? "20887e4bbfdae3aed6bfa1f53ddf138ee325515e"
 
 , pkgs ?
     if builtins.compareVersions builtins.nixVersion "2.0" > 0

--- a/default.nix
+++ b/default.nix
@@ -192,6 +192,8 @@ let
 
       semialign = super.semialign_1_2;
       relude = super.relude_1_0_0_1;
+      hnix-store-core = super.hnix-store-core_0_5_0_0;
+      hnix-store-remote = super.hnix-store-remote_0_5_0_0;
 
     };
 

--- a/hnix.cabal
+++ b/hnix.cabal
@@ -410,6 +410,7 @@ library
     , base16-bytestring >= 0.1.1 && < 1.1
     , binary >= 0.8.5 && < 0.9
     , bytestring >= 0.10.8 && < 0.12
+    , cryptonite
     , comonad >= 5.0.4 && < 5.1
     , containers >= 0.5.11.0 && < 0.7
     , data-fix >= 0.3.0 && < 0.4
@@ -422,8 +423,8 @@ library
     , gitrev >= 1.1.0 && < 1.4
     , hashable >= 1.2.5 && < 1.4
     , hashing >= 0.1.0 && < 0.2
-    , hnix-store-core >= 0.4.0 && < 0.5
-    , hnix-store-remote >= 0.4.0 && < 0.5
+    , hnix-store-core >= 0.5.0 && < 0.6
+    , hnix-store-remote >= 0.5.0 && < 0.6
     , http-client >= 0.5.14 && < 0.6 || >= 0.6.4 && < 0.8
     , http-client-tls >= 0.3.5 && < 0.4
     , http-types >= 0.12.2 && < 0.13

--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -12,6 +12,7 @@
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE ViewPatterns #-}
+{-# LANGUAGE PackageImports #-} -- 2021-07-05: Due to hashing Haskell IT system situation, in HNix we currently ended-up with 2 hash package dependencies @{hashing, cryptonite}@
 
 {-# OPTIONS_GHC -fno-warn-name-shadowing #-}
 
@@ -30,11 +31,11 @@ import           Control.Comonad                ( Comonad )
 import           Control.Monad                  ( foldM )
 import           Control.Monad.Catch            ( MonadCatch(catch) )
 import           Control.Monad.ListM            ( sortByM )
-import           Crypto.Hash
-import qualified Crypto.Hash.MD5               as MD5
-import qualified Crypto.Hash.SHA1              as SHA1
-import qualified Crypto.Hash.SHA256            as SHA256
-import qualified Crypto.Hash.SHA512            as SHA512
+import           "hashing" Crypto.Hash
+import qualified "hashing" Crypto.Hash.MD5     as MD5
+import qualified "hashing" Crypto.Hash.SHA1    as SHA1
+import qualified "hashing" Crypto.Hash.SHA256  as SHA256
+import qualified "hashing" Crypto.Hash.SHA512  as SHA512
 import qualified Data.Aeson                    as A
 import           Data.Align                     ( alignWith )
 import           Data.Array

--- a/src/Nix/Effects.hs
+++ b/src/Nix/Effects.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE PackageImports #-} -- 2021-07-05: Due to hashing Haskell IT system situation, in HNix we currently ended-up with 2 hash package dependencies @{hashing, cryptonite}@
 
 {-# OPTIONS_GHC -Wno-orphans #-}
 
@@ -23,6 +24,7 @@ import qualified Data.Text                     as Text
 import           Network.HTTP.Client     hiding ( path, Proxy )
 import           Network.HTTP.Client.TLS
 import           Network.HTTP.Types
+import qualified "cryptonite" Crypto.Hash      as Hash
 import           Nix.Utils.Fix1
 import           Nix.Expr
 import           Nix.Frames              hiding ( Proxy )
@@ -36,7 +38,6 @@ import           System.FilePath                ( takeFileName )
 import qualified System.Info
 import           System.Process
 
-import qualified System.Nix.Hash               as Store
 import qualified System.Nix.Store.Remote       as Store.Remote
 import qualified System.Nix.StorePath          as Store
 
@@ -402,7 +403,7 @@ instance MonadStore IO where
       (\ pathName ->
         do
           -- TODO: redesign the filter parameter
-          res <- Store.Remote.runStore $ Store.Remote.addToStore @'Store.SHA256 pathName path recursive (const False) repair
+          res <- Store.Remote.runStore $ Store.Remote.addToStore @Hash.SHA256 pathName path recursive (const False) repair
           either
             Left -- err
             (pure . StorePath . decodeUtf8 . Store.storePathToRawFilePath) -- store path


### PR DESCRIPTION
For simplicity (& because we are already in massive breackage) chosen to just
migrate to 0.5.

HNix currently winded-up wih 2 hashing packages, but what to choose would be
seen further down the line, it is smart to postphone in this case.