### PR TITLE
Changes to Shorthands

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -10,7 +10,11 @@ Partial log (for now):
   * `Nix.Expr.Shorthands`:
     * `inherit{,From}`: dropped second argument as irrelevant ([report](https://github.com/haskell-nix/hnix/issues/326)).
     * `mkAssert`: fixed ([report](https://github.com/haskell-nix/hnix/issues/969)).
-    * `mkOper{,2}`: renamed to `mkOp{,2}` accordingly. The old names left as aliases but under deprecation.
+
+* Additional
+  * `Nix.Expr.Shorthands`:
+    * `mkOper{,2}` entered deprecation, superceeded by new name `mkOp{,2}`.
+    * `mkBinop` entered deprecation, supeceeded by new name `mkBinop`.
 
 
 ## [(diff)](https://github.com/haskell-nix/hnix/compare/0.13.1...0.14.0#files_bucket) 0.14.0 (2021-07-08)

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,7 +1,15 @@
 
 # ChangeLog
 
-## [(diff)](https://github.com/haskell-nix/hnix/compare/0.13.1...0.14.0#files_bucket) 0.14.0
+## [(diff)](https://github.com/haskell-nix/hnix/compare/0.14.0...0.15.0#files_bucket) 0.15.0
+
+Partial log (for now):
+
+* Breaking:
+
+  * `Nix.Expr.Shorthands`: `inherit{,From}`: dropped second argument as irrelevant ([report](https://github.com/haskell-nix/hnix/issues/326)).
+
+
 ## [(diff)](https://github.com/haskell-nix/hnix/compare/0.13.1...0.14.0#files_bucket) 0.14.0 (2021-07-08)
 
 * GHC 9.0 support.

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,6 +2,7 @@
 # ChangeLog
 
 ## [(diff)](https://github.com/haskell-nix/hnix/compare/0.13.1...0.14.0#files_bucket) 0.14.0
+## [(diff)](https://github.com/haskell-nix/hnix/compare/0.13.1...0.14.0#files_bucket) 0.14.0 (2021-07-08)
 
 * GHC 9.0 support.
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -10,6 +10,18 @@ Partial log (for now):
   * `Nix.Expr.Shorthands`:
     * `inherit{,From}`: dropped second argument as irrelevant ([report](https://github.com/haskell-nix/hnix/issues/326)).
     * `mkAssert`: fixed ([report](https://github.com/haskell-nix/hnix/issues/969)).
+    * fx presedence between the operators:
+        
+        ```haskell
+        (@@), (@.), (@./), ($==), ($!=), ($<), ($<=), ($>), ($>=), ($&&), ($||), ($->), ($//), ($+), ($-), ($*), ($/), ($++), (==>)
+        ```
+        
+        Now these shorthands can be used without sectioning & so represent the Nix expressions one to one.
+        
+        ```haskell
+        nix = "           a/b   //            c/def   //           <g>  <             def/d"
+        hask = mkRelPath "a/b" $// mkRelPath "c/def" $// mkEnvPath "g" $<  mkRelPath "def/d"
+        ```
 
 * Additional
   * `Nix.Expr.Shorthands`:

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -28,6 +28,7 @@ Partial log (for now):
     * `mkOper{,2}` entered deprecation, superceeded by new name `mkOp{,2}`.
     * `mkBinop` entered deprecation, supeceeded by new name `mkBinop`.
     * added `@.<|>` for Nix language `s.x or y` expession.
+    * add `mkNeg` number negation.
 
 
 ## [(diff)](https://github.com/haskell-nix/hnix/compare/0.13.1...0.14.0#files_bucket) 0.14.0 (2021-07-08)

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -7,8 +7,10 @@ Partial log (for now):
 
 * Breaking:
 
-  * `Nix.Expr.Shorthands`: `inherit{,From}`: dropped second argument as irrelevant ([report](https://github.com/haskell-nix/hnix/issues/326)).
-  * `Nix.Expr.Shorthands`: `mkAssert`: fixed ([report](https://github.com/haskell-nix/hnix/issues/969)).
+  * `Nix.Expr.Shorthands`:
+    * `inherit{,From}`: dropped second argument as irrelevant ([report](https://github.com/haskell-nix/hnix/issues/326)).
+    * `mkAssert`: fixed ([report](https://github.com/haskell-nix/hnix/issues/969)).
+    * `mkOper{,2}`: renamed to `mkOp{,2}` accordingly. The old names left as aliases but under deprecation.
 
 
 ## [(diff)](https://github.com/haskell-nix/hnix/compare/0.13.1...0.14.0#files_bucket) 0.14.0 (2021-07-08)

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -8,6 +8,7 @@ Partial log (for now):
 * Breaking:
 
   * `Nix.Expr.Shorthands`: `inherit{,From}`: dropped second argument as irrelevant ([report](https://github.com/haskell-nix/hnix/issues/326)).
+  * `Nix.Expr.Shorthands`: `mkAssert`: fixed ([report](https://github.com/haskell-nix/hnix/issues/969)).
 
 
 ## [(diff)](https://github.com/haskell-nix/hnix/compare/0.13.1...0.14.0#files_bucket) 0.14.0 (2021-07-08)

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -15,6 +15,7 @@ Partial log (for now):
   * `Nix.Expr.Shorthands`:
     * `mkOper{,2}` entered deprecation, superceeded by new name `mkOp{,2}`.
     * `mkBinop` entered deprecation, supeceeded by new name `mkBinop`.
+    * added `@.<|>` for Nix language `s.x or y` expession.
 
 
 ## [(diff)](https://github.com/haskell-nix/hnix/compare/0.13.1...0.14.0#files_bucket) 0.14.0 (2021-07-08)

--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -583,7 +583,7 @@ headNix :: forall e t f m. MonadNix e t f m => NValue t f m -> m (NValue t f m)
 headNix =
   maybe
     (throwError $ ErrorCall "builtins.head: empty list")
-    (pure)
+    pure
   . viaNonEmpty head <=< fromValue @[NValue t f m]
 
 tailNix :: forall e t f m. MonadNix e t f m => NValue t f m -> m (NValue t f m)

--- a/src/Nix/Expr/Shorthands.hs
+++ b/src/Nix/Expr/Shorthands.hs
@@ -63,16 +63,17 @@ mkSelector :: Text -> NAttrPath NExpr
 mkSelector = (:| mempty) . StaticKey
 
 -- | Put an unary operator.
-mkOper :: NUnaryOp -> NExpr -> NExpr
-mkOper op = Fix . NUnary op
+mkOp :: NUnaryOp -> NExpr -> NExpr
+mkOp op = Fix . NUnary op
 
 -- | Logical negation.
 mkNot :: NExpr -> NExpr
-mkNot = mkOper NNot
+mkNot = mkOp NNot
+
 
 -- | Put a binary operator.
-mkOper2 :: NBinaryOp -> NExpr -> NExpr -> NExpr
-mkOper2 op a = Fix . NBinary op a
+mkOp2 :: NBinaryOp -> NExpr -> NExpr -> NExpr
+mkOp2 op a = Fix . NBinary op a
 
 mkParamset :: [(Text, Maybe NExpr)] -> Bool -> Params NExpr
 mkParamset params variadic = ParamSet params variadic mempty
@@ -277,41 +278,53 @@ recAttrsE pairs = mkRecSet $ uncurry ($=) <$> pairs
 
 -- | Nix binary operator builder.
 mkBinop :: NBinaryOp -> NExpr -> NExpr -> NExpr
-mkBinop = mkOper2
+mkBinop = mkOp2
 
 (@@), ($==), ($!=), ($<), ($<=), ($>), ($>=), ($&&), ($||), ($->), ($//), ($+), ($-), ($*), ($/), ($++)
   :: NExpr -> NExpr -> NExpr
 -- | Function application (@' '@ in @f x@)
-(@@) = mkOper2 NApp
+(@@) = mkOp2 NApp
 infixl 1 @@
 -- | Equality: @==@
-($==) = mkOper2 NEq
+($==) = mkOp2 NEq
 -- | Inequality: @!=@
-($!=) = mkOper2 NNEq
+($!=) = mkOp2 NNEq
 -- | Less than: @<@
-($<)  = mkOper2 NLt
+($<)  = mkOp2 NLt
 -- | Less than OR equal: @<=@
-($<=) = mkOper2 NLte
+($<=) = mkOp2 NLte
 -- | Greater than: @>@
-($>)  = mkOper2 NGt
+($>)  = mkOp2 NGt
 -- | Greater than OR equal: @>=@
-($>=) = mkOper2 NGte
+($>=) = mkOp2 NGte
 -- | AND: @&&@
-($&&) = mkOper2 NAnd
+($&&) = mkOp2 NAnd
 -- | OR: @||@
-($||) = mkOper2 NOr
+($||) = mkOp2 NOr
 -- | Logical implication: @->@
-($->) = mkOper2 NImpl
+($->) = mkOp2 NImpl
 -- | Extend/override the left attr set, with the right one: @//@
-($//) = mkOper2 NUpdate
+($//) = mkOp2 NUpdate
 -- | Addition: @+@
-($+)  = mkOper2 NPlus
+($+)  = mkOp2 NPlus
 -- | Subtraction: @-@
-($-)  = mkOper2 NMinus
+($-)  = mkOp2 NMinus
 -- | Multiplication: @*@
-($*)  = mkOper2 NMult
+($*)  = mkOp2 NMult
 -- | Division: @/@
-($/)  = mkOper2 NDiv
+($/)  = mkOp2 NDiv
 -- | List concatenation: @++@
-($++) = mkOper2 NConcat
+($++) = mkOp2 NConcat
 
+
+-- * Under deprecation
+
+-- NOTE: Remove after 2023-07
+-- | Put an unary operator.
+mkOper :: NUnaryOp -> NExpr -> NExpr
+mkOper op = Fix . NUnary op
+
+-- NOTE: Remove after 2023-07
+-- | Put a binary operator.
+mkOper2 :: NBinaryOp -> NExpr -> NExpr -> NExpr
+mkOper2 op a = Fix . NBinary op a

--- a/src/Nix/Expr/Shorthands.hs
+++ b/src/Nix/Expr/Shorthands.hs
@@ -11,6 +11,10 @@ import           Nix.Expr.Types
 
 -- * Basic expression builders
 
+-- | Put @NAtom@ as expression
+mkConst :: NAtom -> NExpr
+mkConst = Fix . NConstant
+
 -- | Put null.
 mkNull :: NExpr
 mkNull = Fix mkNullF

--- a/src/Nix/Expr/Shorthands.hs
+++ b/src/Nix/Expr/Shorthands.hs
@@ -86,13 +86,17 @@ mkParamset params variadic = ParamSet params variadic mempty
 --
 -- @rec { .. };@
 mkRecSet :: [Binding NExpr] -> NExpr
-mkRecSet = Fix . NSet Recursive
+mkRecSet = mkSet Recursive
 
 -- | Put a non-recursive set.
 --
 -- > { .. }
 mkNonRecSet :: [Binding NExpr] -> NExpr
-mkNonRecSet = Fix . NSet NonRecursive
+mkNonRecSet = mkSet NonRecursive
+
+-- | General set builder function.
+mkSet :: Recursivity -> [Binding NExpr] -> NExpr
+mkSet r = Fix . NSet r
 
 -- | Put a list.
 mkList :: [NExpr] -> NExpr

--- a/src/Nix/Expr/Shorthands.hs
+++ b/src/Nix/Expr/Shorthands.hs
@@ -8,6 +8,7 @@ module Nix.Expr.Shorthands where
 import           Data.Fix
 import           Nix.Atoms
 import           Nix.Expr.Types
+import           Nix.Utils
 
 -- * Basic expression builders
 
@@ -33,15 +34,17 @@ mkFloat = Fix . mkFloatF
 
 -- | Put a regular (double-quoted) string.
 mkStr :: Text -> NExpr
-mkStr = Fix . NStr . DoubleQuoted . \case
-  "" -> mempty
-  x  -> [Plain x]
+mkStr = Fix . NStr . DoubleQuoted .
+  whenText
+    mempty
+    (one . Plain)
 
 -- | Put an indented string.
 mkIndentedStr :: Int -> Text -> NExpr
-mkIndentedStr w = Fix . NStr . Indented w . \case
-  "" -> mempty
-  x  -> [Plain x]
+mkIndentedStr w = Fix . NStr . Indented w .
+  whenText
+    mempty
+    (one . Plain)
 
 -- | Put a path. Use @True@ if the path should be read from the environment, else use @False@.
 mkPath :: Bool -> FilePath -> NExpr

--- a/src/Nix/Expr/Shorthands.hs
+++ b/src/Nix/Expr/Shorthands.hs
@@ -73,9 +73,15 @@ mkSelector = (:| mempty) . StaticKey
 mkOp :: NUnaryOp -> NExpr -> NExpr
 mkOp op = Fix . NUnary op
 
--- | Logical negation.
+-- | Logical negation: @not@.
 mkNot :: NExpr -> NExpr
 mkNot = mkOp NNot
+
+-- | Number negation: @-@.
+--
+-- Negation in the language works with integers and floating point.
+mkNeg :: NExpr -> NExpr
+mkNeg = mkOp NNeg
 
 -- | Put a binary operator.
 mkOp2 :: NBinaryOp -> NExpr -> NExpr -> NExpr

--- a/src/Nix/Expr/Shorthands.hs
+++ b/src/Nix/Expr/Shorthands.hs
@@ -169,16 +169,6 @@ mkIf e1 e2 = Fix . NIf e1 e2
 mkFunction :: Params NExpr -> NExpr -> NExpr
 mkFunction params = Fix . NAbs params
 
--- | Lambda function, analog of Haskell's @\\ x -> x@:
---
--- +---------------+-----------+
--- | Haskell       | Nix       |
--- +===============+===========+
--- | @x ==> expr @ | @x: expr@ |
--- +---------------+-----------+
-(==>) :: Params NExpr -> NExpr -> NExpr
-(==>) = mkFunction
-infixr 1 ==>
 
 -- | Dot-reference into an attribute set: @attrSet.k@
 (@.) :: NExpr -> Text -> NExpr
@@ -340,6 +330,16 @@ infixl 1 @@
 -- | List concatenation: @++@
 ($++) = mkOp2 NConcat
 
+-- | Lambda function, analog of Haskell's @\\ x -> x@:
+--
+-- +---------------+-----------+
+-- | Haskell       | Nix       |
+-- +===============+===========+
+-- | @x ==> expr @ | @x: expr@ |
+-- +---------------+-----------+
+(==>) :: Params NExpr -> NExpr -> NExpr
+(==>) = mkFunction
+infixr 1 ==>
 
 -- * Under deprecation
 

--- a/src/Nix/Expr/Shorthands.hs
+++ b/src/Nix/Expr/Shorthands.hs
@@ -170,9 +170,13 @@ infixr 1 ==>
 
 -- | Dot-reference into an attribute set: @attrSet.k@
 (@.) :: NExpr -> Text -> NExpr
-(@.) obj name = Fix $ NSelect obj (StaticKey name :| mempty) Nothing
+(@.) obj name = getRefOrDefault obj name Nothing
 infixl 2 @.
 
+
+-- | General dot-reference with optional alternative if the jey does not exist.
+getRefOrDefault :: NExpr -> VarName -> Maybe NExpr -> NExpr
+getRefOrDefault obj name alt = Fix $ NSelect obj (StaticKey name :| mempty) alt
 
 -- ** Base functor builders for basic expressions builders *sic
 

--- a/src/Nix/Expr/Shorthands.hs
+++ b/src/Nix/Expr/Shorthands.hs
@@ -115,7 +115,7 @@ mkWith :: NExpr -> NExpr -> NExpr
 mkWith e = Fix . NWith e
 
 mkAssert :: NExpr -> NExpr -> NExpr
-mkAssert e = Fix . NWith e
+mkAssert e = Fix . NAssert e
 
 mkIf :: NExpr -> NExpr -> NExpr -> NExpr
 mkIf e1 e2 = Fix . NIf e1 e2

--- a/src/Nix/Expr/Shorthands.hs
+++ b/src/Nix/Expr/Shorthands.hs
@@ -170,11 +170,6 @@ mkFunction :: Params NExpr -> NExpr -> NExpr
 mkFunction params = Fix . NAbs params
 
 
--- | Dot-reference into an attribute set: @attrSet.k@
-(@.) :: NExpr -> Text -> NExpr
-(@.) obj name = getRefOrDefault obj name Nothing
-infixl 2 @.
-
 
 -- | General dot-reference with optional alternative if the jey does not exist.
 getRefOrDefault :: NExpr -> VarName -> Maybe NExpr -> NExpr
@@ -292,6 +287,11 @@ recAttrsE pairs = mkRecSet $ uncurry ($=) <$> pairs
 
 (@@), ($==), ($!=), ($<), ($<=), ($>), ($>=), ($&&), ($||), ($->), ($//), ($+), ($-), ($*), ($/), ($++)
   :: NExpr -> NExpr -> NExpr
+
+-- | Dot-reference into an attribute set: @attrSet.k@
+(@.) :: NExpr -> Text -> NExpr
+(@.) obj name = getRefOrDefault obj name Nothing
+infix 2 @.
 -- | Function application (@' '@ in @f x@)
 (@@) = mkOp2 NApp
 infixl 1 @@

--- a/src/Nix/Expr/Shorthands.hs
+++ b/src/Nix/Expr/Shorthands.hs
@@ -101,9 +101,18 @@ mkNonRecSet = mkSet NonRecursive
 mkSet :: Recursivity -> [Binding NExpr] -> NExpr
 mkSet r = Fix . NSet r
 
+-- | Empty set.
+--
+-- Monoid. Use @//@ operation (shorthand $//) to extend the set.
+emptySet :: NExpr
+emptySet = mkNonRecSet mempty
+
 -- | Put a list.
 mkList :: [NExpr] -> NExpr
 mkList = Fix . NList
+
+emptyList :: NExpr
+emptyList = mkList mempty
 
 -- | Wrap in a @let@.
 --

--- a/src/Nix/Expr/Shorthands.hs
+++ b/src/Nix/Expr/Shorthands.hs
@@ -296,7 +296,7 @@ infix 9 @.
 (@.<|>) obj name alt = getRefOrDefault obj name $ pure alt
 -- | Function application (@' '@ in @f x@)
 (@@) = mkOp2 NApp
-infixl 1 @@
+infixl 8 @@
 -- | List concatenation: @++@
 ($++) = mkOp2 NConcat
 -- | Multiplication: @*@

--- a/src/Nix/Expr/Shorthands.hs
+++ b/src/Nix/Expr/Shorthands.hs
@@ -290,10 +290,6 @@ recAttrsE pairs = mkRecSet $ uncurry ($=) <$> pairs
 
 -- * Nix binary operators
 
--- | Nix binary operator builder.
-mkBinop :: NBinaryOp -> NExpr -> NExpr -> NExpr
-mkBinop = mkOp2
-
 (@@), ($==), ($!=), ($<), ($<=), ($>), ($>=), ($&&), ($||), ($->), ($//), ($+), ($-), ($*), ($/), ($++)
   :: NExpr -> NExpr -> NExpr
 -- | Function application (@' '@ in @f x@)
@@ -352,3 +348,8 @@ mkOper op = Fix . NUnary op
 -- | Put a binary operator.
 mkOper2 :: NBinaryOp -> NExpr -> NExpr -> NExpr
 mkOper2 op a = Fix . NBinary op a
+
+-- NOTE: Remove after 2023-07
+-- | Nix binary operator builder.
+mkBinop :: NBinaryOp -> NExpr -> NExpr -> NExpr
+mkBinop = mkOp2

--- a/src/Nix/Expr/Shorthands.hs
+++ b/src/Nix/Expr/Shorthands.hs
@@ -284,49 +284,83 @@ recAttrsE pairs = mkRecSet $ uncurry ($=) <$> pairs
 
 (@@), ($==), ($!=), ($<), ($<=), ($>), ($>=), ($&&), ($||), ($->), ($//), ($+), ($-), ($*), ($/), ($++)
   :: NExpr -> NExpr -> NExpr
+--  2021-07-10: NOTE: Probably the presedence of some operators is still needs to be tweaked.
 
 -- | Dot-reference into an attribute set: @attrSet.k@
 (@.) :: NExpr -> Text -> NExpr
 (@.) obj name = getRefOrDefault obj name Nothing
 infix 9 @.
+
 -- | Dot-reference into an attribute set with alternative if the key does not exist.
 --
 -- > s.x or y
 (@.<|>) :: NExpr -> VarName -> NExpr -> NExpr
 (@.<|>) obj name alt = getRefOrDefault obj name $ pure alt
+infix 9 @.<|>
+
 -- | Function application (@' '@ in @f x@)
 (@@) = mkOp2 NApp
 infixl 8 @@
+
 -- | List concatenation: @++@
 ($++) = mkOp2 NConcat
+infixr 7 $++
+
 -- | Multiplication: @*@
 ($*)  = mkOp2 NMult
+infixl 6 $*
+
 -- | Division: @/@
 ($/)  = mkOp2 NDiv
+infixl 6 $/
+
 -- | Addition: @+@
 ($+)  = mkOp2 NPlus
+infixl 5 $+
+
 -- | Subtraction: @-@
 ($-)  = mkOp2 NMinus
+infixl 5 $-
+
 -- | Extend/override the left attr set, with the right one: @//@
 ($//) = mkOp2 NUpdate
+infixr 5 $//
+
 -- | Greater than: @>@
 ($>)  = mkOp2 NGt
+infix 4 $>
+
 -- | Greater than OR equal: @>=@
+infix 4 $>=
 ($>=) = mkOp2 NGte
+
 -- | Less than OR equal: @<=@
 ($<=) = mkOp2 NLte
+infix 4 $<=
+
 -- | Less than: @<@
 ($<)  = mkOp2 NLt
+infix 4 $<
+
 -- | Equality: @==@
 ($==) = mkOp2 NEq
+infix 3 $==
+
 -- | Inequality: @!=@
 ($!=) = mkOp2 NNEq
+infix 3 $!=
+
 -- | AND: @&&@
 ($&&) = mkOp2 NAnd
+infixl 2 $&&
+
 -- | OR: @||@
 ($||) = mkOp2 NOr
+infixl 2 $||
+
 -- | Logical implication: @->@
 ($->) = mkOp2 NImpl
+infix 1 $->
 
 -- | Lambda function, analog of Haskell's @\\ x -> x@:
 --

--- a/src/Nix/Expr/Shorthands.hs
+++ b/src/Nix/Expr/Shorthands.hs
@@ -110,7 +110,7 @@ mkLets bindings = Fix . NLet bindings
 -- | Haskell            | Nix               |
 -- +====================+===================+
 -- | @mkWith body main@ | @with body; expr@ |
--- +--------------------+----00-------------+
+-- +--------------------+-------------------+
 mkWith :: NExpr -> NExpr -> NExpr
 mkWith e = Fix . NWith e
 
@@ -133,19 +133,7 @@ mkFunction params = Fix . NAbs params
 (==>) = mkFunction
 infixr 1 ==>
 
-{-
-mkDot :: NExpr -> Text -> NExpr
-mkDot e key = mkDots e [key]
 
--- | Create a dotted expression using only text.
-mkDots :: NExpr -> [Text] -> NExpr
-mkDots e [] = e
-mkDots (Fix (NSelect e keys' x)) keys =
-  -- Special case: if the expression in the first argument is already
-  -- a dotted expression, just extend it.
-  Fix (NSelect e (keys' <> fmap (`StaticKey` Nothing) keys) x)
-mkDots e keys = Fix $ NSelect e (fmap (`StaticKey` Nothing) keys) Nothing
--}
 
 -- ** Basic base functor builders
 

--- a/src/Nix/Expr/Shorthands.hs
+++ b/src/Nix/Expr/Shorthands.hs
@@ -292,6 +292,11 @@ recAttrsE pairs = mkRecSet $ uncurry ($=) <$> pairs
 (@.) :: NExpr -> Text -> NExpr
 (@.) obj name = getRefOrDefault obj name Nothing
 infix 2 @.
+-- | Dot-reference into an attribute set with alternative if the key does not exist.
+--
+-- > s.x or y
+(@.<|>) :: NExpr -> VarName -> NExpr -> NExpr
+(@.<|>) obj name alt = getRefOrDefault obj name $ pure alt
 -- | Function application (@' '@ in @f x@)
 (@@) = mkOp2 NApp
 infixl 1 @@

--- a/src/Nix/Expr/Shorthands.hs
+++ b/src/Nix/Expr/Shorthands.hs
@@ -77,7 +77,6 @@ mkOp op = Fix . NUnary op
 mkNot :: NExpr -> NExpr
 mkNot = mkOp NNot
 
-
 -- | Put a binary operator.
 mkOp2 :: NBinaryOp -> NExpr -> NExpr -> NExpr
 mkOp2 op a = Fix . NBinary op a
@@ -169,11 +168,9 @@ mkIf e1 e2 = Fix . NIf e1 e2
 mkFunction :: Params NExpr -> NExpr -> NExpr
 mkFunction params = Fix . NAbs params
 
-
-
 -- | General dot-reference with optional alternative if the jey does not exist.
 getRefOrDefault :: NExpr -> VarName -> Maybe NExpr -> NExpr
-getRefOrDefault obj name alt = Fix $ NSelect obj (StaticKey name :| mempty) alt
+getRefOrDefault obj name alt = Fix $ NSelect obj (mkSelector name) alt
 
 -- ** Base functor builders for basic expressions builders *sic
 

--- a/src/Nix/Expr/Shorthands.hs
+++ b/src/Nix/Expr/Shorthands.hs
@@ -216,36 +216,36 @@ mkBinop = mkOper2
 (@@), ($==), ($!=), ($<), ($<=), ($>), ($>=), ($&&), ($||), ($->), ($//), ($+), ($-), ($*), ($/), ($++)
   :: NExpr -> NExpr -> NExpr
 -- | Function application (@' '@ in @f x@)
-(@@) = mkBinop NApp
+(@@) = mkOper2 NApp
 infixl 1 @@
 -- | Equality: @==@
-($==) = mkBinop NEq
+($==) = mkOper2 NEq
 -- | Inequality: @!=@
-($!=) = mkBinop NNEq
+($!=) = mkOper2 NNEq
 -- | Less than: @<@
-($<)  = mkBinop NLt
+($<)  = mkOper2 NLt
 -- | Less than OR equal: @<=@
-($<=) = mkBinop NLte
+($<=) = mkOper2 NLte
 -- | Greater than: @>@
-($>)  = mkBinop NGt
+($>)  = mkOper2 NGt
 -- | Greater than OR equal: @>=@
-($>=) = mkBinop NGte
+($>=) = mkOper2 NGte
 -- | AND: @&&@
-($&&) = mkBinop NAnd
+($&&) = mkOper2 NAnd
 -- | OR: @||@
-($||) = mkBinop NOr
+($||) = mkOper2 NOr
 -- | Logical implication: @->@
-($->) = mkBinop NImpl
+($->) = mkOper2 NImpl
 -- | Extend/override the left attr set, with the right one: @//@
-($//) = mkBinop NUpdate
+($//) = mkOper2 NUpdate
 -- | Addition: @+@
-($+)  = mkBinop NPlus
+($+)  = mkOper2 NPlus
 -- | Subtraction: @-@
-($-)  = mkBinop NMinus
+($-)  = mkOper2 NMinus
 -- | Multiplication: @*@
-($*)  = mkBinop NMult
+($*)  = mkOper2 NMult
 -- | Division: @/@
-($/)  = mkBinop NDiv
+($/)  = mkOper2 NDiv
 -- | List concatenation: @++@
-($++) = mkBinop NConcat
+($++) = mkOper2 NConcat
 

--- a/src/Nix/Expr/Shorthands.hs
+++ b/src/Nix/Expr/Shorthands.hs
@@ -8,7 +8,6 @@ module Nix.Expr.Shorthands where
 import           Data.Fix
 import           Nix.Atoms
 import           Nix.Expr.Types
-import           Text.Megaparsec.Pos            ( SourcePos )
 
 -- | Make an integer literal expression.
 mkInt :: Integer -> NExpr
@@ -136,12 +135,12 @@ mkDots e keys = Fix $ NSelect e (fmap (`StaticKey` Nothing) keys) Nothing
 -}
 
 -- | An `inherit` clause without an expression to pull from.
-inherit :: [NKeyName e] -> SourcePos -> Binding e
-inherit = Inherit Nothing
+inherit :: [NKeyName e] -> Binding e
+inherit ks = Inherit Nothing ks nullPos
 
 -- | An `inherit` clause with an expression to pull from.
-inheritFrom :: e -> [NKeyName e] -> SourcePos -> Binding e
-inheritFrom expr = Inherit (pure expr)
+inheritFrom :: e -> [NKeyName e] -> Binding e
+inheritFrom expr ks = Inherit (pure expr) ks nullPos
 
 -- | Shorthand for producing a binding of a name to an expression: @=
 bindTo :: Text -> NExpr -> Binding NExpr

--- a/src/Nix/Expr/Shorthands.hs
+++ b/src/Nix/Expr/Shorthands.hs
@@ -288,7 +288,7 @@ recAttrsE pairs = mkRecSet $ uncurry ($=) <$> pairs
 -- | Dot-reference into an attribute set: @attrSet.k@
 (@.) :: NExpr -> Text -> NExpr
 (@.) obj name = getRefOrDefault obj name Nothing
-infix 2 @.
+infix 9 @.
 -- | Dot-reference into an attribute set with alternative if the key does not exist.
 --
 -- > s.x or y

--- a/src/Nix/Expr/Shorthands.hs
+++ b/src/Nix/Expr/Shorthands.hs
@@ -300,36 +300,36 @@ infix 2 @.
 -- | Function application (@' '@ in @f x@)
 (@@) = mkOp2 NApp
 infixl 1 @@
--- | Equality: @==@
-($==) = mkOp2 NEq
--- | Inequality: @!=@
-($!=) = mkOp2 NNEq
--- | Less than: @<@
-($<)  = mkOp2 NLt
--- | Less than OR equal: @<=@
-($<=) = mkOp2 NLte
+-- | List concatenation: @++@
+($++) = mkOp2 NConcat
+-- | Multiplication: @*@
+($*)  = mkOp2 NMult
+-- | Division: @/@
+($/)  = mkOp2 NDiv
+-- | Addition: @+@
+($+)  = mkOp2 NPlus
+-- | Subtraction: @-@
+($-)  = mkOp2 NMinus
+-- | Extend/override the left attr set, with the right one: @//@
+($//) = mkOp2 NUpdate
 -- | Greater than: @>@
 ($>)  = mkOp2 NGt
 -- | Greater than OR equal: @>=@
 ($>=) = mkOp2 NGte
+-- | Less than OR equal: @<=@
+($<=) = mkOp2 NLte
+-- | Less than: @<@
+($<)  = mkOp2 NLt
+-- | Equality: @==@
+($==) = mkOp2 NEq
+-- | Inequality: @!=@
+($!=) = mkOp2 NNEq
 -- | AND: @&&@
 ($&&) = mkOp2 NAnd
 -- | OR: @||@
 ($||) = mkOp2 NOr
 -- | Logical implication: @->@
 ($->) = mkOp2 NImpl
--- | Extend/override the left attr set, with the right one: @//@
-($//) = mkOp2 NUpdate
--- | Addition: @+@
-($+)  = mkOp2 NPlus
--- | Subtraction: @-@
-($-)  = mkOp2 NMinus
--- | Multiplication: @*@
-($*)  = mkOp2 NMult
--- | Division: @/@
-($/)  = mkOp2 NDiv
--- | List concatenation: @++@
-($++) = mkOp2 NConcat
 
 -- | Lambda function, analog of Haskell's @\\ x -> x@:
 --
@@ -341,6 +341,7 @@ infixl 1 @@
 (==>) :: Params NExpr -> NExpr -> NExpr
 (==>) = mkFunction
 infixr 1 ==>
+
 
 -- * Under deprecation
 

--- a/src/Nix/Expr/Strings.hs
+++ b/src/Nix/Expr/Strings.hs
@@ -10,7 +10,7 @@ import           Data.List                      ( dropWhileEnd
                                                 , lookup
                                                 )
 import qualified Data.Text                     as T
-import           Nix.Expr
+import           Nix.Expr.Types
 
 -- | Merge adjacent @Plain@ values with @<>@.
 mergePlain :: [Antiquoted Text r] -> [Antiquoted Text r]
@@ -111,7 +111,7 @@ escapeCodes =
   [('\n', 'n'), ('\r', 'r'), ('\t', 't'), ('\\', '\\'), ('$', '$'), ('"', '"')]
 
 fromEscapeCode :: Char -> Maybe Char
-fromEscapeCode = (`lookup` fmap swap escapeCodes)
+fromEscapeCode = (`lookup` (swap <$> escapeCodes))
 
 toEscapeCode :: Char -> Maybe Char
 toEscapeCode = (`lookup` escapeCodes)

--- a/src/Nix/Utils.hs
+++ b/src/Nix/Utils.hs
@@ -196,6 +196,14 @@ list e f l =
     (null l)
 {-# inline list #-}
 
+whenText
+  :: a -> (Text -> a) -> Text -> a
+whenText e f t =
+  bool
+    (f t)
+    e
+    (Text.null t)
+
 -- | Lambda analog of @maybe@ or @either@ for Free monad.
 free :: (a -> b) -> (f (Free f a) -> b) -> Free f a -> b
 free fP fF fr =

--- a/tests/ParserTests.hs
+++ b/tests/ParserTests.hs
@@ -1,13 +1,16 @@
 {-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ExtendedDefaultRules #-}
 
 {-# OPTIONS_GHC -fno-warn-name-shadowing #-}
 {-# OPTIONS_GHC -Wno-missing-signatures #-}
+{-# OPTIONS_GHC -Wno-type-defaults #-}
 
 
 module ParserTests (tests) where
 
+import Prelude hiding (($<))
 import Data.Fix
 import NeatInterpolation (text)
 import Nix.Atoms
@@ -20,312 +23,525 @@ import Test.Tasty
 import Test.Tasty.HUnit
 import Test.Tasty.TH
 
-case_constant_int = assertParseText "234" $ mkInt 234
+default (NixLang)
+
+-- * Tests
+
+
+-- ** Literals
+
+case_constant_int =
+  checks
+    ( mkInt 234
+    , "234"
+    )
 
 case_constant_bool = do
-  assertParseText "true" $ mkBool True
-  assertParseText "false" $ mkBool False
+  checks
+    ( mkBool True
+    , "true"
+    )
+    ( mkBool False
+    , "false"
+    )
 
 case_constant_bool_respects_attributes = do
-  assertParseText "true-foo"  $ mkSym "true-foo"
-  assertParseText "false-bar" $ mkSym "false-bar"
+  invariantVals
+    "true-foo"
+    "false-bar"
 
-case_constant_path = do
-  assertParseText "./." $ mkPath False "./."
-  assertParseText "./+-_/cdef/09ad+-" $ mkPath False "./+-_/cdef/09ad+-"
-  assertParseText "/abc" $ mkPath False "/abc"
-  assertParseText "../abc" $ mkPath False "../abc"
-  assertParseText "<abc>" $ mkPath True "abc"
-  assertParseText "<../cdef>" $ mkPath True "../cdef"
-  assertParseText "a//b" $ mkOp2 NUpdate (mkSym "a") (mkSym "b")
-  assertParseText "rec+def/cdef" $ mkPath False "rec+def/cdef"
-  assertParseText "a/b//c/def//<g> < def/d" $ mkOp2 NLt
-    (mkOp2 NUpdate (mkPath False "a/b") $ mkOp2 NUpdate
-      (mkPath False "c/def") (mkPath True "g"))
-    (mkPath False "def/d")
-  assertParseText "a'b/c" $ Fix $ NBinary NApp (mkSym "a'b") (mkPath False "/c")
-  assertParseText "a/b" $ mkPath False "a/b"
-  assertParseText "4/2" $ mkPath False "4/2"
-  assertParseFail "."
-  assertParseFail ".."
-  assertParseFail "/"
-  assertParseFail "a/"
-  assertParseFail "a/def/"
-  assertParseFail "~"
-  assertParseFail "~/"
-  assertParseText "~/a" $ mkPath False "~/a"
-  assertParseText "~/a/b" $ mkPath False "~/a/b"
+case_constant_path_invariants =
+  knownAs (staysInvariantUnder (mkRelPath . toString))
+    "./."
+    "./+-_/cdef/09ad+-"
+    "/abc"
+    "../abc"
+    "~/a"
+    "~/a/b"
+    "a/b"
+    "4/2"
+    "rec+def/cdef"
 
-case_constant_uri = do
-  assertParseText "a:a" $ mkStr "a:a"
-  assertParseText "http://foo.bar" $ mkStr "http://foo.bar"
-  assertParseText "a+de+.adA+-:%%%ads%5asdk&/" $ mkStr "a+de+.adA+-:%%%ads%5asdk&/"
-  assertParseText "rec+def:c" $ mkStr "rec+def:c"
-  assertParseText "f.foo:bar" $ mkStr "f.foo:bar"
-  assertParseFail "http://foo${\"bar\"}"
-  assertParseFail ":bcdef"
-  assertParseFail "a%20:asda"
-  assertParseFail ".:adasd"
-  assertParseFail "+:acdcd"
+case_constant_path =
+  checks
+    ( var "a'b" @@ mkRelPath "/c"
+    , "a'b/c"
+    )
+    ( mkRelPath "a/b" $// mkRelPath "c/def" $// mkEnvPath "g" $<  mkRelPath "def/d"
+    , "a/b//c/def//<g> < def/d"
+    )
+    ( mkEnvPath "abc"
+    , "<abc>"
+    )
+    ( mkEnvPath "../cdef"
+    , "<../cdef>"
+    )
+    ( var "a" $// var "b"
+    , "a//b"
+    )
 
-case_simple_set = do
-  assertParseText "{ a = 23; b = 4; }" $ Fix $ NSet NonRecursive
-    [ NamedVar (mkSelector "a") (mkInt 23) nullPos
-    , NamedVar (mkSelector "b") (mkInt 4) nullPos
-    ]
-  assertParseFail "{ a = 23 }"
+case_constant_path_syntax_mistakes =
+  mistakes
+    "."
+    ".."
+    "/"
+    "a/"
+    "a/def/"
+    "~"
+    "~/"
 
-case_set_inherit = do
-  assertParseText "{ e = 3; inherit a b; }" $ Fix $ NSet NonRecursive
-    [ NamedVar (mkSelector "e") (mkInt 3) nullPos
-    , Inherit Nothing (StaticKey <$> ["a", "b"]) nullPos
-    ]
-  assertParseText "{ inherit; }" $ Fix $ NSet NonRecursive [ Inherit Nothing mempty nullPos ]
+case_constant_uri =
+  knownAs (staysInvariantUnder mkStr)
+    "a:a"
+    "http://foo.bar"
+    "a+de+.adA+-:%%%ads%5asdk&/"
+    "rec+def:c"
+    "f.foo:bar"
 
-case_set_scoped_inherit = assertParseText "{ inherit (a) b c; e = 4; inherit(a)b c; }" $ Fix $ NSet NonRecursive
-  [ Inherit (pure (mkSym "a")) (StaticKey <$> ["b", "c"]) nullPos
-  , NamedVar (mkSelector "e") (mkInt 4) nullPos
-  , Inherit (pure (mkSym "a")) (StaticKey <$> ["b", "c"]) nullPos
-  ]
 
-case_set_rec = assertParseText "rec { a = 3; b = a; }" $ Fix $ NSet Recursive
-  [ NamedVar (mkSelector "a") (mkInt 3) nullPos
-  , NamedVar (mkSelector "b") (mkSym "a") nullPos
-  ]
+case_constant_uri_syntax_mistakes =
+  mistakes
+    "http://foo${\"bar\"}"
+    ":bcdef"
+    "a%20:asda"
+    ".:adasd"
+    "+:acdcd"
 
-case_set_complex_keynames = do
-  assertParseText "{ \"\" = null; }" $ Fix $ NSet NonRecursive
-    [ NamedVar (DynamicKey (Plain (DoubleQuoted mempty)) :| mempty) mkNull nullPos ]
-  assertParseText "{ a.b = 3; a.c = 4; }" $ Fix $ NSet NonRecursive
-    [ NamedVar (StaticKey "a" :| [StaticKey "b"]) (mkInt 3) nullPos
-    , NamedVar (StaticKey "a" :| [StaticKey "c"]) (mkInt 4) nullPos
-    ]
-  assertParseText "{ ${let a = \"b\"; in a} = 4; }" $ Fix $ NSet NonRecursive
-    [ NamedVar (DynamicKey (Antiquoted letExpr) :| mempty) (mkInt 4) nullPos ]
-  assertParseText "{ \"a${let a = \"b\"; in a}c\".e = 4; }" $ Fix $ NSet NonRecursive
-    [ NamedVar (DynamicKey (Plain str) :| [StaticKey "e"]) (mkInt 4) nullPos ]
+
+-- *** Special chars in vals
+
+case_identifier_special_chars =
+  invariantVals
+    "_a"
+    "a_b"
+    "a'b"
+    "a''b"
+    "a-b"
+    "a--b"
+    "a12a"
+
+case_identifier_special_chars_syntax_mistakes =
+  mistakes
+    ".a"
+    "'a"
+
+-- ** Sets
+
+-- *** Non-recursive sets
+
+case_simple_set =
+  checks
+    ( mkNonRecSet
+        [ "a" $= mkInt 23
+        , "b" $= mkInt  4
+        ]
+    , "{ a = 23; b = 4; }"
+    )
+
+case_simple_set_syntax_mistakes =
+  mistakes
+    "{ a = 23 }"
+
+case_set_complex_keynames =
+  checks
+    ( mkNonRecSet
+        [ NamedVar (DynamicKey (Plain (DoubleQuoted mempty)) :| mempty) mkNull nullPos ]
+    , "{ \"\" = null; }"
+    )
+    ( mkNonRecSet
+        [ NamedVar (StaticKey "a" :| [StaticKey "b"]) (mkInt 3) nullPos
+        , NamedVar (StaticKey "a" :| [StaticKey "c"]) (mkInt 4) nullPos
+        ]
+    , "{ a.b = 3; a.c = 4; }"
+    )
+    ( mkNonRecSet
+        [ NamedVar (DynamicKey (Antiquoted letExpr) :| mempty) (mkInt 4) nullPos ]
+    , "{ ${let a = \"b\"; in a} = 4; }"
+    )
+    ( mkNonRecSet
+        [ NamedVar (DynamicKey (Plain str) :| [StaticKey "e"]) (mkInt 4) nullPos ]
+    , "{ \"a${let a = \"b\"; in a}c\".e = 4; }"
+    )
  where
-  letExpr = Fix $ NLet [NamedVar (mkSelector "a") (mkStr "b") nullPos] (mkSym "a")
+  letExpr = mkLets ["a" $= mkStr "b"] (var "a")
   str = DoubleQuoted [Plain "a", Antiquoted letExpr, Plain "c"]
 
-case_set_inherit_direct = assertParseText "{ inherit ({a = 3;}); }" $ Fix $ NSet NonRecursive
-  [ Inherit (pure $ Fix $ NSet NonRecursive [NamedVar (mkSelector "a") (mkInt 3) nullPos]) mempty nullPos
-  ]
 
-case_inherit_selector = do
-  assertParseText "{ inherit \"a\"; }" $ Fix $ NSet NonRecursive
-    [Inherit Nothing [DynamicKey (Plain (DoubleQuoted [Plain "a"]))] nullPos]
-  assertParseFail "{ inherit a.x; }"
+-- *** Recursivity in sets
 
-case_int_list = assertParseText "[1 2 3]" $ Fix $ NList
-  [ mkInt i | i <- [1,2,3] ]
+case_set_rec =
+  checks
+    ( mkRecSet
+        [ "a" $= mkInt 3
+        , "b" $= var "a"
+        ]
+    , "rec { a = 3; b = a; }"
+    )
 
-case_int_null_list = assertParseText "[1 2 3 null 4]" $ Fix (NList (fmap (Fix . NConstant) [NInt 1, NInt 2, NInt 3, NNull, NInt 4]))
 
-case_mixed_list = do
-  assertParseText "[{a = 3;}.a (if true then null else false) null false 4 [] c.d or null]" $ Fix $ NList
-    [ Fix (NSelect (Fix (NSet NonRecursive [NamedVar (mkSelector "a") (mkInt 3) nullPos]))
-                   (mkSelector "a") Nothing)
-    , Fix (NIf (mkBool True) mkNull (mkBool False))
-    , mkNull, mkBool False, mkInt 4, Fix (NList mempty)
-    , Fix (NSelect (mkSym "c") (mkSelector "d") (pure mkNull))
-    ]
-  assertParseFail "[if true then null else null]"
-  assertParseFail "[a ? b]"
-  assertParseFail "[a : a]"
-  assertParseFail "[${\"test\")]"
+-- *** Inheritance
 
-case_simple_lambda = assertParseText "a: a" $ Fix $ NAbs (Param "a") (mkSym "a")
+case_set_inherit =
+  checks
+    ( mkNonRecSet
+        [ "e" $= mkInt 3
+        , inherit (StaticKey <$> ["a", "b"])
+        ]
+    , "{ e = 3; inherit a b; }"
+    )
+    ( mkNonRecSet [ inherit mempty ]
+    , "{ inherit; }"
+    )
 
-case_lambda_or_uri = do
-  assertParseText "a :b" $ Fix $ NAbs (Param "a") (mkSym "b")
-  assertParseText "a c:def" $ Fix $ NBinary NApp (mkSym "a") (mkStr "c:def")
-  assertParseText "c:def: c" $ Fix $ NBinary NApp (mkStr "c:def:") (mkSym "c")
-  assertParseText "a:{}" $ Fix $ NAbs (Param "a") $ Fix $ NSet NonRecursive mempty
-  assertParseText "a:[a]" $ Fix $ NAbs (Param "a") $ Fix $ NList [mkSym "a"]
-  assertParseFail "def:"
+case_set_scoped_inherit =
+  checks
+    ( mkNonRecSet $
+        (\ x -> [x, "e" $= mkInt 4, x]) $
+          inheritFrom (var "a") (StaticKey <$> ["b", "c"])
+    , "{ inherit (a) b c; e = 4; inherit(a)b c; }"
+    )
 
-case_lambda_pattern = do
-  assertParseText "{b, c ? 1}: b" $
-    Fix $ NAbs (fixed args mempty) (mkSym "b")
-  assertParseText "{ b ? x: x  }: b" $
-    Fix $ NAbs (fixed args2 mempty) (mkSym "b")
-  assertParseText "a@{b,c ? 1}: b" $
-    Fix $ NAbs (fixed args (pure "a")) (mkSym "b")
-  assertParseText "{b,c?1}@a: c" $
-    Fix $ NAbs (fixed args (pure "a")) (mkSym "c")
-  assertParseText "{b,c?1,...}@a: c" $
-    Fix $ NAbs (variadic vargs (pure "a")) (mkSym "c")
-  assertParseText "{...}: 1" $
-    Fix $ NAbs (variadic mempty mempty) (mkInt 1)
-  assertParseFail "a@b: a"
-  assertParseFail "{a}@{b}: a"
+case_set_inherit_direct =
+  checks
+    ( mkNonRecSet [ inheritFrom (mkNonRecSet ["a" $= mkInt 3]) mempty ]
+    , "{ inherit ({a = 3;}); }"
+    )
+
+case_inherit_selector =
+  checks
+    ( mkNonRecSet [inherit [DynamicKey (Plain (DoubleQuoted [Plain "a"]))]]
+    , "{ inherit \"a\"; }"
+    )
+
+case_inherit_selector_syntax_mistakes =
+  mistakes
+    "{ inherit a.x; }"
+
+
+-- ** Lists
+
+case_int_list =
+  checks
+    ( mkList $ mkInt <$> [ i | i <- [1,2,3] ]
+    , "[1 2 3]"
+    )
+
+case_int_null_list =
+  checks
+    ( mkList (mkConst <$> [NInt 1, NInt 2, NInt 3, NNull, NInt 4])
+    , "[1 2 3 null 4]"
+    )
+
+case_mixed_list =
+  checks
+    ( mkList
+        [ mkNonRecSet ["a" $= mkInt 3] @. "a"
+        , mkIf (mkBool True) mkNull (mkBool False)
+        , mkNull
+        , mkBool False
+        , mkInt 4
+        , emptyList
+        , (@.<|>) (var "c") "d" mkNull
+        ]
+    , "[{a = 3;}.a (if true then null else false) null false 4 [] c.d or null]"
+    )
+
+case_mixed_list_syntax_mistakes =
+  mistakes
+    "[if true then null else null]"
+    "[a ? b]"
+    "[a : a]"
+    "[${\"test\")]"
+
+
+-- ** Lambdas
+
+case_simple_lambda =
+  checks
+    ( mkFunction (Param "a") (var "a")
+    , "a: a"
+    )
+
+case_lambda_or_uri =
+  checks
+    ( mkFunction (Param "a") $ var "b"
+    , "a :b"
+    )
+    ( var "a" @@ mkStr "c:def"
+    , "a c:def"
+    )
+    ( mkStr "c:def:" @@ var "c"
+    , "c:def: c"
+    )
+    ( mkFunction (Param "a") emptySet
+    , "a:{}"
+    )
+    ( mkFunction (Param "a") $ mkList [var "a"]
+    , "a:[a]"
+    )
+
+case_lambda_or_uri_syntax_mistakes =
+  mistakes
+    "def:"
+
+case_lambda_pattern =
+  checks
+    ( mkFunction (fixed args mempty) $ var "b"
+    , "{b, c ? 1}: b"
+    )
+    ( mkFunction (fixed args2 mempty) $ var "b"
+    , "{ b ? x: x  }: b"
+    )
+    ( mkFunction (fixed args $ pure "a") $ var "b"
+    , "a@{b,c ? 1}: b"
+    )
+    ( mkFunction (fixed args $ pure "a") $ var "c"
+    , "{b,c?1}@a: c"
+    )
+    ( mkFunction (variadic vargs $ pure "a") $ var "c"
+    , "{b,c?1,...}@a: c"
+    )
+    ( mkFunction (variadic mempty mempty) $ mkInt 1
+    , "{...}: 1"
+    )
  where
-  fixed args = ParamSet args False
+  fixed    args = ParamSet args False
   variadic args = ParamSet args True
-  args = [("b", Nothing), ("c", pure $ mkInt 1)]
+  args  = [("b", Nothing), ("c", pure $ mkInt 1)]
   vargs = [("b", Nothing), ("c", pure $ mkInt 1)]
   args2 = [("b", pure lam)]
-  lam = Fix $ NAbs (Param "x") (mkSym "x")
+  lam = mkFunction (Param "x") $ var "x"
 
-case_lambda_app_int = assertParseText "(a: a) 3" $ Fix (NBinary NApp lam int) where
-  int = mkInt 3
-  lam = Fix (NAbs (Param "a") asym)
-  asym = mkSym "a"
+case_lambda_pattern_syntax_mistakes =
+  mistakes
+    "a@b: a"
+    "{a}@{b}: a"
 
-case_simple_let = do
-  assertParseText "let a = 4; in a" $ Fix (NLet binds $ mkSym "a")
-  assertParseFail "let a = 4 in a"
- where
-  binds = [NamedVar (mkSelector "a") (mkInt 4) nullPos]
+case_lambda_app_int =
+  checks
+    ( mkFunction (Param "a") (var "a") @@ mkInt 3
+    , "(a: a) 3"
+    )
 
-case_let_body = assertParseText "let { body = 1; }" letBody
-  where
-    letBody = Fix $ NSelect aset (mkSelector "body") Nothing
-    aset = Fix $ NSet Recursive [NamedVar (mkSelector "body") (mkInt 1) nullPos]
 
-case_nested_let = do
-  assertParseText "let a = 4; in let b = 5; in a" $ Fix $ NLet
-    [NamedVar (mkSelector "a") (mkInt 4) nullPos]
-    (Fix $ NLet [NamedVar (mkSelector "b") (mkInt 5) nullPos] $ mkSym "a")
-  assertParseFail "let a = 4; let b = 3; in b"
+-- ** Let
 
-case_let_scoped_inherit = do
-  assertParseText "let a = null; inherit (b) c; in c" $ Fix $ NLet
-    [ NamedVar (mkSelector "a") mkNull nullPos
-    , Inherit (pure $ mkSym "b") [StaticKey "c"] nullPos ]
-    (mkSym "c")
-  assertParseFail "let inherit (b) c in c"
+case_simple_let =
+  checks
+    ( mkLets ["a" $= mkInt 4] $ var "a"
+    , "let a = 4; in a"
+    )
 
-case_if = do
-  assertParseText "if true then true else false" $
-      Fix $ NIf (mkBool True) (mkBool True) (mkBool False)
-  assertParseFail "if true then false"
-  assertParseFail "else"
-  assertParseFail "if true then false else"
-  assertParseFail "if true then false else false else"
-  assertParseFail "1 + 2 then"
+case_simple_let_syntax_mistakes =
+  mistakes
+    "let a = 4 in a"
 
-case_identifier_special_chars = do
-  assertParseText "_a" $ mkSym "_a"
-  assertParseText "a_b" $ mkSym "a_b"
-  assertParseText "a'b" $ mkSym "a'b"
-  assertParseText "a''b" $ mkSym "a''b"
-  assertParseText "a-b" $ mkSym "a-b"
-  assertParseText "a--b" $ mkSym "a--b"
-  assertParseText "a12a" $ mkSym "a12a"
-  assertParseFail ".a"
-  assertParseFail "'a"
+case_let_body =
+  checks
+    ( mkRecSet ["body" $= mkInt 1] @. "body"
+    , "let { body = 1; }"
+    )
 
-case_identifier_keyword_prefix = do
-  assertParseText "true-name" $ mkSym "true-name"
-  assertParseText "trueName" $ mkSym "trueName"
-  assertParseText "null-name" $ mkSym "null-name"
-  assertParseText "nullName" $ mkSym "nullName"
-  assertParseText "[ null-name ]" $ mkList [ mkSym "null-name" ]
+case_nested_let =
+  checks
+    ( mkLets ["a" $= mkInt 4] $
+        mkLets ["b" $= mkInt 5] $ var "a"
+    , "let a = 4; in let b = 5; in a"
+    )
 
-makeTextParseTest str = assertParseText ("\"" <> str <> "\"") $ mkStr str
+case_nested_let_syntax_mistakes =
+  mistakes
+    "let a = 4; let b = 3; in b"
 
-case_simple_string = traverse_ makeTextParseTest ["abcdef", "a", "A", "   a a  ", ""]
+case_let_scoped_inherit =
+  checks
+    ( mkLets
+        [ "a" $= mkNull
+        , inheritFrom (var "b") [StaticKey "c"]
+        ]
+        $ var "c"
+    , "let a = null; inherit (b) c; in c"
+    )
 
-case_string_dollar = traverse_ makeTextParseTest ["a$b", "a$$b", "$cdef", "gh$i"]
+case_let_scoped_inherit_syntax_mistakes =
+  mistakes
+    "let inherit (b) c in c"
 
-case_string_escape = do
-  assertParseText "\"\\$\\n\\t\\r\\\\\"" $ mkStr "$\n\t\r\\"
-  assertParseText "\" \\\" \\' \"" $ mkStr " \" ' "
 
-case_string_antiquote = do
-  assertParseText "\"abc${  if true then \"def\" else \"abc\"  } g\"" $
-    Fix $ NStr $ DoubleQuoted
-      [ Plain "abc"
-      , Antiquoted $ Fix $ NIf (mkBool True) (mkStr "def") (mkStr "abc")
-      , Plain " g"
-      ]
-  assertParseText "\"\\${a}\"" $ mkStr "${a}"
-  assertParseFail "\"a"
-  assertParseFail "${true}"
-  assertParseFail "\"${true\""
+-- ** If
 
-case_select = do
-  assertParseText "a .  e .di. f" $ Fix $ NSelect (mkSym "a")
-    (StaticKey "e" :| [StaticKey "di", StaticKey "f"])
-    Nothing
-  assertParseText "a.e . d    or null" $ Fix $ NSelect (mkSym "a")
-    (StaticKey "e" :| [StaticKey "d"])
-    (pure mkNull)
-  assertParseText "{}.\"\"or null" $ Fix $ NSelect (Fix (NSet NonRecursive mempty))
-    (DynamicKey (Plain (DoubleQuoted mempty)) :| mempty) (pure mkNull)
-  assertParseText "{ a = [1]; }.a or [2] ++ [3]" $ Fix $ NBinary NConcat
-      (Fix (NSelect
-                (Fix (NSet NonRecursive [NamedVar (StaticKey "a" :| mempty)
-                                     (Fix (NList [Fix (NConstant (NInt 1))]))
-                                     nullPos]))
-                (StaticKey "a" :| mempty)
-                (pure (Fix (NList [Fix (NConstant (NInt 2))])))))
-      (Fix (NList [Fix (NConstant (NInt 3))]))
+case_if =
+  checks
+    ( mkIf (mkBool True) (mkBool True) (mkBool False)
+    , "if true then true else false"
+    )
 
-case_select_path = do
-  assertParseText "f ./." $ Fix $ NBinary NApp (mkSym "f") (mkPath False "./.")
-  assertParseText "f.b ../a" $ Fix $ NBinary NApp select (mkPath False "../a")
-  assertParseText "{}./def" $ Fix $ NBinary NApp (Fix (NSet NonRecursive mempty)) (mkPath False "./def")
-  assertParseText "{}.\"\"./def" $ Fix $ NBinary NApp
-    (Fix $ NSelect (Fix (NSet NonRecursive mempty)) (DynamicKey (Plain (DoubleQuoted mempty)) :| mempty) Nothing)
-    (mkPath False "./def")
- where select = Fix $ NSelect (mkSym "f") (mkSelector "b") Nothing
+case_if_syntax_mistakes =
+  mistakes
+    "if true then false"
+    "else"
+    "if true then false else"
+    "if true then false else false else"
+    "1 + 2 then"
 
-case_select_keyword = do
-  assertParseText "{ false = \"foo\"; }" $ Fix $ NSet NonRecursive [NamedVar (mkSelector "false") (mkStr "foo") nullPos]
 
-case_fun_app = do
-  assertParseText "f a b" $ Fix $ NBinary NApp (Fix $ NBinary NApp (mkSym "f") (mkSym "a")) (mkSym "b")
-  assertParseText "f a.x or null" $ Fix $ NBinary NApp (mkSym "f") $ Fix $
-    NSelect (mkSym "a") (mkSelector "x") (pure mkNull)
-  assertParseFail "f if true then null else null"
+-- ** Literal expressions in vals
 
-case_indented_string = do
-  assertParseText "''a''" $ mkIndentedStr 0 "a"
-  assertParseText "''\n  foo\n  bar''" $ mkIndentedStr 2 "foo\nbar"
-  assertParseText "''        ''" $ mkIndentedStr 0 ""
-  assertParseText "'''''''" $ mkIndentedStr 0 "''"
-  assertParseText "''   ${null}\n   a${null}''" $ Fix $ NStr $ Indented 3
-    [ Antiquoted mkNull
-    , Plain "\na"
-    , Antiquoted mkNull
-    ]
-  assertParseFail "'''''"
-  assertParseFail "''   '"
+case_identifier_keyword_prefix_invariants =
+  invariantVals
+    "true-name"
+    "trueName"
+    "null-name"
+    "nullName"
 
-case_indented_string_escape = assertParseText
-  "'' ''\\n ''\\t ''\\\\ ''${ \\ \\n ' ''' ''" $
-  mkIndentedStr 1 "\n \t \\ ${ \\ \\n ' '' "
+case_identifier_keyword_prefix =
+  checks
+    ( mkList [ var "null-name" ]
+    , "[ null-name ]"
+    )
 
-case_operator_fun_app = do
-  assertParseText "a ++ b" $ mkOp2 NConcat (mkSym "a") (mkSym "b")
-  assertParseText "a ++ f b" $ mkOp2 NConcat (mkSym "a") $ Fix $ NBinary NApp
-    (mkSym "f") (mkSym "b")
 
-case_operators = do
-  assertParseText "1 + 2 - 3" $ mkOp2 NMinus
-    (mkOp2 NPlus (mkInt 1) (mkInt 2)) (mkInt 3)
-  assertParseFail "1 + if true then 1 else 2"
-  assertParseText "1 + (if true then 2 else 3)" $ mkOp2 NPlus (mkInt 1) $ Fix $ NIf
-   (mkBool True) (mkInt 2) (mkInt 3)
-  assertParseText "{ a = 3; } // rec { b = 4; }" $ mkOp2 NUpdate
-    (Fix $ NSet NonRecursive [NamedVar (mkSelector "a") (mkInt 3) nullPos])
-    (Fix $ NSet Recursive [NamedVar (mkSelector "b") (mkInt 4) nullPos])
-  assertParseText "--a" $ mkOp NNeg $ mkOp NNeg $ mkSym "a"
-  assertParseText "a - b - c" $ mkOp2 NMinus
-    (mkOp2 NMinus (mkSym "a") (mkSym "b")) $
-    mkSym "c"
-  assertParseText "foo<bar" $ mkOp2 NLt (mkSym "foo") (mkSym "bar")
-  assertParseFail "+ 3"
-  assertParseFail "foo +"
+-- ** Strings
 
-case_comments =
-  do
-    Right expected <- parseNixFile "data/let.nix"
-    assertParseFile "let-comments-multiline.nix" expected
-    assertParseFile "let-comments.nix" expected
+invariantString str =
+  checks
+    ( mkStr str
+    , "\"" <> str <> "\""
+    )
+
+case_simple_string =
+  knownAs invariantString
+    "abcdef"
+    "a"
+    "A"
+    "   a a  "
+    ""
+
+case_string_dollar =
+  knownAs invariantString
+    "a$b"
+    "a$$b"
+    "$cdef"
+    "gh$i"
+
+case_string_escape =
+  checks
+    ( mkStr "$\n\t\r\\"
+    , "\"\\$\\n\\t\\r\\\\\""
+    )
+    ( mkStr " \" ' "
+    , "\" \\\" \\' \""
+    )
+
+case_string_antiquote =
+  checks
+    ( Fix $ NStr $ DoubleQuoted
+        [ Plain "abc"
+        , Antiquoted $ mkIf (mkBool True) (mkStr "def") (mkStr "abc")
+        , Plain " g"
+        ]
+    , "\"abc${  if true then \"def\" else \"abc\"  } g\""
+    )
+    ( mkStr "${a}"
+    , "\"\\${a}\""
+    )
+
+case_string_antiquote_syntax_mistakes =
+  mistakes
+    "\"a"
+    "${true}"
+    "\"${true\""
+
+
+-- *** Indented string
+
+case_indented_string =
+  checks
+    ( mkIndentedStr 0 "a"
+    , "''a''"
+    )
+    ( mkIndentedStr 2 "foo\nbar"
+    , "''\n  foo\n  bar''"
+    )
+    ( mkIndentedStr 0 ""
+    , "''        ''"
+    )
+    ( mkIndentedStr 0 "''"
+    , "'''''''"
+    )
+    ( Fix $ NStr $ Indented 3
+        [ Antiquoted mkNull
+        , Plain "\na"
+        , Antiquoted mkNull
+        ]
+    , "''   ${null}\n   a${null}''"
+    )
+
+case_indented_string_syntax_mistakes =
+  mistakes
+    "'''''"
+    "''   '"
+
+case_indented_string_escape =
+  checks
+    ( mkIndentedStr 1 "\n \t \\ ${ \\ \\n ' '' "
+    , "'' ''\\n ''\\t ''\\\\ ''${ \\ \\n ' ''' ''"
+    )
+
+-- ** Selection
+
+case_select =
+  checks
+    ( Fix $ NSelect (var "a")
+        (StaticKey "e" :| [StaticKey "di", StaticKey "f"])
+        Nothing
+    , "a .  e .di. f"
+    )
+    ( Fix $ NSelect (var "a")
+        (StaticKey "e" :| [StaticKey "d"])
+        (pure mkNull)
+    , "a.e . d    or null"
+    )
+    ( Fix $ NSelect emptySet
+        (DynamicKey (Plain (DoubleQuoted mempty)) :| mempty) (pure mkNull)
+    , "{}.\"\"or null"
+    )
+    ( Fix $ NBinary NConcat
+        ((@.<|>)
+          (mkNonRecSet
+            [NamedVar
+              (mkSelector "a")
+              (mkList $ one $ mkInt 1)
+              nullPos
+            ]
+          )
+          "a"
+          (mkList $ one $ mkInt 2)
+        )
+        (mkList $ one $ mkInt 3)
+    , "{ a = [1]; }.a or [2] ++ [3]"
+    )
+
+case_select_path =
+  checks
+    ( var "f" @@ mkRelPath "./."
+    , "f ./."
+    )
+    ( var "f" @. "b" @@ mkRelPath "../a"
+    , "f.b ../a"
+    )
+    ( emptySet @@ mkRelPath "./def"
+    , "{}./def"
+    )
+    ( Fix (NSelect emptySet (DynamicKey (Plain $ DoubleQuoted mempty) :| mempty) Nothing) @@ mkRelPath "./def"
+    , "{}.\"\"./def"
+    )
+
+case_select_keyword =
+  checks
+    ( mkNonRecSet ["false" $= mkStr "foo"]
+    , "{ false = \"foo\"; }"
+    )
 
 case_select_or_precedence =
     assertParsePrint [text|let
@@ -357,6 +573,72 @@ in null|] [text|let
         in (matcher.case or null).foo (v.case);
 in null|]
 
+-- ** Function application
+
+case_fun_app =
+  checks
+    ( var "f" @@ var "a" @@ var "b"
+    , "f a b"
+    )
+    ( var "f" @@ (@.<|>) (var "a") "x" mkNull
+    , "f a.x or null"
+    )
+
+case_fun_app_syntax_mistakes =
+  mistakes
+   "f if true then null else null"
+
+
+-- ** Operators
+
+case_operator_fun_app =
+  checks
+    ( var "a" $++ var "b"
+    , "a ++ b"
+    )
+    ( var "a" $++ var "f" @@ var "b"
+    , "a ++ f b"
+    )
+
+case_operators =
+  checks
+    ( mkInt 1 $+ mkInt 2 $- mkInt 3
+    , "1 + 2 - 3"
+    )
+    ( mkInt 1 $+ mkIf (mkBool True) (mkInt 2) (mkInt 3)
+    , "1 + (if true then 2 else 3)"
+    )
+    ( mkNonRecSet ["a" $= mkInt 3] $// mkRecSet ["b" $= mkInt 4]
+    , "{ a = 3; } // rec { b = 4; }"
+    )
+    ( mkNeg $ mkNeg $ var "a"
+    , "--a"
+    )
+    ( var "a" $- var "b" $- var "c"
+    , "a - b - c"
+    )
+    ( var "foo" $< var "bar"
+    , "foo<bar"
+    )
+
+case_operators_syntax_mistakes =
+  mistakes
+    "+ 3"
+    "foo +"
+    "1 + if true then 1 else 2"
+
+
+-- ** Comments
+
+case_comments =
+  do
+    Right expected <- parseNixFile "data/let.nix"
+    assertParseFile "let-comments-multiline.nix" expected
+    assertParseFile "let-comments.nix" expected
+
+
+-- ** Location
+
 case_simpleLoc =
   let
     mkSPos l c = SourcePos "<string>" (mkPos l) (mkPos c)
@@ -377,10 +659,11 @@ case_simpleLoc =
                 (mkSpan 2 7 3 15)
                 NApp
                 (Fix
-                  (NBinary_ (mkSpan 2 7 3 9)
-                            NApp
-                            (Fix (NSym_ (mkSpan 2 7 2 10) "bar"))
-                            (Fix (NSym_ (mkSpan 3 6 3 9) "baz"))
+                  (NBinary_
+                    (mkSpan 2 7 3 9)
+                    NApp
+                    (Fix (NSym_ (mkSpan 2 7 2 10) "bar"))
+                    (Fix (NSym_ (mkSpan 3 6 3 9) "baz"))
                   )
                 )
                 (Fix (NStr_ (mkSpan 3 10 3 15) (DoubleQuoted [Plain "qux"])))
@@ -398,12 +681,35 @@ tests = $testGroupGenerator
 
 ---------------------------------------------------------------------------------
 
-assertParseText :: Text -> NExpr -> Assertion
-assertParseText str expected =
-  either
-    (\ err ->
-      assertFailure $ toString $ "Unexpected fail parsing `" <> str <> "':\n" <> show err
+-- * Helpers
+
+var = mkSym
+
+invariantVal = staysInvariantUnder var
+
+staysInvariantUnder :: (NixLang -> ExpectedHask) -> NixLang -> Assertion
+staysInvariantUnder f v =
+  (<=>) (f v) v
+
+type NixLang = Text
+type ExpectedHask = NExpr
+
+(<=>) :: ExpectedHask -> NixLang -> Assertion
+(<=>) = assertParseText
+
+throwParseError
+  :: ( IsString a
+    , ToString a
+    , Semigroup a
+    , Show b
     )
+  => a -> a -> b -> IO c
+throwParseError what str err = assertFailure $ toString $ "Unexpected fail parsing " <> what <> ":\n  ''\n" <> str <> "\n''\n  Error: ''" <> show err <> "''."
+
+assertParseText :: ExpectedHask -> NixLang -> Assertion
+assertParseText expected str =
+  either
+    (throwParseError "expression" str)
     (assertEqual
       ("When parsing " <> toString str)
       (stripPositionInfo expected)
@@ -411,12 +717,10 @@ assertParseText str expected =
     )
     (parseNixText str)
 
-assertParseTextLoc :: Text -> NExprLoc -> Assertion
+assertParseTextLoc :: NixLang -> NExprLoc -> Assertion
 assertParseTextLoc str expected =
   either
-    (\ err ->
-      assertFailure $ toString $ "Unexpected fail parsing `" <> str <> "':\n" <> show err
-    )
+    (throwParseError "expression" str)
     (assertEqual
       ("When parsing " <> toString str)
       expected
@@ -428,9 +732,7 @@ assertParseFile file expected =
   do
   res <- parseNixFile $ "data/" <> file
   either
-    (\ err ->
-      assertFailure $ "Unexpected fail parsing data file `" <> file <> "':\n" <> show err
-    )
+    (throwParseError "data file" file)
     (assertEqual
       ("Parsing data file " <> file)
       (stripPositionInfo expected)
@@ -438,12 +740,12 @@ assertParseFile file expected =
     )
     res
 
-assertParseFail :: Text -> Assertion
+assertParseFail :: NixLang -> Assertion
 assertParseFail str =
   either
     (const pass)
     (\ r ->
-      assertFailure $ toString $ "Unexpected success parsing `" <> str <> ":\nParsed value: " <> show r
+      assertFailure $ toString $ "Unexpected success parsing ''" <> str <> "'':\n  Parsed value: ''" <> show r <> "''."
     )
     (parseNixText str)
 
@@ -461,3 +763,47 @@ assertParsePrint src expect =
       . stripAnnotation $
         expr
   in assertEqual "" expect result
+
+
+-----
+
+-- | This class constructs functions that accept variacic number of argumets.
+-- Every argument is an assertion.
+-- So now the new assertions can be added just by adding it to a block of according assertions.
+class VariadicAssertions t where
+  checkListPairs' :: ((ExpectedHask, NixLang) -> Assertion) -> [(ExpectedHask, NixLang)] -> t
+
+instance VariadicAssertions (IO a) where
+  checkListPairs' f acc =
+    do
+      traverse_ f acc
+      pure $ error "never would be reached, cuz `I'm lazy`."
+
+instance (VariadicAssertions a) => VariadicAssertions ((ExpectedHask, NixLang) -> a) where
+  checkListPairs' f acc x = checkListPairs' f (acc <> [x])
+
+checks :: (VariadicAssertions a) => a
+checks = checkListPairs' (uncurry assertParseText) []
+
+
+class VariadicArgs t where
+  checkList' :: (NixLang -> Assertion) -> [NixLang] -> t
+
+instance VariadicArgs (IO a) where
+  checkList' f acc =
+    do
+      traverse_ f acc
+      pure $ error "never would be reached, cuz `I'm lazy`."
+
+instance (VariadicArgs a) => VariadicArgs (NixLang -> a) where
+  checkList' f acc x = checkList' f (acc <> [x])
+
+knownAs :: (VariadicArgs a) => (NixLang -> Assertion) -> a
+knownAs f = checkList' f []
+
+mistakes :: (VariadicArgs a) => a
+mistakes = knownAs assertParseFail
+
+invariantVals :: (VariadicArgs a) => a
+invariantVals = knownAs invariantVal
+

--- a/tests/ParserTests.hs
+++ b/tests/ParserTests.hs
@@ -37,10 +37,10 @@ case_constant_path = do
   assertParseText "../abc" $ mkPath False "../abc"
   assertParseText "<abc>" $ mkPath True "abc"
   assertParseText "<../cdef>" $ mkPath True "../cdef"
-  assertParseText "a//b" $ mkOper2 NUpdate (mkSym "a") (mkSym "b")
+  assertParseText "a//b" $ mkOp2 NUpdate (mkSym "a") (mkSym "b")
   assertParseText "rec+def/cdef" $ mkPath False "rec+def/cdef"
-  assertParseText "a/b//c/def//<g> < def/d" $ mkOper2 NLt
-    (mkOper2 NUpdate (mkPath False "a/b") $ mkOper2 NUpdate
+  assertParseText "a/b//c/def//<g> < def/d" $ mkOp2 NLt
+    (mkOp2 NUpdate (mkPath False "a/b") $ mkOp2 NUpdate
       (mkPath False "c/def") (mkPath True "g"))
     (mkPath False "def/d")
   assertParseText "a'b/c" $ Fix $ NBinary NApp (mkSym "a'b") (mkPath False "/c")
@@ -300,24 +300,24 @@ case_indented_string_escape = assertParseText
   mkIndentedStr 1 "\n \t \\ ${ \\ \\n ' '' "
 
 case_operator_fun_app = do
-  assertParseText "a ++ b" $ mkOper2 NConcat (mkSym "a") (mkSym "b")
-  assertParseText "a ++ f b" $ mkOper2 NConcat (mkSym "a") $ Fix $ NBinary NApp
+  assertParseText "a ++ b" $ mkOp2 NConcat (mkSym "a") (mkSym "b")
+  assertParseText "a ++ f b" $ mkOp2 NConcat (mkSym "a") $ Fix $ NBinary NApp
     (mkSym "f") (mkSym "b")
 
 case_operators = do
-  assertParseText "1 + 2 - 3" $ mkOper2 NMinus
-    (mkOper2 NPlus (mkInt 1) (mkInt 2)) (mkInt 3)
+  assertParseText "1 + 2 - 3" $ mkOp2 NMinus
+    (mkOp2 NPlus (mkInt 1) (mkInt 2)) (mkInt 3)
   assertParseFail "1 + if true then 1 else 2"
-  assertParseText "1 + (if true then 2 else 3)" $ mkOper2 NPlus (mkInt 1) $ Fix $ NIf
+  assertParseText "1 + (if true then 2 else 3)" $ mkOp2 NPlus (mkInt 1) $ Fix $ NIf
    (mkBool True) (mkInt 2) (mkInt 3)
-  assertParseText "{ a = 3; } // rec { b = 4; }" $ mkOper2 NUpdate
+  assertParseText "{ a = 3; } // rec { b = 4; }" $ mkOp2 NUpdate
     (Fix $ NSet NonRecursive [NamedVar (mkSelector "a") (mkInt 3) nullPos])
     (Fix $ NSet Recursive [NamedVar (mkSelector "b") (mkInt 4) nullPos])
-  assertParseText "--a" $ mkOper NNeg $ mkOper NNeg $ mkSym "a"
-  assertParseText "a - b - c" $ mkOper2 NMinus
-    (mkOper2 NMinus (mkSym "a") (mkSym "b")) $
+  assertParseText "--a" $ mkOp NNeg $ mkOp NNeg $ mkSym "a"
+  assertParseText "a - b - c" $ mkOp2 NMinus
+    (mkOp2 NMinus (mkSym "a") (mkSym "b")) $
     mkSym "c"
-  assertParseText "foo<bar" $ mkOper2 NLt (mkSym "foo") (mkSym "bar")
+  assertParseText "foo<bar" $ mkOp2 NLt (mkSym "foo") (mkSym "bar")
   assertParseFail "+ 3"
   assertParseFail "foo +"
 

--- a/tests/PrettyParseTests.hs
+++ b/tests/PrettyParseTests.hs
@@ -37,8 +37,7 @@ genPos = mkPos <$> Gen.int (Range.linear 1 256)
 
 genSourcePos :: Gen SourcePos
 genSourcePos =
-  liftA3
-    SourcePos
+  liftA3 SourcePos
     asciiString
     genPos
     genPos
@@ -53,13 +52,11 @@ genAntiquoted gen =
 
 genBinding :: Gen (Binding NExpr)
 genBinding = Gen.choice
-  [ liftA3
-      NamedVar
+  [ liftA3 NamedVar
       genAttrPath
       genExpr
       genSourcePos
-  , liftA3
-      Inherit
+  , liftA3 Inherit
       (Gen.maybe genExpr)
       (Gen.list (Range.linear 0 5) genKeyName)
       genSourcePos
@@ -68,8 +65,7 @@ genBinding = Gen.choice
 genString :: Gen (NString NExpr)
 genString = Gen.choice
   [ DoubleQuoted <$> Gen.list (Range.linear 0 5) (genAntiquoted asciiText)
-  , liftA2
-      Indented
+  , liftA2 Indented
       (Gen.int (Range.linear 0 10))
       (Gen.list
         (Range.linear 0 5)
@@ -79,16 +75,14 @@ genString = Gen.choice
 
 genAttrPath :: Gen (NAttrPath NExpr)
 genAttrPath =
-  liftA2
-    (:|)
+  liftA2 (:|)
     genKeyName
     $ Gen.list (Range.linear 0 4) genKeyName
 
 genParams :: Gen (Params NExpr)
 genParams = Gen.choice
   [ Param <$> asciiText
-  , liftA3
-      ParamSet
+  , liftA3 ParamSet
       (Gen.list (Range.linear 0 10) (liftA2 (,) asciiText $ Gen.maybe genExpr))
       Gen.bool
       (Gen.choice [stub, pure <$> asciiText])
@@ -96,8 +90,8 @@ genParams = Gen.choice
 
 genAtom :: Gen NAtom
 genAtom = Gen.choice
-  [ NInt   <$> Gen.integral (Range.linear 0 1000)
-  , NFloat <$> Gen.float (Range.linearFrac 0.0 1000.0)
+  [ NInt   <$> Gen.integral (Range.linear     0   1000  )
+  , NFloat <$> Gen.float    (Range.linearFrac 0.0 1000.0)
   , NBool  <$> Gen.bool
   , pure NNull
   ]
@@ -106,24 +100,27 @@ genAtom = Gen.choice
 -- list Arbitrary instance which makes the generator terminate. The
 -- distribution is not scientifically chosen.
 genExpr :: Gen NExpr
-genExpr = Gen.sized $ \(Size n) -> Fix <$> if n < 2
-  then Gen.choice [genConstant, genStr, genSym, genLiteralPath, genEnvPath]
-  else Gen.frequency
-    [ (1 , genConstant)
-    , (1 , genSym)
-    , (4 , Gen.resize (Size (n `div` 3)) genIf)
-    , (10, genRecSet)
-    , (20, genSet)
-    , (5 , genList)
-    , (2 , genUnary)
-    , (2, Gen.resize (Size (n `div` 3)) genBinary)
-    , (3, Gen.resize (Size (n `div` 3)) genSelect)
-    , (20, Gen.resize (Size (n `div` 2)) genAbs)
-    , (2, Gen.resize (Size (n `div` 2)) genHasAttr)
-    , (10, Gen.resize (Size (n `div` 2)) genLet)
-    , (10, Gen.resize (Size (n `div` 2)) genWith)
-    , (1, Gen.resize (Size (n `div` 2)) genAssert)
-    ]
+genExpr =
+  Gen.sized $
+    \(Size n) -> Fix <$>
+      if n < 2
+        then Gen.choice [genConstant, genStr, genSym, genLiteralPath, genEnvPath]
+        else Gen.frequency
+          [ (1 , genConstant)
+          , (1 , genSym)
+          , (4 , Gen.resize (Size (n `div` 3)) genIf)
+          , (10, genRecSet)
+          , (20, genSet)
+          , (5 , genList)
+          , (2 , genUnary)
+          , (2 , Gen.resize (Size (n `div` 3)) genBinary)
+          , (3 , Gen.resize (Size (n `div` 3)) genSelect)
+          , (20, Gen.resize (Size (n `div` 2)) genAbs)
+          , (2 , Gen.resize (Size (n `div` 2)) genHasAttr)
+          , (10, Gen.resize (Size (n `div` 2)) genLet)
+          , (10, Gen.resize (Size (n `div` 2)) genWith)
+          , (1 , Gen.resize (Size (n `div` 2)) genAssert)
+          ]
  where
   genConstant    = NConstant                <$> genAtom
   genStr         = NStr                     <$> genString
@@ -155,18 +152,21 @@ equivUpToNormalization :: NExpr -> NExpr -> Bool
 equivUpToNormalization x y = normalize x == normalize y
 
 normalize :: NExpr -> NExpr
-normalize = foldFix $ Fix . \case
+normalize = foldFix $ \case
   NConstant (NInt n) | n < 0 ->
-    NUnary NNeg $ Fix $ NConstant $ NInt $ negate n
+    mkNeg $ mkInt $ negate n
   NConstant (NFloat n) | n < 0 ->
-    NUnary NNeg $ Fix $ NConstant $ NFloat $ negate n
+    mkNeg $ mkFloat $ negate n
 
-  NSet recur binds -> NSet recur $ normBinding <$> binds
-  NLet binds  r -> NLet (normBinding <$> binds) r
+  NSet recur binds ->
+    mkSet recur $ normBinding <$> binds
+  NLet binds  r ->
+    mkLets (normBinding <$> binds) r
 
-  NAbs params r -> NAbs (normParams params) r
+  NAbs params r ->
+    mkFunction (normParams params) r
 
-  r             -> r
+  r             -> Fix r
 
  where
   normBinding (NamedVar path r     pos) = NamedVar (normKey <$> path) r pos
@@ -176,17 +176,19 @@ normalize = foldFix $ Fix . \case
   normKey (StaticKey  name  ) = StaticKey name
 
   normAntiquotedString
-    :: Antiquoted (NString NExpr) NExpr -> Antiquoted (NString NExpr) NExpr
+    :: Antiquoted (NString NExpr) NExpr
+    -> Antiquoted (NString NExpr) NExpr
   normAntiquotedString (Plain (DoubleQuoted [EscapedNewline])) = EscapedNewline
   normAntiquotedString (Plain (DoubleQuoted strs)) =
-    let strs' = normAntiquotedText <$> strs
-    in
-    if strs == strs'
-      then Plain $ DoubleQuoted strs
-      else normAntiquotedString $ Plain $ DoubleQuoted strs'
+    bool normAntiquotedString id (strs == strs')
+      (Plain $ DoubleQuoted strs')
+    where
+     strs' = normAntiquotedText <$> strs
   normAntiquotedString r = r
 
-  normAntiquotedText :: Antiquoted Text NExpr -> Antiquoted Text NExpr
+  normAntiquotedText
+    :: Antiquoted Text NExpr
+    -> Antiquoted Text NExpr
   normAntiquotedText (Plain "\n"  ) = EscapedNewline
   normAntiquotedText (Plain "''\n") = EscapedNewline
   normAntiquotedText r              = r

--- a/tests/ReduceExprTests.hs
+++ b/tests/ReduceExprTests.hs
@@ -1,14 +1,13 @@
 {-# OPTIONS_GHC -fno-warn-name-shadowing #-}
 module ReduceExprTests (tests) where
-import           Data.Fix
 import           Test.Tasty
 import           Test.Tasty.HUnit
 
-import           Nix.Atoms
 import           Nix.Expr.Types
 import           Nix.Expr.Types.Annotated
 import           Nix.Parser
 import           Nix.Reduce                     ( reduceExpr )
+import           Nix.Expr.Shorthands
 
 
 tests :: TestTree
@@ -46,13 +45,13 @@ selectBasic :: Result NExprLoc
 selectBasic = parseNixTextLoc "{b=2;a=42;}.a"
 
 selectBasicExpect :: NExpr
-selectBasicExpect = Fix . NConstant $ NInt 42
+selectBasicExpect = mkInt 42
 
 selectNested :: Result NExprLoc
 selectNested = parseNixTextLoc "{a={b=2;a=42;};b={a=2;};}.a.a"
 
 selectNestedExpect :: NExpr
-selectNestedExpect = Fix . NConstant $ NInt 42
+selectNestedExpect = mkInt 42
 
 selectIncorrectAttrPath :: Result NExprLoc
 selectIncorrectAttrPath = parseNixTextLoc "{a=42;}.b"


### PR DESCRIPTION
Walked into the `Shorthands` module.

Main things: https://github.com/haskell-nix/hnix/blob/2021-07-09-changes/ChangeLog.md
  * fixed `mkAssert`
  * refactored `ParserTests`.
  * Added `@.<|>` operator that represents (previously unrepresentable by shorthands) feature of a language: `s.x or y`.
  * Established precedence between shorthand operators. This allows to write down the Haskell (pretty) directly to represent a one-to-one a Nix expression.