### PR TITLE
String: (make -> mk) renames; other optimizations

### DIFF
--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -351,7 +351,7 @@ data FileType
 
 instance Convertible e t f m => ToValue FileType m (NValue t f m) where
   toValue =
-    toValue . makeNixStringWithoutContext .
+    toValue . mkNixStringWithoutContext .
       \case
         FileTypeRegular   -> "regular" :: Text
         FileTypeDirectory -> "directory"
@@ -654,7 +654,7 @@ matchNix pat str =
       mkMatch t =
         bool
           (toValue ()) -- Shorthand for Null
-          (toValue $ makeNixStringWithoutContext t)
+          (toValue $ mkNixStringWithoutContext t)
           (not $ Text.null t)
 
     case matchOnceText re s of
@@ -710,7 +710,7 @@ attrNamesNix
   :: forall e t f m . MonadNix e t f m => NValue t f m -> m (NValue t f m)
 attrNamesNix =
     coersion . inHask @(AttrSet (NValue t f m))
-      (fmap (makeNixStringWithoutContext . coerce) . sort . M.keys)
+      (fmap (mkNixStringWithoutContext . coerce) . sort . M.keys)
  where
   coersion = fmap (coerce :: CoerceDeeperToNValue t f m)
 
@@ -862,7 +862,7 @@ dirOfNix nvdir =
 unsafeDiscardStringContextNix
   :: MonadNix e t f m => NValue t f m -> m (NValue t f m)
 unsafeDiscardStringContextNix =
-  inHask (makeNixStringWithoutContext . stringIgnoreContext)
+  inHask (mkNixStringWithoutContext . stringIgnoreContext)
 
 -- | Evaluate `a` to WHNF to collect its topmost effect.
 seqNix
@@ -1022,7 +1022,7 @@ replaceStringsNix tfrom tto ts =
 
         --  2021-02-18: NOTE: rly?: toStrict . toLazyText
         --  Maybe `text-builder`, `text-show`?
-        finish ctx output = makeNixString (toStrict $ Builder.toLazyText output) ctx
+        finish ctx output = mkNixString (toStrict $ Builder.toLazyText output) ctx
 
         replace (key, replacementNS, unprocessedInput) = replaceWithNixBug unprocessedInput updatedOutput
 
@@ -1120,7 +1120,7 @@ toFileNix name s =
       t  = coerce $ toText @FilePath $ coerce mres
       sc = StringContext t DirectPath
 
-    toValue $ makeNixStringWithSingletonContext t sc
+    toValue $ mkNixStringWithSingletonContext t sc
 
 toPathNix :: MonadNix e t f m => NValue t f m -> m (NValue t f m)
 toPathNix = toValue @Path <=< fromValue @Path
@@ -1273,7 +1273,7 @@ scopedImportNix asetArg pathArg =
 
 getEnvNix :: MonadNix e t f m => NValue t f m -> m (NValue t f m)
 getEnvNix v =
-  (toValue . makeNixStringWithoutContext . fromMaybe mempty) =<< getEnvVar =<< fromStringNoContext =<< fromValue v
+  (toValue . mkNixStringWithoutContext . fromMaybe mempty) =<< getEnvVar =<< fromStringNoContext =<< fromValue v
 
 sortNix
   :: MonadNix e t f m
@@ -1405,11 +1405,11 @@ placeHolderNix p =
     t <- fromStringNoContext =<< fromValue p
     h <-
       coerce @(Prim m NixString) @(m NixString) $
-        (hashStringNix `on` makeNixStringWithoutContext)
+        (hashStringNix `on` mkNixStringWithoutContext)
           "sha256"
           ("nix-output:" <> t)
     toValue
-      $ makeNixStringWithoutContext
+      $ mkNixStringWithoutContext
       $ Text.cons '/'
       $ Base32.encode
       -- Please, stop Text -> Bytestring here after migration to Text
@@ -1540,7 +1540,7 @@ typeOfNix nvv =
           NVBuiltin _ _ -> "lambda"
           _             -> error "Pattern synonyms obscure complete patterns"
 
-    toValue $ makeNixStringWithoutContext detectType
+    toValue $ mkNixStringWithoutContext detectType
 
 tryEvalNix
   :: forall e t f m . MonadNix e t f m => NValue t f m -> m (NValue t f m)
@@ -1736,7 +1736,7 @@ appendContextNix tx ty =
         _x -> throwError $ ErrorCall $ "Invalid types for context value in builtins.appendContext: " <> show _x
 
   addContext ns newContextValues =
-    makeNixString
+    mkNixString
       (stringIgnoreContext ns)
       (fromNixLikeContext $
         NixLikeContext $
@@ -1750,7 +1750,7 @@ appendContextNix tx ty =
       )
 
 nixVersionNix :: MonadNix e t f m => m (NValue t f m)
-nixVersionNix = toValue $ makeNixStringWithoutContext "2.3"
+nixVersionNix = toValue $ mkNixStringWithoutContext "2.3"
 
 langVersionNix :: MonadNix e t f m => m (NValue t f m)
 langVersionNix = toValue (5 :: Int)

--- a/src/Nix/Convert.hs
+++ b/src/Nix/Convert.hs
@@ -210,7 +210,7 @@ instance ( Convertible e t f m
     \case
       NVStr' ns -> pure $ pure ns
       NVPath' p ->
-        (\path -> pure $ makeNixStringWithSingletonContext path (StringContext path DirectPath)) . fromString . coerce <$>
+        (\path -> pure $ mkNixStringWithSingletonContext path (StringContext path DirectPath)) . fromString . coerce <$>
           addPath p
       NVSet' _ s ->
         maybe
@@ -373,7 +373,7 @@ instance Convertible e t f m
 
 instance Convertible e t f m
   => ToValue ByteString m (NValue' t f m (NValue t f m)) where
-  toValue = pure . nvStr' . makeNixStringWithoutContext . decodeUtf8
+  toValue = pure . nvStr' . mkNixStringWithoutContext . decodeUtf8
 
 instance Convertible e t f m
   => ToValue Path m (NValue' t f m (NValue t f m)) where
@@ -387,7 +387,7 @@ instance ( Convertible e t f m
          )
   => ToValue SourcePos m (NValue' t f m (NValue t f m)) where
   toValue (SourcePos f l c) = do
-    f' <- toValue $ makeNixStringWithoutContext $ toText f
+    f' <- toValue $ mkNixStringWithoutContext $ toText f
     l' <- toValue $ unPos l
     c' <- toValue $ unPos c
     let pos = M.fromList [("file" :: VarName, f'), ("line", l'), ("column", c')]
@@ -439,7 +439,7 @@ instance Convertible e t f m
     allOutputs <- g nlcvAllOutputs
     outputs <- do
       let
-        outputs = makeNixStringWithoutContext <$> nlcvOutputs nlcv
+        outputs = mkNixStringWithoutContext <$> nlcvOutputs nlcv
 
       ts :: [NValue t f m] <- traverse toValue outputs
       list

--- a/src/Nix/Effects.hs
+++ b/src/Nix/Effects.hs
@@ -61,12 +61,11 @@ class
   )
   => MonadEffects t f m where
 
-  -- | Determine the absolute path of relative path in the current context
-  makeAbsolutePath :: Path -> m Path
+  -- | Determine the absolute path in the current context.
+  toAbsolutePath :: Path -> m Path
   findEnvPath :: String -> m Path
 
-  -- | Having an explicit list of sets corresponding to the NIX_PATH
-  -- and a file path try to find an existing path
+  -- | Having an explicit list of sets corresponding to the @NIX_PATH@ and a file path try to find an existing path.
   findPath :: [NValue t f m] -> Path -> m Path
 
   importPath :: Path -> m (NValue t f m)

--- a/src/Nix/Effects/Basic.hs
+++ b/src/Nix/Effects/Basic.hs
@@ -34,8 +34,8 @@ import           Nix.Value.Monad
 import           GHC.DataSize
 #endif
 
-defaultMakeAbsolutePath :: MonadNix e t f m => Path -> m Path
-defaultMakeAbsolutePath origPath = do
+defaultToAbsolutePath :: MonadNix e t f m => Path -> m Path
+defaultToAbsolutePath origPath = do
   origPathExpanded <- expandHomePath origPath
   absPath          <-
     bool
@@ -102,12 +102,12 @@ findEnvPathM name = do
  where
   nixFilePath :: MonadEffects t f m => Path -> m (Maybe Path)
   nixFilePath path = do
-    absPath <- makeAbsolutePath @t @f path
+    absPath <- toAbsolutePath @t @f path
     isDir   <- doesDirectoryExist absPath
     absFile <-
       bool
         (pure absPath)
-        (makeAbsolutePath @t @f $ coerce $ (coerce absPath) </> "default.nix")
+        (toAbsolutePath @t @f $ coerce $ (coerce absPath) </> "default.nix")
         isDir
     exists <- doesFileExist absFile
     pure $
@@ -232,7 +232,7 @@ findPathM = findPathBy existingPath
   existingPath :: MonadEffects t f m => Path -> m (Maybe Path)
   existingPath path =
     do
-      apath  <- makeAbsolutePath @t @f path
+      apath  <- toAbsolutePath @t @f path
       doesExist <- doesPathExist apath
       pure $ pure apath `whenTrue` doesExist
 

--- a/src/Nix/Effects/Derivation.hs
+++ b/src/Nix/Effects/Derivation.hs
@@ -289,9 +289,9 @@ defaultDerivationStrict val = do
     let
       outputsWithContext =
         Map.mapWithKey
-          (\out (coerce -> path) -> makeNixStringWithSingletonContext path $ StringContext drvPath $ DerivationOutput out)
+          (\out (coerce -> path) -> mkNixStringWithSingletonContext path $ StringContext drvPath $ DerivationOutput out)
           (outputs drv')
-      drvPathWithContext = makeNixStringWithSingletonContext drvPath $ StringContext drvPath AllOutputs
+      drvPathWithContext = mkNixStringWithSingletonContext drvPath $ StringContext drvPath AllOutputs
       attrSet = nvStr <$> M.fromList (("drvPath", drvPathWithContext) : Map.toList outputsWithContext)
     -- TODO: Add location information for all the entries.
     --              here --v

--- a/src/Nix/Eval.hs
+++ b/src/Nix/Eval.hs
@@ -466,7 +466,7 @@ assembleString = fromParts . stringParts
   go =
     runAntiquoted
       "\n"
-      (pure . pure . makeNixStringWithoutContext)
+      (pure . pure . mkNixStringWithoutContext)
       (fromValueMay =<<)
 
 buildArgument

--- a/src/Nix/Exec.hs
+++ b/src/Nix/Exec.hs
@@ -212,7 +212,7 @@ instance MonadNix e t f m => MonadEval (NValue t f m) m where
     scope <- currentScopes
     span  <- currentPos
     nvPathP (Provenance scope $ NLiteralPathAnnF span p) <$>
-      makeAbsolutePath @t @f @m p
+      toAbsolutePath @t @f @m p
 
   evalEnvPath p = do
     scope <- currentScopes
@@ -422,10 +422,10 @@ execBinaryOpForced scope span op lval rval = case op of
           (throwError $ ErrorCall "A string that refers to a store path cannot be appended to a path.") -- data/nix/src/libexpr/eval.cc:1412
           (\ rs2 ->
             nvPathP prov <$>
-              makeAbsolutePath @t @f (ls <> (coerce $ toString rs2))
+              toAbsolutePath @t @f (ls <> (coerce $ toString rs2))
           )
           (getStringNoContext rs)
-      (NVPath ls, NVPath rs) -> nvPathP prov <$> makeAbsolutePath @t @f (ls <> rs)
+      (NVPath ls, NVPath rs) -> nvPathP prov <$> toAbsolutePath @t @f (ls <> rs)
 
       (ls@NVSet{}, NVStr rs) ->
         (\ls2 -> nvStrP prov (ls2 <> rs)) <$>

--- a/src/Nix/Expr/Types.hs
+++ b/src/Nix/Expr/Types.hs
@@ -631,7 +631,7 @@ instance TH.Lift NExpr where
           pure [| $(TH.lift b) |]
       )
 #if MIN_VERSION_template_haskell(2,17,0)
-  liftTyped = TH.liftTyped
+  liftTyped = TH.unsafeCodeCoerce . TH.lift
 #elif MIN_VERSION_template_haskell(2,16,0)
   liftTyped = TH.unsafeTExpCoerce . TH.lift
 #endif
@@ -677,12 +677,12 @@ stripPositionInfo = transport phi
  where
   transport f (Fix x) = Fix $ transport f <$> f x
 
-  phi (NSet recur binds) = NSet recur $ go <$> binds
-  phi (NLet binds body) = NLet (go <$> binds) body
+  phi (NSet recur binds) = NSet recur $ erasePositions <$> binds
+  phi (NLet binds body) = NLet (erasePositions <$> binds) body
   phi x                 = x
 
-  go (NamedVar path r     _pos) = NamedVar path r     nullPos
-  go (Inherit  ms   names _pos) = Inherit  ms   names nullPos
+  erasePositions (NamedVar path r     _pos) = NamedVar path r     nullPos
+  erasePositions (Inherit  ms   names _pos) = Inherit  ms   names nullPos
 
 nullPos :: SourcePos
 nullPos = on (SourcePos "<string>") mkPos 1 1

--- a/src/Nix/Frames.hs
+++ b/src/Nix/Frames.hs
@@ -30,12 +30,12 @@ import           Nix.Utils                      ( Has(..)
                                                 )
 
 data NixLevel = Fatal | Error | Warning | Info | Debug
-    deriving (Ord, Eq, Bounded, Enum, Show)
+  deriving (Ord, Eq, Bounded, Enum, Show)
 
 data NixFrame = NixFrame
-    { frameLevel :: NixLevel
-    , frame      :: SomeException
-    }
+  { frameLevel :: NixLevel
+  , frame      :: SomeException
+  }
 
 instance Show NixFrame where
   show (NixFrame level f) =
@@ -46,7 +46,7 @@ type Frames = [NixFrame]
 type Framed e m = (MonadReader e m, Has e Frames, MonadThrow m)
 
 newtype NixException = NixException Frames
-    deriving Show
+  deriving Show
 
 instance Exception NixException
 

--- a/src/Nix/Fresh/Basic.hs
+++ b/src/Nix/Fresh/Basic.hs
@@ -29,7 +29,7 @@ instance MonadExec m => MonadExec (StdIdT m)
 
 instance (MonadEffects t f m, MonadDataContext f m)
   => MonadEffects t f (StdIdT m) where
-  makeAbsolutePath = lift . makeAbsolutePath @t @f @m
+  toAbsolutePath = lift . toAbsolutePath @t @f @m
   findEnvPath      = lift . findEnvPath @t @f @m
   findPath vs path = do
     i <- FreshIdT ask

--- a/src/Nix/Standard.hs
+++ b/src/Nix/Standard.hs
@@ -106,7 +106,7 @@ instance
   , MonadValue (StdValue m) m
   )
   => MonadEffects (StdThunk m) (StdCited m) m where
-  makeAbsolutePath = defaultMakeAbsolutePath
+  toAbsolutePath   = defaultToAbsolutePath
   findEnvPath      = defaultFindEnvPath
   findPath         = defaultFindPath
   importPath       = defaultImportPath

--- a/src/Nix/Standard.hs
+++ b/src/Nix/Standard.hs
@@ -142,27 +142,32 @@ instance
     :: m (StdValue m)
     -> m (StdThunk m)
   thunk = fmap coerce . thunk @(CitedStdThunk m)
+  {-# inline thunk #-}
 
   query
     :: m (StdValue m)
     ->    StdThunk m
     -> m (StdValue m)
   query b = query @(CitedStdThunk m) b . coerce
+  {-# inline query #-}
 
   force
     ::    StdThunk m
     -> m (StdValue m)
   force = force @(CitedStdThunk m) . coerce
+  {-# inline force #-}
 
   forceEff
     ::    StdThunk m
     -> m (StdValue m)
   forceEff = forceEff @(CitedStdThunk m) . coerce
+  {-# inline forceEff #-}
 
   further
     ::    StdThunk m
     -> m (StdThunk m)
   further = fmap coerce . further @(CitedStdThunk m) . coerce
+  {-# inline further #-}
 
 
 -- * @instance MonadThunkF@ (Kleisli functor HOFs)

--- a/src/Nix/Standard.hs
+++ b/src/Nix/Standard.hs
@@ -337,6 +337,7 @@ type StandardT m = Fix1T StandardTF m
 
 instance MonadTrans (Fix1T StandardTF) where
   lift = Fix1T . lift
+  {-# inline lift #-}
 
 instance MonadThunkId m
   => MonadThunkId (StandardT m) where

--- a/src/Nix/String.hs
+++ b/src/Nix/String.hs
@@ -3,7 +3,7 @@
 module Nix.String
   ( NixString
   , getContext
-  , makeNixString
+  , mkNixString
   , StringContext(..)
   , ContextFlavor(..)
   , NixLikeContext(..)
@@ -14,8 +14,8 @@ module Nix.String
   , intercalateNixString
   , getStringNoContext
   , stringIgnoreContext
-  , makeNixStringWithoutContext
-  , makeNixStringWithSingletonContext
+  , mkNixStringWithoutContext
+  , mkNixStringWithSingletonContext
   , modifyNixContents
   , WithStringContext
   , WithStringContextT(..)
@@ -127,17 +127,17 @@ instance Hashable NixString
 -- ** Makers
 
 -- | Constructs NixString without a context
-makeNixStringWithoutContext :: Text -> NixString
-makeNixStringWithoutContext = (`NixString` mempty)
+mkNixStringWithoutContext :: Text -> NixString
+mkNixStringWithoutContext = (`NixString` mempty)
 
 -- | Create NixString using a singleton context
-makeNixStringWithSingletonContext
+mkNixStringWithSingletonContext
   :: VarName -> StringContext -> NixString
-makeNixStringWithSingletonContext s c = NixString (coerce @VarName @Text s) $ one c
+mkNixStringWithSingletonContext s c = NixString (coerce @VarName @Text s) $ one c
 
 -- | Create NixString from a Text and context
-makeNixString :: Text -> S.HashSet StringContext -> NixString
-makeNixString = NixString
+mkNixString :: Text -> S.HashSet StringContext -> NixString
+mkNixString = NixString
 
 
 -- ** Checkers

--- a/src/Nix/String/Coerce.hs
+++ b/src/Nix/String/Coerce.hs
@@ -107,13 +107,13 @@ coerceToString call ctsm clevel = go
 
           v -> err v
       err v = throwError $ ErrorCall $ "Expected a string, but saw: " <> show v
-      castToNixString = pure . makeNixStringWithoutContext
+      castToNixString = pure . mkNixStringWithoutContext
 
-  nixStringUnwords = intercalateNixString $ makeNixStringWithoutContext " "
+  nixStringUnwords = intercalateNixString $ mkNixStringWithoutContext " "
 
   storePathToNixString :: StorePath -> NixString
   storePathToNixString sp =
-    makeNixStringWithSingletonContext
+    mkNixStringWithSingletonContext
       t
       (StringContext t DirectPath)
    where

--- a/src/Nix/Utils/Fix1.hs
+++ b/src/Nix/Utils/Fix1.hs
@@ -87,8 +87,11 @@ instance
   type Ref (Fix1T t m) = Ref m
 
   newRef  = lift . newRef
+  {-# inline newRef #-}
   readRef = lift . readRef
+  {-# inline readRef #-}
   writeRef r = lift . writeRef r
+  {-# inline writeRef #-}
 
 
 instance
@@ -98,6 +101,7 @@ instance
   => MonadAtomicRef (Fix1T t m)
  where
   atomicModifyRef r = lift . atomicModifyRef r
+  {-# inline atomicModifyRef #-}
 
 {-
 

--- a/src/Nix/Value.hs
+++ b/src/Nix/Value.hs
@@ -600,7 +600,7 @@ nvStr = Free . nvStr'
 nvStrWithoutContext :: Applicative f
   => Text
   -> NValue t f m
-nvStrWithoutContext = nvStr . makeNixStringWithoutContext
+nvStrWithoutContext = nvStr . mkNixStringWithoutContext
 
 
 -- | Life of a Haskell FilePath to the life of a Nix path


### PR DESCRIPTION
  * `String`: reduce (make -> mk) for the sake of unification of maker names
it is around #406, but the topic needs work.
  * `Effects`: `class MonadEffects`: `(make -> to)AbsolutePath`
  * `Standard`: `{StdCited, StdThunk}` rm newtype accessor
  * noticed that `Standard`: `instance MonadValue (StdValue m) m` recurses on itself, so closed the recursion
  * `Expr`: `Types`: `TH.Lift NExpr`: TH 2.17: fx `liftTyped`
  * `Eval`: `evalSelect`: `extract`: one of the most used functions, so optimizing it a bit