### PR TITLE
clean-up & refactors; enabling some tests; specializing Path functions

### DIFF
--- a/hnix.cabal
+++ b/hnix.cabal
@@ -464,7 +464,7 @@ library
     , time >= 1.8.0 && < 1.9 || >= 1.9.3 && < 1.10
     , transformers >= 0.5.5 && < 0.6
     , transformers-base >= 0.4.5 && < 0.5
-    , unix >= 2.7.2 && < 2.8
+    , unix-compat >= 0.4.3 && < 0.6
     , unordered-containers >= 0.2.9 && < 0.3
     , vector >= 0.12.0 && < 0.13
     , xml >= 1.3.14 && < 1.4
@@ -613,7 +613,7 @@ test-suite hnix-tests
     , serialise
     , template-haskell
     , time
-    , unix
+    , unix-compat
   default-extensions:
       OverloadedStrings
     , DeriveGeneric

--- a/main/Main.hs
+++ b/main/Main.hs
@@ -73,7 +73,8 @@ main' opts@Options{..} = runWithBasicEffectsIO opts execContentsFilesOrRepl
           expr <- liftIO Text.getContents
           processExpr expr
 
-    processSeveralFiles files = traverse_ processFile files
+    processSeveralFiles :: [Path] -> StandardT (StdIdT IO) ()
+    processSeveralFiles = traverse_ processFile
      where
       processFile path = handleResult (pure path) =<< parseNixFileLoc path
 

--- a/main/Main.hs
+++ b/main/Main.hs
@@ -32,8 +32,6 @@ import           Options.Applicative     hiding ( ParserResult(..) )
 import           Prettyprinter           hiding ( list )
 import           Prettyprinter.Render.Text      ( renderIO )
 import qualified Repl
-import           System.FilePath                (replaceExtension
-                                                )
 import           Nix.Eval
 
 main :: IO ()

--- a/main/Main.hs
+++ b/main/Main.hs
@@ -32,7 +32,8 @@ import           Options.Applicative     hiding ( ParserResult(..) )
 import           Prettyprinter           hiding ( list )
 import           Prettyprinter.Render.Text      ( renderIO )
 import qualified Repl
-import           System.FilePath
+import           System.FilePath                (replaceExtension
+                                                )
 import           Nix.Eval
 
 main :: IO ()

--- a/main/Main.hs
+++ b/main/Main.hs
@@ -80,7 +80,7 @@ main' opts@Options{..} = runWithBasicEffectsIO opts execContentsFilesOrRepl
     loadBinaryCacheFile =
       (\ (binaryCacheFile :: Path) ->
         do
-          let file = coerce $ (replaceExtension . coerce) binaryCacheFile "nixc"
+          let file = replaceExtension binaryCacheFile "nixc"
           processCLIOptions (Just file) =<< liftIO (readCache binaryCacheFile)
       ) <$> readFrom
 
@@ -160,7 +160,7 @@ main' opts@Options{..} = runWithBasicEffectsIO opts execContentsFilesOrRepl
     | xml                        = fail "Rendering expression trees to XML is not yet implemented"
     | json                       = fail "Rendering expression trees to JSON is not implemented"
     | verbose >= DebugInfo       =  liftIO . putStr . ppShow . stripAnnotation $ expr
-    | cache , Just path <- mpath =  liftIO . writeCache (coerce $ replaceExtension (coerce path) "nixc") $ expr
+    | cache , Just path <- mpath =  liftIO . writeCache (replaceExtension path "nixc") $ expr
     | parseOnly                  =  void . liftIO . Exception.evaluate . force $ expr
     | otherwise                  =
       liftIO .

--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -72,7 +72,6 @@ import           Nix.Value.Monad
 import           Nix.XML
 import           System.Nix.Base32             as Base32
 import           System.FilePath                ( isAbsolute
-                                                , takeFileName
                                                 , takeDirectory
                                                 , (</>)
                                                 )

--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -71,7 +71,11 @@ import           Nix.Value.Equal
 import           Nix.Value.Monad
 import           Nix.XML
 import           System.Nix.Base32             as Base32
-import           System.FilePath
+import           System.FilePath                ( isAbsolute
+                                                , takeFileName
+                                                , takeDirectory
+                                                , (</>)
+                                                )
 import           System.PosixCompat.Files       ( isRegularFile
                                                 , isDirectory
                                                 , isSymbolicLink

--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -1283,7 +1283,7 @@ scopedImportNix asetArg pathArg =
             p' <- fromValue @Path =<< demand res
 
             traceM $ "Current file being evaluated is: " <> show p'
-            pure $ coerce $ coerce takeDirectory p' </> coerce path
+            pure $ takeDirectory p' </> path
         )
         =<< lookupVar "__cur_file"
 
@@ -1485,7 +1485,7 @@ readDirNix nvpath =
       detectFileTypes :: Path -> m (VarName, FileType)
       detectFileTypes item =
         do
-          s <- getSymbolicLinkStatus $ coerce $ on (</>) coerce path item
+          s <- getSymbolicLinkStatus $ path </> item
           let
             t =
               if

--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -875,8 +875,8 @@ dirOfNix nvdir =
     dir <- demand nvdir
 
     case dir of
-      NVStr ns -> pure $ nvStr $ modifyNixContents (fromString . takeDirectory . toString) ns
-      NVPath path -> pure $ nvPath $ coerce $ takeDirectory $ coerce path
+      NVStr ns -> pure $ nvStr $ modifyNixContents (fromString . coerce takeDirectory . toString) ns
+      NVPath path -> pure $ nvPath $ takeDirectory path
       v -> throwError $ ErrorCall $ "dirOf: expected string or path, got " <> show v
 
 -- jww (2018-04-28): This should only be a string argument, and not coerced?
@@ -1283,7 +1283,7 @@ scopedImportNix asetArg pathArg =
             p' <- fromValue @Path =<< demand res
 
             traceM $ "Current file being evaluated is: " <> show p'
-            pure $ coerce $ takeDirectory (coerce p') </> coerce path
+            pure $ coerce $ coerce takeDirectory p' </> coerce path
         )
         =<< lookupVar "__cur_file"
 

--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -821,7 +821,7 @@ baseNameOfNix x =
     pure $
       nvStr $
         modifyNixContents
-          (fromString . takeFileName . toString)
+          (fromString . coerce takeFileName . toString)
           ns
 
 bitAndNix

--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -353,10 +353,10 @@ absolutePathFromValue =
     NVStr ns ->
       do
         let
-          path = toString $ stringIgnoreContext ns
+          path = coerce . toString $ stringIgnoreContext ns
 
         unless (isAbsolute path) $ throwError $ ErrorCall $ "string " <> show path <> " doesn't represent an absolute path"
-        pure $ coerce path
+        pure path
 
     NVPath path -> pure path
     v           -> throwError $ ErrorCall $ "expected a path, got " <> show v

--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -288,24 +288,26 @@ compareVersions s1 s2 =
 
 splitDrvName :: Text -> (Text, Text)
 splitDrvName s =
-  let
-    sep    = "-"
-    pieces = Text.splitOn sep s
-    isFirstVersionPiece p =
-      case Text.uncons p of
-        Just (h, _) -> isDigit h
-        _           -> False
-    -- Like 'break', but always puts the first item into the first result
-    -- list
-    breakAfterFirstItem :: (a -> Bool) -> [a] -> ([a], [a])
-    breakAfterFirstItem f =
-      list
-        (mempty, mempty)
-        (\ (h : t) -> let (a, b) = break f t in (h : a, b))
-    (namePieces, versionPieces) =
-      breakAfterFirstItem isFirstVersionPiece pieces
-  in
   (Text.intercalate sep namePieces, Text.intercalate sep versionPieces)
+ where
+  sep    = "-"
+  pieces :: [Text]
+  pieces = Text.splitOn sep s
+  isFirstVersionPiece :: Text -> Bool
+  isFirstVersionPiece p =
+    maybe
+      False
+      (isDigit . fst)
+      (Text.uncons p)
+  -- Like 'break', but always puts the first item into the first result
+  -- list
+  breakAfterFirstItem :: (a -> Bool) -> [a] -> ([a], [a])
+  breakAfterFirstItem f =
+    list
+      (mempty, mempty)
+      (\ (h : t) -> let (a, b) = break f t in (h : a, b))
+  (namePieces, versionPieces) =
+    breakAfterFirstItem isFirstVersionPiece pieces
 
 splitMatches
   :: forall e t f m

--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -237,9 +237,6 @@ data VersionComponent
   | VersionComponentNumber !Integer -- ^ A number
   deriving (Read, Eq, Ord)
 
--- | Based on https://github.com/NixOS/nix/blob/4ee4fda521137fed6af0446948b3877e0c5db803/src/libexpr/names.cc#L44
-versionComponentSeparators :: String
-versionComponentSeparators = ".-"
 instance Show VersionComponent where
   show =
     \case
@@ -273,6 +270,11 @@ splitVersion s =
               x     -> VersionComponentString x
         in
         thisComponent : splitVersion rest
+ where
+  -- | Based on https://github.com/NixOS/nix/blob/4ee4fda521137fed6af0446948b3877e0c5db803/src/libexpr/names.cc#L44
+  versionComponentSeparators :: String
+  versionComponentSeparators = ".-"
+
 
 compareVersions :: Text -> Text -> Ordering
 compareVersions s1 s2 =

--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -71,8 +71,6 @@ import           Nix.Value.Equal
 import           Nix.Value.Monad
 import           Nix.XML
 import           System.Nix.Base32             as Base32
-import           System.FilePath                ( takeDirectory
-                                                )
 import           System.PosixCompat.Files       ( isRegularFile
                                                 , isDirectory
                                                 , isSymbolicLink

--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -71,8 +71,7 @@ import           Nix.Value.Equal
 import           Nix.Value.Monad
 import           Nix.XML
 import           System.Nix.Base32             as Base32
-import           System.FilePath                ( isAbsolute
-                                                , takeDirectory
+import           System.FilePath                ( takeDirectory
                                                 , (</>)
                                                 )
 import           System.PosixCompat.Files       ( isRegularFile

--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -76,6 +76,7 @@ import           System.PosixCompat.Files       ( isRegularFile
                                                 , isDirectory
                                                 , isSymbolicLink
                                                 )
+import qualified Text.Show
 import           Text.Regex.TDFA                ( Regex
                                                 , makeRegex
                                                 , matchOnceText
@@ -234,18 +235,17 @@ data VersionComponent
   = VersionComponentPre -- ^ The string "pre"
   | VersionComponentString !Text -- ^ A string other than "pre"
   | VersionComponentNumber !Integer -- ^ A number
-  deriving (Show, Read, Eq, Ord)
-
-versionComponentToString :: VersionComponent -> Text
-versionComponentToString =
-  \case
-    VersionComponentPre      -> "pre"
-    VersionComponentString s -> s
-    VersionComponentNumber n -> show n
+  deriving (Read, Eq, Ord)
 
 -- | Based on https://github.com/NixOS/nix/blob/4ee4fda521137fed6af0446948b3877e0c5db803/src/libexpr/names.cc#L44
 versionComponentSeparators :: String
 versionComponentSeparators = ".-"
+instance Show VersionComponent where
+  show =
+    \case
+      VersionComponentPre      -> "pre"
+      VersionComponentString s -> show s
+      VersionComponentNumber n -> show n
 
 splitVersion :: Text -> [VersionComponent]
 splitVersion s =
@@ -598,7 +598,7 @@ splitVersionNix v =
     version <- fromStringNoContext =<< fromValue v
     pure $
       nvList $
-        nvStrWithoutContext . versionComponentToString <$>
+        nvStrWithoutContext . show <$>
           splitVersion version
 
 compareVersionsNix

--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -72,7 +72,7 @@ import           Nix.Value.Monad
 import           Nix.XML
 import           System.Nix.Base32             as Base32
 import           System.FilePath
-import           System.Posix.Files             ( isRegularFile
+import           System.PosixCompat.Files       ( isRegularFile
                                                 , isDirectory
                                                 , isSymbolicLink
                                                 )

--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -72,7 +72,6 @@ import           Nix.Value.Monad
 import           Nix.XML
 import           System.Nix.Base32             as Base32
 import           System.FilePath                ( takeDirectory
-                                                , (</>)
                                                 )
 import           System.PosixCompat.Files       ( isRegularFile
                                                 , isDirectory

--- a/src/Nix/Effects.hs
+++ b/src/Nix/Effects.hs
@@ -437,7 +437,7 @@ addPath p =
   either
     throwError
     pure
-    =<< addToStore (fromString $ takeFileName (coerce p)) p True False
+    =<< addToStore (fromString $ coerce takeFileName p) p True False
 
 toFile_ :: (Framed e m, MonadStore m) => Path -> Text -> m StorePath
 toFile_ p contents = addTextToStore (toText p) contents mempty False

--- a/src/Nix/Effects.hs
+++ b/src/Nix/Effects.hs
@@ -263,7 +263,7 @@ class
 -- ** Instances
 
 instance MonadPaths IO where
-  getDataDir = coerce <$> Paths_hnix.getDataDir
+  getDataDir = coerce Paths_hnix.getDataDir
 
 deriving
   instance

--- a/src/Nix/Effects.hs
+++ b/src/Nix/Effects.hs
@@ -103,7 +103,7 @@ instance MonadIntrospect IO where
 #ifdef MIN_VERSION_ghc_datasize
     recursiveSize
 #else
-    \_ -> pure 0
+    const $ pure 0
 #endif
 
 deriving

--- a/src/Nix/Effects.hs
+++ b/src/Nix/Effects.hs
@@ -30,7 +30,6 @@ import           Nix.Render
 import           Nix.Value
 import qualified Paths_hnix
 import           System.Exit
-import           System.FilePath                ( takeFileName )
 import qualified System.Info
 import           System.Process
 

--- a/src/Nix/Effects/Basic.hs
+++ b/src/Nix/Effects/Basic.hs
@@ -10,7 +10,7 @@ import           Control.Monad                  ( foldM )
 import qualified Data.HashMap.Lazy             as M
 import           Data.List.Split                ( splitOn )
 import qualified Data.Text                     as Text
-import           Data.Text.Prettyprint.Doc      ( fillSep )
+import           Prettyprinter                  ( fillSep )
 import           System.FilePath
 import           Nix.Convert
 import           Nix.Effects

--- a/src/Nix/Effects/Basic.hs
+++ b/src/Nix/Effects/Basic.hs
@@ -12,7 +12,6 @@ import           Data.List.Split                ( splitOn )
 import qualified Data.Text                     as Text
 import           Prettyprinter                  ( fillSep )
 import           System.FilePath                ( takeDirectory
-                                                , isAbsolute
                                                 , splitDirectories
                                                 , (</>)
                                                 , joinPath

--- a/src/Nix/Effects/Basic.hs
+++ b/src/Nix/Effects/Basic.hs
@@ -11,8 +11,6 @@ import qualified Data.HashMap.Lazy             as M
 import           Data.List.Split                ( splitOn )
 import qualified Data.Text                     as Text
 import           Prettyprinter                  ( fillSep )
-import           System.FilePath                ( joinPath
-                                                )
 import           Nix.Convert
 import           Nix.Effects
 import           Nix.Exec                       ( MonadNix

--- a/src/Nix/Effects/Basic.hs
+++ b/src/Nix/Effects/Basic.hs
@@ -11,7 +11,12 @@ import qualified Data.HashMap.Lazy             as M
 import           Data.List.Split                ( splitOn )
 import qualified Data.Text                     as Text
 import           Prettyprinter                  ( fillSep )
-import           System.FilePath
+import           System.FilePath                ( takeDirectory
+                                                , isAbsolute
+                                                , splitDirectories
+                                                , (</>)
+                                                , joinPath
+                                                )
 import           Nix.Convert
 import           Nix.Effects
 import           Nix.Exec                       ( MonadNix

--- a/src/Nix/Effects/Basic.hs
+++ b/src/Nix/Effects/Basic.hs
@@ -71,13 +71,13 @@ removeDotDotIndirections = coerce . intercalate "/" . go mempty . splitOn "/" . 
 
 infixr 9 <///>
 (<///>) :: Path -> Path -> Path
-(coerce -> x) <///> y
-  | isAbsolute y || "." `isPrefixOf` coerce y = coerce $ x </> coerce y
+x <///> y
+  | isAbsolute y || "." `isPrefixOf` coerce y = coerce $ coerce x </> coerce y
   | otherwise                          = joinByLargestOverlap x y
  where
-  joinByLargestOverlap :: FilePath -> Path -> Path
-  joinByLargestOverlap (splitDirectories -> xs) (splitDirectories . coerce -> ys) =
-    joinPath $ coerce $ head
+  joinByLargestOverlap :: Path -> Path -> Path
+  joinByLargestOverlap (splitDirectories -> xs) (splitDirectories -> ys) =
+    joinPath $ head
       [ xs <> drop (length tx) ys | tx <- tails xs, tx `elem` inits ys ]
 
 defaultFindEnvPath :: MonadNix e t f m => String -> m Path

--- a/src/Nix/Effects/Basic.hs
+++ b/src/Nix/Effects/Basic.hs
@@ -43,7 +43,7 @@ defaultToAbsolutePath origPath = do
             getCurrentDirectory
             (
               (\case
-                NVPath s -> pure $ coerce takeDirectory s
+                NVPath s -> pure $ takeDirectory s
                 val -> throwError $ ErrorCall $ "when resolving relative path, __cur_file is in scope, but is not a path; it is: " <> show val
               ) <=< demand
             )

--- a/src/Nix/Effects/Basic.hs
+++ b/src/Nix/Effects/Basic.hs
@@ -72,7 +72,7 @@ removeDotDotIndirections = coerce . intercalate "/" . go mempty . splitOn "/" . 
 infixr 9 <///>
 (<///>) :: Path -> Path -> Path
 x <///> y
-  | isAbsolute y || "." `isPrefixOf` coerce y = coerce $ coerce x </> coerce y
+  | isAbsolute y || "." `isPrefixOf` coerce y = x </> y
   | otherwise                          = joinByLargestOverlap x y
  where
   joinByLargestOverlap :: Path -> Path -> Path
@@ -103,7 +103,7 @@ findEnvPathM name =
     absFile <-
       bool
         (pure absPath)
-        (toAbsolutePath @t @f $ coerce $ coerce absPath </> "default.nix")
+        (toAbsolutePath @t @f $ absPath </> "default.nix")
         isDir
     exists <- doesFileExist absFile
     pure $ pure absFile `whenTrue` exists
@@ -259,9 +259,10 @@ defaultPathToDefaultNix = pathToDefaultNixFile
 
 -- Given a path, determine the nix file to load
 pathToDefaultNixFile :: MonadFile m => Path -> m Path
-pathToDefaultNixFile p = do
-  isDir <- doesDirectoryExist p
-  pure $ coerce $ coerce p </> "default.nix" `whenTrue` isDir
+pathToDefaultNixFile p =
+  do
+    isDir <- doesDirectoryExist p
+    pure $ p </> "default.nix" `whenTrue` isDir
 
 defaultTraceEffect :: MonadPutStr m => String -> m ()
 defaultTraceEffect = Nix.Effects.putStrLn

--- a/src/Nix/Effects/Basic.hs
+++ b/src/Nix/Effects/Basic.hs
@@ -76,8 +76,8 @@ infixr 9 <///>
   | otherwise                          = joinByLargestOverlap x y
  where
   joinByLargestOverlap :: FilePath -> Path -> Path
-  joinByLargestOverlap (splitDirectories -> xs) (splitDirectories . coerce -> ys) = coerce $
-    joinPath $ head
+  joinByLargestOverlap (splitDirectories -> xs) (splitDirectories . coerce -> ys) =
+    joinPath $ coerce $ head
       [ xs <> drop (length tx) ys | tx <- tails xs, tx `elem` inits ys ]
 
 defaultFindEnvPath :: MonadNix e t f m => String -> m Path
@@ -150,7 +150,7 @@ findPathBy finder ls name = do
 
   tryPath :: Path -> Maybe Path -> m (Maybe Path)
   tryPath p (Just n) | n' : ns <- splitDirectories (coerce name), n == coerce n' =
-    finder $ p <///> coerce (joinPath ns)
+    finder $ p <///> coerce joinPath ns
   tryPath p _ = finder $ p <///> name
 
   resolvePath s =

--- a/src/Nix/Effects/Basic.hs
+++ b/src/Nix/Effects/Basic.hs
@@ -11,8 +11,7 @@ import qualified Data.HashMap.Lazy             as M
 import           Data.List.Split                ( splitOn )
 import qualified Data.Text                     as Text
 import           Prettyprinter                  ( fillSep )
-import           System.FilePath                ( takeDirectory
-                                                , splitDirectories
+import           System.FilePath                ( splitDirectories
                                                 , joinPath
                                                 )
 import           Nix.Convert

--- a/src/Nix/Effects/Basic.hs
+++ b/src/Nix/Effects/Basic.hs
@@ -13,7 +13,6 @@ import qualified Data.Text                     as Text
 import           Prettyprinter                  ( fillSep )
 import           System.FilePath                ( takeDirectory
                                                 , splitDirectories
-                                                , (</>)
                                                 , joinPath
                                                 )
 import           Nix.Convert

--- a/src/Nix/Effects/Basic.hs
+++ b/src/Nix/Effects/Basic.hs
@@ -11,8 +11,7 @@ import qualified Data.HashMap.Lazy             as M
 import           Data.List.Split                ( splitOn )
 import qualified Data.Text                     as Text
 import           Prettyprinter                  ( fillSep )
-import           System.FilePath                ( splitDirectories
-                                                , joinPath
+import           System.FilePath                ( joinPath
                                                 )
 import           Nix.Convert
 import           Nix.Effects

--- a/src/Nix/Effects/Basic.hs
+++ b/src/Nix/Effects/Basic.hs
@@ -51,7 +51,7 @@ defaultToAbsolutePath origPath = do
         pure $ cwd <///> origPathExpanded
       )
       (pure origPathExpanded)
-      (isAbsolute $ coerce origPathExpanded)
+      (isAbsolute origPathExpanded)
   removeDotDotIndirections <$> canonicalizePath absPath
 
 expandHomePath :: MonadFile m => Path -> m Path
@@ -71,11 +71,12 @@ removeDotDotIndirections = coerce . intercalate "/" . go mempty . splitOn "/" . 
 
 infixr 9 <///>
 (<///>) :: Path -> Path -> Path
-(coerce -> x) <///> (coerce -> y)
-  | isAbsolute y || "." `isPrefixOf` y = coerce $ x </> y
+(coerce -> x) <///> y
+  | isAbsolute y || "." `isPrefixOf` coerce y = coerce $ x </> coerce y
   | otherwise                          = joinByLargestOverlap x y
  where
-  joinByLargestOverlap (splitDirectories -> xs) (splitDirectories -> ys) = coerce $
+  joinByLargestOverlap :: FilePath -> Path -> Path
+  joinByLargestOverlap (splitDirectories -> xs) (splitDirectories . coerce -> ys) = coerce $
     joinPath $ head
       [ xs <> drop (length tx) ys | tx <- tails xs, tx `elem` inits ys ]
 

--- a/src/Nix/Eval.hs
+++ b/src/Nix/Eval.hs
@@ -180,21 +180,20 @@ eval (NAbs    params body) = do
   -- needs to be used when evaluating the body and default arguments, hence we
   -- defer here so the present scope is restored when the parameters and body
   -- are forced during application.
-  scopes <- currentScopes
+  curScope <- currentScopes
   let
-    withScope = withScopes scopes
-    withScopeInform = withScope . inform
+    withCurScope = withScopes curScope
 
   evalAbs
     params
     (\arg k ->
-      withScope $
+      withCurScope $
         do
-          (coerce -> scope) <- buildArgument params arg
+          (coerce -> newScope) <- buildArgument params arg
           pushScope
-            scope $
+            newScope $
             k
-              (withScopeInform <$> coerce scope)
+              (coerce $ withCurScope . inform <$> newScope)
               body
     )
 

--- a/src/Nix/Exec.hs
+++ b/src/Nix/Exec.hs
@@ -167,7 +167,7 @@ instance MonadNix e t f m => MonadEval (NValue t f m) m where
         )
         ms
        where
-        attr = Text.intercalate "." $ NE.toList $ coerce <$> ks
+        attr = Text.intercalate "." $ NE.toList $ coerce ks
 
   evalCurPos = do
     scope                  <- currentScopes

--- a/src/Nix/Lint.hs
+++ b/src/Nix/Lint.hs
@@ -324,7 +324,7 @@ instance MonadLint e m => MonadEval (Symbolic m) m where
         (\ s ->  "Could not look up attribute " <> attr <> " in " <> show s)
         ms
    where
-    attr = Text.intercalate "." $ NE.toList $ coerce <$> ks
+    attr = Text.intercalate "." $ NE.toList $ coerce ks
 
   evalCurPos = do
     f <- mkSymbolic [TPath]

--- a/src/Nix/Parser.hs
+++ b/src/Nix/Parser.hs
@@ -359,7 +359,7 @@ identifier =
   identLetter x = isAlphanumeric x || x == '_' || x == '\'' || x == '-'
 
 nixSym :: Parser NExprLoc
-nixSym = annotateLocation $ mkSymF . coerce <$> identifier
+nixSym = annotateLocation $ mkSymF <$> coerce identifier
 
 
 -- ** ( ) parens
@@ -822,7 +822,7 @@ nixSelect term =
 -- ** _ - syntax hole
 
 nixSynHole :: Parser NExprLoc
-nixSynHole = annotateLocation $ mkSynHoleF . coerce <$> (char '^' *> identifier)
+nixSynHole = annotateLocation $ mkSynHoleF <$> coerce (char '^' *> identifier)
 
 
 -- ** Expr & its constituents (Language term, expr algebra)

--- a/src/Nix/Parser.hs
+++ b/src/Nix/Parser.hs
@@ -812,11 +812,10 @@ nixSelect term =
       , Maybe NExprLoc
       )
     -> NExprLoc
-  build t mexpr =
+  build t =
     maybe
       t
       (\ (a, m) -> (`annNSelect` t) m a)
-      mexpr
 
 
 -- ** _ - syntax hole

--- a/src/Nix/Parser.hs
+++ b/src/Nix/Parser.hs
@@ -249,13 +249,13 @@ nixUri =
         do
           start    <- letterChar
           protocol <-
-            takeWhileP Nothing $
+            takeWhileP mempty $
               \ x ->
                 isAlphanumeric x
                 || (`elem` ("+-." :: String)) x
           _       <- single ':'
           address <-
-            takeWhile1P Nothing $
+            takeWhile1P mempty $
                 \ x ->
                   isAlphanumeric x
                   || (`elem` ("%/?:@&=+$,-_.!~*'" :: String)) x
@@ -431,12 +431,12 @@ pathStr :: Parser Path
 pathStr =
   lexeme $ coerce . toString <$>
     liftA2 (<>)
-      (takeWhileP Nothing pathChar)
+      (takeWhileP mempty pathChar)
       (Text.concat <$>
         some
           (liftA2 Text.cons
             slash
-            (takeWhile1P Nothing pathChar)
+            (takeWhile1P mempty pathChar)
           )
       )
 
@@ -491,7 +491,6 @@ opWithLoc f op name =
   do
     AnnUnit ann _ <-
       annotateLocation1 $
-        {- dbg (toString name) $ -}
         operator name
 
     pure . f $ AnnUnit ann op
@@ -640,6 +639,7 @@ getBinaryOperator = detectPrecedence spec
     \case
       (NBinaryDef assoc op name, _) -> [(op, OperatorInfo i assoc name)]
       _                             -> mempty
+
 getSpecialOperator :: NSpecialOp -> OperatorInfo
 getSpecialOperator NSelectOp = OperatorInfo 1 NAssocLeft "."
 getSpecialOperator o         = detectPrecedence spec o

--- a/src/Nix/Parser.hs
+++ b/src/Nix/Parser.hs
@@ -862,8 +862,6 @@ nixExprAlgebra =
       nixOperators nixSelector
     )
 
--- | Nix term parser.
--- | Term is a language unit on the level where precedence and associativity matters.
 nixExpr :: Parser NExprLoc
 nixExpr = keywords <|> nixLambda <|> nixExprAlgebra
  where

--- a/src/Nix/Reduce.hs
+++ b/src/Nix/Reduce.hs
@@ -50,7 +50,9 @@ import           Nix.Options                    ( Options
 import           Nix.Parser
 import           Nix.Scope
 import           System.Directory
-import           System.FilePath
+import           System.FilePath                ( (</>)
+                                                , takeDirectory
+                                                )
 
 newtype Reducer m a = Reducer
     { runReducer ::

--- a/src/Nix/Reduce.hs
+++ b/src/Nix/Reduce.hs
@@ -50,8 +50,6 @@ import           Nix.Options                    ( Options
 import           Nix.Parser
 import           Nix.Scope
 import           System.Directory
-import           System.FilePath                ( takeDirectory
-                                                )
 
 newtype Reducer m a = Reducer
     { runReducer ::

--- a/src/Nix/Reduce.hs
+++ b/src/Nix/Reduce.hs
@@ -85,10 +85,10 @@ staticImport
   -> m NExprLoc
 staticImport pann path =
   do
-    mfile <- asks (coerce . fst)
+    mfile <- asks fst
     path'  <- liftIO $ pathToDefaultNixFile path
     path'' <- liftIO $ pathToDefaultNixFile =<< coerce canonicalizePath
-      (maybe id ((</>) . takeDirectory) mfile (coerce path'))
+      (maybe id ((</>) . coerce takeDirectory) mfile (coerce path'))
 
     let
       importIt :: m NExprLoc

--- a/src/Nix/Reduce.hs
+++ b/src/Nix/Reduce.hs
@@ -88,7 +88,7 @@ staticImport pann path =
     mfile <- asks fst
     path'  <- liftIO $ pathToDefaultNixFile path
     path'' <- liftIO $ pathToDefaultNixFile =<< coerce canonicalizePath
-      (maybe id ((</>) . coerce takeDirectory) mfile (coerce path'))
+      (maybe id ((</>) . takeDirectory) mfile path')
 
     let
       importIt :: m NExprLoc

--- a/src/Nix/Reduce.hs
+++ b/src/Nix/Reduce.hs
@@ -308,7 +308,7 @@ reduce e@(NIfAnnF _ b t f) =
 --   symbol if the assertion is a boolean constant.
 reduce e@(NAssertAnnF _ b body) =
   (\case
-    NConstantAnn _ (NBool b') | b' -> body
+    NConstantAnn _ (NBool True) -> body
     _ -> reduceLayer e
   ) =<< b
 

--- a/src/Nix/Reduce.hs
+++ b/src/Nix/Reduce.hs
@@ -50,8 +50,7 @@ import           Nix.Options                    ( Options
 import           Nix.Parser
 import           Nix.Scope
 import           System.Directory
-import           System.FilePath                ( (</>)
-                                                , takeDirectory
+import           System.FilePath                ( takeDirectory
                                                 )
 
 newtype Reducer m a = Reducer

--- a/src/Nix/Render.hs
+++ b/src/Nix/Render.hs
@@ -11,11 +11,12 @@ module Nix.Render where
 
 import qualified Data.Set                      as Set
 import           Nix.Utils.Fix1                 ( Fix1T
-                                                , MonadFix1T )
+                                                , MonadFix1T
+                                                )
 import           Nix.Expr.Types.Annotated
 import           Prettyprinter
 import qualified System.Directory              as S
-import qualified System.Posix.Files            as S
+import qualified System.PosixCompat.Files      as S
 import           Text.Megaparsec.Error
 import           Text.Megaparsec.Pos
 import qualified Data.Text                     as Text
@@ -67,7 +68,7 @@ posAndMsg :: SourcePos -> Doc a -> ParseError s Void
 posAndMsg (SourcePos _ lineNo _) msg =
   FancyError
     (unPos lineNo)
-    (Set.fromList [ErrorFail (show msg) :: ErrorFancy Void])
+    (Set.fromList $ one (ErrorFail (show msg) :: ErrorFancy Void))
 
 renderLocation :: MonadFile m => SrcSpan -> Doc a -> m (Doc a)
 renderLocation (SrcSpan (SourcePos (coerce -> file) begLine begCol) (SourcePos (coerce -> file') endLine endCol)) msg

--- a/src/Nix/Render.hs
+++ b/src/Nix/Render.hs
@@ -52,14 +52,14 @@ class (MonadFail m, MonadIO m) => MonadFile m where
 
 instance MonadFile IO where
   readFile              = Prelude.readFile
-  listDirectory         = coerce <$> (S.listDirectory . coerce)
-  getCurrentDirectory   = coerce <$> S.getCurrentDirectory
-  canonicalizePath      = coerce <$> (S.canonicalizePath . coerce)
-  getHomeDirectory      = coerce <$> S.getHomeDirectory
-  doesPathExist         = S.doesPathExist . coerce
-  doesFileExist         = S.doesFileExist . coerce
-  doesDirectoryExist    = S.doesDirectoryExist . coerce
-  getSymbolicLinkStatus = S.getSymbolicLinkStatus . coerce
+  listDirectory         = coerce S.listDirectory
+  getCurrentDirectory   = coerce S.getCurrentDirectory
+  canonicalizePath      = coerce S.canonicalizePath
+  getHomeDirectory      = coerce S.getHomeDirectory
+  doesPathExist         = coerce S.doesPathExist
+  doesFileExist         = coerce S.doesFileExist
+  doesDirectoryExist    = coerce S.doesDirectoryExist
+  getSymbolicLinkStatus = coerce S.getSymbolicLinkStatus
 
 
 instance (MonadFix1T t m, MonadIO (Fix1T t m), MonadFail (Fix1T t m), MonadFile m) => MonadFile (Fix1T t m)
@@ -72,21 +72,21 @@ posAndMsg (SourcePos _ lineNo _) msg =
 
 renderLocation :: MonadFile m => SrcSpan -> Doc a -> m (Doc a)
 renderLocation (SrcSpan (SourcePos (coerce -> file) begLine begCol) (SourcePos (coerce -> file') endLine endCol)) msg
-  | file == file' && file == "<string>" && begLine == endLine
-  = pure $ "In raw input string at position " <> pretty (unPos begCol)
+  | file == file' && file == "<string>" && begLine == endLine =
+    pure $ "In raw input string at position " <> pretty (unPos begCol)
 
-  | file /= "<string>" && file == file'
-  = do
-    exist <- doesFileExist file
-    if exist
-      then do
+  | file /= "<string>" && file == file' =
+    bool
+      (pure msg)
+      (do
         txt <- sourceContext file begLine begCol endLine endCol msg
         pure $
           vsep
             [ "In file " <> errorContext file begLine begCol endLine endCol <> ":"
             , txt
             ]
-      else pure msg
+      )
+      =<< doesFileExist file
 renderLocation (SrcSpan beg end) msg = fail $ "Don't know how to render range from " <> show beg <>" to " <> show end <>" for fail: " <> show msg
 
 errorContext :: Path -> Pos -> Pos -> Pos -> Pos -> Doc a
@@ -133,4 +133,4 @@ sourceContext path (unPos -> begLine) (unPos -> _begCol) (unPos -> endLine) (unP
 
       ls' = concat $ zipWith composeLine [beg' ..] ls
 
-    pure $ vsep $ ls' <> [ indent (Text.length $ pad begLine) msg ]
+    pure $ vsep $ ls' <> one (indent (Text.length $ pad begLine) msg)

--- a/src/Nix/Scope.hs
+++ b/src/Nix/Scope.hs
@@ -23,9 +23,6 @@ newtype Scope a = Scope (AttrSet a)
 instance Show (Scope a) where
   show (Scope m) = show $ M.keys m
 
-newScope :: AttrSet a -> Scope a
-newScope = coerce
-
 scopeLookup :: VarName -> [Scope a] -> Maybe a
 scopeLookup key = foldr go Nothing
  where

--- a/src/Nix/Scope.hs
+++ b/src/Nix/Scope.hs
@@ -79,7 +79,7 @@ pushScope
   => Scope a
   -> m r
   -> m r
-pushScope scope = pushScopes $ Scopes [scope] mempty
+pushScope scope = pushScopes $ Scopes (one scope) mempty
 
 pushWeakScope
   :: ( Functor m
@@ -88,7 +88,7 @@ pushWeakScope
   => m (Scope a)
   -> m r
   -> m r
-pushWeakScope scope = pushScopes $ Scopes mempty [scope]
+pushWeakScope scope = pushScopes $ Scopes mempty $ one scope
 
 pushScopesReader
   :: ( MonadReader e m

--- a/src/Nix/Standard.hs
+++ b/src/Nix/Standard.hs
@@ -17,7 +17,7 @@ import           Control.Monad.Catch            ( MonadThrow
 #if !MIN_VERSION_base(4,13,0)
 import           Control.Monad.Fail             ( MonadFail )
 #endif
-import           Control.Monad.Free             ( Free(Pure,Free) )
+import           Control.Monad.Free             ( Free(Free) )
 import           Control.Monad.Reader           ( MonadFix )
 import           Control.Monad.Ref              ( MonadRef(newRef)
                                                 , MonadAtomicRef
@@ -246,8 +246,10 @@ instance
   inform = go -- lock to ensure no type class jumps.
    where
     go :: StdValue m -> m (StdValue m)
-    go (Pure t) = (Pure . coerce <$>) . (further @(CitedStdThunk m) . coerce) $ t
-    go (Free v) = (Free <$>) . bindNValue' id go $ v
+    go =
+      free
+        ((pure . coerce <$>) . (further @(CitedStdThunk m) . coerce))
+        ((Free <$>) . bindNValue' id go)
 
 
 -- * @instance MonadValueF (StdValue m) m@

--- a/src/Nix/Utils.hs
+++ b/src/Nix/Utils.hs
@@ -21,6 +21,7 @@ module Nix.Utils
   , takeBaseName
   , takeExtension
   , takeExtensions
+  , addExtension
   , dropExtensions
   , replaceExtension
 
@@ -142,6 +143,9 @@ takeExtension = coerce FilePath.takeExtensions
 -- | @takeExtensions@ specialized to @Path@
 takeExtensions :: Path -> String
 takeExtensions = coerce FilePath.takeExtensions
+
+addExtension :: Path -> String -> Path
+addExtension = coerce FilePath.addExtension
 
 -- | @dropExtensions@ specialized to @Path@
 dropExtensions :: Path -> Path

--- a/src/Nix/Utils.hs
+++ b/src/Nix/Utils.hs
@@ -124,8 +124,9 @@ splitDirectories = FilePath.splitDirectories
 takeDirectory :: Path -> Path
 takeDirectory = coerce FilePath.takeDirectory
 
-takeFileName :: FilePath -> FilePath
-takeFileName = FilePath.takeFileName
+-- | @takeFileName@ specialized to @Path@
+takeFileName :: Path -> Path
+takeFileName = coerce FilePath.takeFileName
 
 takeBaseName :: FilePath -> String
 takeBaseName = FilePath.takeBaseName

--- a/src/Nix/Utils.hs
+++ b/src/Nix/Utils.hs
@@ -118,8 +118,9 @@ infixr 5 </>
 joinPath :: [Path] -> Path
 joinPath = coerce FilePath.joinPath
 
-splitDirectories :: FilePath -> [FilePath]
-splitDirectories = FilePath.splitDirectories
+-- | @splitDirectories@ specialized to @Path@
+splitDirectories :: Path -> [Path]
+splitDirectories = coerce FilePath.splitDirectories
 
 -- | @takeDirectory@ specialized to @Path@
 takeDirectory :: Path -> Path

--- a/src/Nix/Utils.hs
+++ b/src/Nix/Utils.hs
@@ -10,18 +10,20 @@ module Nix.Utils
   , TransformF
   , Transform
   , Alg
+
   , Path(..)
+  , isAbsolute
+  , (</>)
+  , joinPath
+  , splitDirectories
+  , takeDirectory
   , takeFileName
   , takeBaseName
-  , takeDirectory
-  , isAbsolute
-  , splitDirectories
-  , joinPath
-  , (</>)
-  , replaceExtension
   , takeExtension
   , takeExtensions
   , dropExtensions
+  , replaceExtension
+
   , Has(..)
   , trace
   , traceM
@@ -102,6 +104,22 @@ instance ToText Path where
 instance IsString Path where
   fromString = coerce
 
+isAbsolute :: FilePath -> Bool
+isAbsolute = FilePath.isAbsolute
+
+(</>) :: FilePath -> FilePath -> FilePath
+(</>) = (FilePath.</>)
+infixr 5 </>
+
+joinPath :: [FilePath] -> FilePath
+joinPath = FilePath.joinPath
+
+splitDirectories :: FilePath -> [FilePath]
+splitDirectories = FilePath.splitDirectories
+
+takeDirectory :: FilePath -> FilePath
+takeDirectory = FilePath.takeDirectory
+
 takeFileName :: FilePath -> FilePath
 takeFileName = FilePath.takeFileName
 
@@ -117,24 +135,9 @@ takeExtensions = FilePath.takeExtensions
 dropExtensions :: FilePath -> FilePath
 dropExtensions = FilePath.dropExtensions
 
-isAbsolute :: FilePath -> Bool
-isAbsolute = FilePath.isAbsolute
-
-takeDirectory :: FilePath -> FilePath
-takeDirectory = FilePath.takeDirectory
-
-(</>) :: FilePath -> FilePath -> FilePath
-(</>) = (FilePath.</>)
-infixr 5 </>
-
-splitDirectories :: FilePath -> [FilePath]
-splitDirectories = FilePath.splitDirectories
-
-joinPath :: [FilePath] -> FilePath
-joinPath = FilePath.joinPath
-
 replaceExtension :: FilePath -> String -> FilePath
 replaceExtension = FilePath.replaceExtension
+
 
 -- | > Hashmap Text -- type synonym
 type KeyMap = HashMap Text

--- a/src/Nix/Utils.hs
+++ b/src/Nix/Utils.hs
@@ -110,11 +110,12 @@ instance IsString Path where
 isAbsolute :: Path -> Bool
 isAbsolute = coerce FilePath.isAbsolute
 
-(</>) :: FilePath -> FilePath -> FilePath
-(</>) = (FilePath.</>)
+-- | @(</>)@ specialized to @Path@
+(</>) :: Path -> Path -> Path
+(</>) = coerce (FilePath.</>)
 infixr 5 </>
 
--- @joinPath@ specialized to @Path@
+-- | @joinPath@ specialized to @Path@
 joinPath :: [Path] -> Path
 joinPath = coerce FilePath.joinPath
 

--- a/src/Nix/Utils.hs
+++ b/src/Nix/Utils.hs
@@ -104,8 +104,9 @@ instance ToText Path where
 instance IsString Path where
   fromString = coerce
 
-isAbsolute :: FilePath -> Bool
-isAbsolute = FilePath.isAbsolute
+-- | @isAbsolute@ specialized to @Path@.
+isAbsolute :: Path -> Bool
+isAbsolute = coerce FilePath.isAbsolute
 
 (</>) :: FilePath -> FilePath -> FilePath
 (</>) = (FilePath.</>)

--- a/src/Nix/Utils.hs
+++ b/src/Nix/Utils.hs
@@ -18,6 +18,7 @@ module Nix.Utils
   , joinPath
   , (</>)
   , replaceExtension
+  , takeExtension
   , Has(..)
   , trace
   , traceM
@@ -100,6 +101,9 @@ instance IsString Path where
 
 takeFileName :: FilePath -> FilePath
 takeFileName = FilePath.takeFileName
+
+takeExtension :: FilePath -> String
+takeExtension = FilePath.takeExtensions
 
 isAbsolute :: FilePath -> Bool
 isAbsolute = FilePath.isAbsolute

--- a/src/Nix/Utils.hs
+++ b/src/Nix/Utils.hs
@@ -14,6 +14,7 @@ module Nix.Utils
   , takeFileName
   , takeDirectory
   , isAbsolute
+  , splitDirectories
   , (</>)
   , Has(..)
   , trace
@@ -107,6 +108,9 @@ takeDirectory = FilePath.takeDirectory
 (</>) :: FilePath -> FilePath -> FilePath
 (</>) = (FilePath.</>)
 infixr 5 </>
+
+splitDirectories :: FilePath -> [FilePath]
+splitDirectories = FilePath.splitDirectories
 
 -- | > Hashmap Text -- type synonym
 type KeyMap = HashMap Text

--- a/src/Nix/Utils.hs
+++ b/src/Nix/Utils.hs
@@ -128,8 +128,9 @@ takeDirectory = coerce FilePath.takeDirectory
 takeFileName :: Path -> Path
 takeFileName = coerce FilePath.takeFileName
 
-takeBaseName :: FilePath -> String
-takeBaseName = FilePath.takeBaseName
+-- | @takeBaseName@ specialized to @Path@
+takeBaseName :: Path -> String
+takeBaseName = coerce FilePath.takeBaseName
 
 takeExtension :: FilePath -> String
 takeExtension = FilePath.takeExtensions

--- a/src/Nix/Utils.hs
+++ b/src/Nix/Utils.hs
@@ -140,8 +140,9 @@ takeExtensions = FilePath.takeExtensions
 dropExtensions :: Path -> Path
 dropExtensions = coerce FilePath.dropExtensions
 
-replaceExtension :: FilePath -> String -> FilePath
-replaceExtension = FilePath.replaceExtension
+-- | @replaceExtension@ specialized to @Path@
+replaceExtension :: Path -> String -> Path
+replaceExtension = coerce FilePath.replaceExtension
 
 
 -- | > Hashmap Text -- type synonym

--- a/src/Nix/Utils.hs
+++ b/src/Nix/Utils.hs
@@ -118,8 +118,9 @@ joinPath = FilePath.joinPath
 splitDirectories :: FilePath -> [FilePath]
 splitDirectories = FilePath.splitDirectories
 
-takeDirectory :: FilePath -> FilePath
-takeDirectory = FilePath.takeDirectory
+-- | @takeDirectory@ specialized to @Path@
+takeDirectory :: Path -> Path
+takeDirectory = coerce FilePath.takeDirectory
 
 takeFileName :: FilePath -> FilePath
 takeFileName = FilePath.takeFileName

--- a/src/Nix/Utils.hs
+++ b/src/Nix/Utils.hs
@@ -132,8 +132,9 @@ takeFileName = coerce FilePath.takeFileName
 takeBaseName :: Path -> String
 takeBaseName = coerce FilePath.takeBaseName
 
-takeExtension :: FilePath -> String
-takeExtension = FilePath.takeExtensions
+-- | @takeExtension@ specialized to @Path@
+takeExtension :: Path -> String
+takeExtension = coerce FilePath.takeExtensions
 
 takeExtensions :: FilePath -> String
 takeExtensions = FilePath.takeExtensions

--- a/src/Nix/Utils.hs
+++ b/src/Nix/Utils.hs
@@ -136,8 +136,9 @@ takeBaseName = coerce FilePath.takeBaseName
 takeExtension :: Path -> String
 takeExtension = coerce FilePath.takeExtensions
 
-takeExtensions :: FilePath -> String
-takeExtensions = FilePath.takeExtensions
+-- | @takeExtensions@ specialized to @Path@
+takeExtensions :: Path -> String
+takeExtensions = coerce FilePath.takeExtensions
 
 -- | @dropExtensions@ specialized to @Path@
 dropExtensions :: Path -> Path

--- a/src/Nix/Utils.hs
+++ b/src/Nix/Utils.hs
@@ -12,6 +12,7 @@ module Nix.Utils
   , Alg
   , Path(..)
   , takeFileName
+  , takeDirectory
   , isAbsolute
   , (</>)
   , Has(..)
@@ -99,6 +100,9 @@ takeFileName = FilePath.takeFileName
 
 isAbsolute :: FilePath -> Bool
 isAbsolute = FilePath.isAbsolute
+
+takeDirectory :: FilePath -> FilePath
+takeDirectory = FilePath.takeDirectory
 
 (</>) :: FilePath -> FilePath -> FilePath
 (</>) = (FilePath.</>)

--- a/src/Nix/Utils.hs
+++ b/src/Nix/Utils.hs
@@ -114,8 +114,9 @@ isAbsolute = coerce FilePath.isAbsolute
 (</>) = (FilePath.</>)
 infixr 5 </>
 
-joinPath :: [FilePath] -> FilePath
-joinPath = FilePath.joinPath
+-- @joinPath@ specialized to @Path@
+joinPath :: [Path] -> Path
+joinPath = coerce FilePath.joinPath
 
 splitDirectories :: FilePath -> [FilePath]
 splitDirectories = FilePath.splitDirectories

--- a/src/Nix/Utils.hs
+++ b/src/Nix/Utils.hs
@@ -20,6 +20,7 @@ module Nix.Utils
   , replaceExtension
   , takeExtension
   , takeExtensions
+  , dropExtensions
   , Has(..)
   , trace
   , traceM
@@ -108,6 +109,9 @@ takeExtension = FilePath.takeExtensions
 
 takeExtensions :: FilePath -> String
 takeExtensions = FilePath.takeExtensions
+
+dropExtensions :: FilePath -> FilePath
+dropExtensions = FilePath.dropExtensions
 
 isAbsolute :: FilePath -> Bool
 isAbsolute = FilePath.isAbsolute

--- a/src/Nix/Utils.hs
+++ b/src/Nix/Utils.hs
@@ -15,6 +15,7 @@ module Nix.Utils
   , takeDirectory
   , isAbsolute
   , splitDirectories
+  , joinPath
   , (</>)
   , Has(..)
   , trace
@@ -111,6 +112,9 @@ infixr 5 </>
 
 splitDirectories :: FilePath -> [FilePath]
 splitDirectories = FilePath.splitDirectories
+
+joinPath :: [FilePath] -> FilePath
+joinPath = FilePath.joinPath
 
 -- | > Hashmap Text -- type synonym
 type KeyMap = HashMap Text

--- a/src/Nix/Utils.hs
+++ b/src/Nix/Utils.hs
@@ -19,6 +19,7 @@ module Nix.Utils
   , (</>)
   , replaceExtension
   , takeExtension
+  , takeExtensions
   , Has(..)
   , trace
   , traceM
@@ -104,6 +105,9 @@ takeFileName = FilePath.takeFileName
 
 takeExtension :: FilePath -> String
 takeExtension = FilePath.takeExtensions
+
+takeExtensions :: FilePath -> String
+takeExtensions = FilePath.takeExtensions
 
 isAbsolute :: FilePath -> Bool
 isAbsolute = FilePath.isAbsolute

--- a/src/Nix/Utils.hs
+++ b/src/Nix/Utils.hs
@@ -12,6 +12,7 @@ module Nix.Utils
   , Alg
   , Path(..)
   , takeFileName
+  , takeBaseName
   , takeDirectory
   , isAbsolute
   , splitDirectories
@@ -103,6 +104,9 @@ instance IsString Path where
 
 takeFileName :: FilePath -> FilePath
 takeFileName = FilePath.takeFileName
+
+takeBaseName :: FilePath -> String
+takeBaseName = FilePath.takeBaseName
 
 takeExtension :: FilePath -> String
 takeExtension = FilePath.takeExtensions

--- a/src/Nix/Utils.hs
+++ b/src/Nix/Utils.hs
@@ -17,6 +17,7 @@ module Nix.Utils
   , splitDirectories
   , joinPath
   , (</>)
+  , replaceExtension
   , Has(..)
   , trace
   , traceM
@@ -115,6 +116,9 @@ splitDirectories = FilePath.splitDirectories
 
 joinPath :: [FilePath] -> FilePath
 joinPath = FilePath.joinPath
+
+replaceExtension :: FilePath -> String -> FilePath
+replaceExtension = FilePath.replaceExtension
 
 -- | > Hashmap Text -- type synonym
 type KeyMap = HashMap Text

--- a/src/Nix/Utils.hs
+++ b/src/Nix/Utils.hs
@@ -11,6 +11,7 @@ module Nix.Utils
   , Transform
   , Alg
   , Path(..)
+  , takeFileName
   , Has(..)
   , trace
   , traceM
@@ -62,6 +63,7 @@ import           Lens.Family2                  as X
 import           Lens.Family2.Stock             ( _1
                                                 , _2
                                                 )
+import qualified System.FilePath              as FilePath
 
 #if ENABLE_TRACING
 import qualified Relude.Debug                 as X
@@ -90,6 +92,8 @@ instance ToText Path where
 instance IsString Path where
   fromString = coerce
 
+takeFileName :: FilePath -> FilePath
+takeFileName = FilePath.takeFileName
 
 -- | > Hashmap Text -- type synonym
 type KeyMap = HashMap Text

--- a/src/Nix/Utils.hs
+++ b/src/Nix/Utils.hs
@@ -104,6 +104,8 @@ instance ToText Path where
 instance IsString Path where
   fromString = coerce
 
+-- This set of @Path@ funcs is to control system filepath types & typesafety and to easy migrate from FilePath to anything suitable (like @path@ or so).
+
 -- | @isAbsolute@ specialized to @Path@.
 isAbsolute :: Path -> Bool
 isAbsolute = coerce FilePath.isAbsolute
@@ -134,8 +136,9 @@ takeExtension = FilePath.takeExtensions
 takeExtensions :: FilePath -> String
 takeExtensions = FilePath.takeExtensions
 
-dropExtensions :: FilePath -> FilePath
-dropExtensions = FilePath.dropExtensions
+-- | @dropExtensions@ specialized to @Path@
+dropExtensions :: Path -> Path
+dropExtensions = coerce FilePath.dropExtensions
 
 replaceExtension :: FilePath -> String -> FilePath
 replaceExtension = FilePath.replaceExtension

--- a/src/Nix/Utils.hs
+++ b/src/Nix/Utils.hs
@@ -13,6 +13,7 @@ module Nix.Utils
   , Path(..)
   , takeFileName
   , isAbsolute
+  , (</>)
   , Has(..)
   , trace
   , traceM
@@ -98,6 +99,10 @@ takeFileName = FilePath.takeFileName
 
 isAbsolute :: FilePath -> Bool
 isAbsolute = FilePath.isAbsolute
+
+(</>) :: FilePath -> FilePath -> FilePath
+(</>) = (FilePath.</>)
+infixr 5 </>
 
 -- | > Hashmap Text -- type synonym
 type KeyMap = HashMap Text

--- a/src/Nix/Utils.hs
+++ b/src/Nix/Utils.hs
@@ -12,6 +12,7 @@ module Nix.Utils
   , Alg
   , Path(..)
   , takeFileName
+  , isAbsolute
   , Has(..)
   , trace
   , traceM
@@ -94,6 +95,9 @@ instance IsString Path where
 
 takeFileName :: FilePath -> FilePath
 takeFileName = FilePath.takeFileName
+
+isAbsolute :: FilePath -> Bool
+isAbsolute = FilePath.isAbsolute
 
 -- | > Hashmap Text -- type synonym
 type KeyMap = HashMap Text

--- a/tests/EvalTests.hs
+++ b/tests/EvalTests.hs
@@ -16,7 +16,7 @@ import           Nix.Standard
 import           Nix.TH
 import           Nix.Value.Equal
 import qualified System.Directory as D
-import           System.FilePath
+import           System.FilePath (takeExtension)
 import           Test.Tasty
 import           Test.Tasty.HUnit
 import           Test.Tasty.TH

--- a/tests/EvalTests.hs
+++ b/tests/EvalTests.hs
@@ -16,7 +16,6 @@ import           Nix.Standard
 import           Nix.TH
 import           Nix.Value.Equal
 import qualified System.Directory as D
-import           System.FilePath (takeExtension)
 import           Test.Tasty
 import           Test.Tasty.HUnit
 import           Test.Tasty.TH

--- a/tests/EvalTests.hs
+++ b/tests/EvalTests.hs
@@ -457,7 +457,7 @@ genEvalCompareTests =
     pure $ testGroup "Eval comparison tests" $ fmap (mkTestCase testDir) files
   where
     mkTestCase :: Path -> TestName -> TestTree
-    mkTestCase td f = testCase f $ assertEvalFileMatchesNix $ coerce $ coerce td </> f
+    mkTestCase td f = testCase f $ assertEvalFileMatchesNix $ td </> coerce f
 
 constantEqual :: NExprLoc -> NExprLoc -> Assertion
 constantEqual expected actual =

--- a/tests/EvalTests.hs
+++ b/tests/EvalTests.hs
@@ -372,10 +372,18 @@ case_mapattrs_builtin =
 
 -- Regression test for #373
 case_regression_373 :: Assertion
-case_regression_373 = do
-  freeVarsEqual "{ inherit a; }" ["a"]
-  freeVarsEqual "rec {inherit a; }" ["a"]
-  freeVarsEqual "let inherit a; in { }" ["a"]
+case_regression_373 =
+  traverse_ (uncurry freeVarsEqual)
+    [ ( "{ inherit a; }"
+      , one "a"
+      )
+    , ("rec {inherit a; }"
+      , one "a"
+      )
+    , ( "let inherit a; in { }"
+      , one "a"
+      )
+    ]
 
 case_expression_split =
   constantEqualText

--- a/tests/EvalTests.hs
+++ b/tests/EvalTests.hs
@@ -161,7 +161,7 @@ case_inherit_from_set_has_no_scope =
     |]
 
 -- github/orblivion (2018-08-05): Adding these failing tests so we fix this feature
-
+--
 -- case_overrides =
 --     constantEqualText' "2" [text|
 --       let
@@ -354,10 +354,10 @@ case_directory_pathexists =
     constantEqualText "false" "builtins.pathExists \"/var/empty/invalid-directory\""
 
 -- jww (2018-05-02): This constantly changes!
--- case_placeholder =
---   constantEqualText
---       "\"/1rz4g4znpzjwh1xymhjpm42vipw92pr73vdgl6xs1hycac8kf2n9\""
---       "builtins.placeholder \"out\""
+case_placeholder =
+  constantEqualText
+      "\"/1rz4g4znpzjwh1xymhjpm42vipw92pr73vdgl6xs1hycac8kf2n9\""
+      "builtins.placeholder \"out\""
 
 case_rec_path_attr =
     constantEqualText "10"

--- a/tests/EvalTests.hs
+++ b/tests/EvalTests.hs
@@ -28,18 +28,20 @@ case_basic_sum =
 case_basic_div =
     constantEqualText "3" "builtins.div 6 2"
 
-case_zero_div = do
-  assertNixEvalThrows "builtins.div 1 0"
-  assertNixEvalThrows "builtins.div 1.0 0"
-  assertNixEvalThrows "builtins.div 1 0.0"
-  assertNixEvalThrows "builtins.div 1.0 0.0"
+case_zero_div =
+  traverse_ assertNixEvalThrows
+    [ "builtins.div 1 0"
+    , "builtins.div 1.0 0"
+    , "builtins.div 1 0.0"
+    , "builtins.div 1.0 0.0"
+    ]
 
-case_bit_ops = do
-    -- mic92 (2018-08-20): change to constantEqualText,
-    -- when hnix's nix fork supports bitAnd/bitOr/bitXor
-    constantEqualText' "0" "builtins.bitAnd 1 0"
-    constantEqualText' "1" "builtins.bitOr 1 1"
-    constantEqualText' "3" "builtins.bitXor 1 2"
+case_bit_ops =
+  traverse_ (uncurry constantEqualText)
+    [ ("0", "builtins.bitAnd 1 0")
+    , ("1", "builtins.bitOr 1 1")
+    , ("3", "builtins.bitXor 1 2")
+    ]
 
 case_basic_function =
     constantEqualText "2" "(a: a) 2"

--- a/tests/EvalTests.hs
+++ b/tests/EvalTests.hs
@@ -188,97 +188,102 @@ case_inherit_from_set_has_no_scope =
 --       }.__overrides.a)
 --     |]
 
-case_unsafegetattrpos1 =
-    constantEqualText "[ 5 14 ]" [text|
-      let e = 1;
-          f = 1;
-          t = {};
-          s = {
-            inherit t e f;
-            a = 1;
-            "b" = 2;
-            c.d = 3;
-          };
-          p = builtins.unsafeGetAttrPos "e" s; in
-      [ p.line p.column ]
-    |]
+case_unsafegetattrpos =
+  traverse_ (uncurry constantEqualText)
+    [ ( "[ 5 14 ]"
+      , [text|
+          let e = 1;
+              f = 1;
+              t = {};
+              s = {
+                inherit t e f;
+                a = 1;
+                "b" = 2;
+                c.d = 3;
+              };
+              p = builtins.unsafeGetAttrPos "e" s; in
+          [ p.line p.column ]
+          |]
+      )
+    , ( "[ 5 14 ]"
+      , [text|
+          let e = 1;
+              f = 1;
+              t = {};
+              s = {
+                inherit t e f;
+                a = 1;
+                "b" = 2;
+                c.d = 3;
+              };
+              p = builtins.unsafeGetAttrPos "f" s; in
+          [ p.line p.column ]
+        |]
+      )
+    , ( "[ 6 7 ]"
+      , [text|
+          let e = 1;
+              f = 1;
+              t = {};
+              s = {
+                inherit t e f;
+                a = 1;
+                "b" = 2;
+                c.d = 3;
+              };
+              p = builtins.unsafeGetAttrPos "a" s; in
+            [ p.line p.column ]
+          |]
+      )
+    , ( "[ 7 7 ]"
+      , [text|
+        let e = 1;
+            f = 1;
+            t = {};
+            s = {
+              inherit t e f;
+              a = 1;
+              "b" = 2;
+              c.d = 3;
+            };
+            p = builtins.unsafeGetAttrPos "b" s; in
+          [ p.line p.column ]
+        |]
+      )
+    -- jww (2018-05-09): These two are failing but they shouldn't be
+    --
+    -- , ( "[ 7 13 ]"
+    --   , [text|
+    --       let e = 1;
+    --           f = 1;
+    --           t = {};
+    --           s = {
+    --             inherit t e f;
+    --             a = 1;
+    --             "b" = 2;
+    --             c.d = 3;
+    --           };
+    --           p = builtins.unsafeGetAttrPos "c.d" s; in
+    --         [ p.line p.column ]
+    --       |]
+    --   )
 
-case_unsafegetattrpos2 =
-    constantEqualText "[ 5 14 ]" [text|
-      let e = 1;
-          f = 1;
-          t = {};
-          s = {
-            inherit t e f;
-            a = 1;
-            "b" = 2;
-            c.d = 3;
-          };
-          p = builtins.unsafeGetAttrPos "f" s; in
-      [ p.line p.column ]
-    |]
-
-case_unsafegetattrpos3 =
-    constantEqualText "[ 6 7 ]" [text|
-      let e = 1;
-          f = 1;
-          t = {};
-          s = {
-            inherit t e f;
-            a = 1;
-            "b" = 2;
-            c.d = 3;
-          };
-          p = builtins.unsafeGetAttrPos "a" s; in
-      [ p.line p.column ]
-    |]
-
-case_unsafegetattrpos4 =
-    constantEqualText "[ 7 7 ]" [text|
-      let e = 1;
-          f = 1;
-          t = {};
-          s = {
-            inherit t e f;
-            a = 1;
-            "b" = 2;
-            c.d = 3;
-          };
-          p = builtins.unsafeGetAttrPos "b" s; in
-      [ p.line p.column ]
-    |]
-
--- jww (2018-05-09): These two are failing but they shouldn't be
-
--- case_unsafegetattrpos5 =
---     constantEqualText "[ 7 13 ]" [text|
---       let e = 1;
---           f = 1;
---           t = {};
---           s = {
---             inherit t e f;
---             a = 1;
---             "b" = 2;
---             c.d = 3;
---           };
---           p = builtins.unsafeGetAttrPos "c.d" s; in
---       [ p.line p.column ]
---     |]
-
--- case_unsafegetattrpos6 =
---     constantEqualText "[ 7 13 ]" [text|
---       let e = 1;
---           f = 1;
---           t = {};
---           s = {
---             inherit t e f;
---             a = 1;
---             "b" = 2;
---             c.d = 3;
---           };
---           p = builtins.unsafeGetAttrPos "d" s; in
---       [ p.line p.column ]
---     |]
+    -- , ( "[ 7 13 ]"
+    --   , [text|
+    --       let e = 1;
+    --           f = 1;
+    --           t = {};
+    --           s = {
+    --             inherit t e f;
+    --             a = 1;
+    --             "b" = 2;
+    --             c.d = 3;
+    --           };
+    --           p = builtins.unsafeGetAttrPos "d" s; in
+    --         [ p.line p.column ]
+    --       |]
+    --   )
+    ]
 
 case_fixed_points =
     constantEqualText [text|[
@@ -323,20 +328,27 @@ case_fixed_points_attrsets =
       in fix f
     |]
 
--- case_function_equals1 =
---     constantEqualText "true" "{f = x: x;} == {f = x: x;}"
-
--- case_function_equals2 =
---     constantEqualText "true" "[(x: x)] == [(x: x)]"
-
-case_function_equals3 =
-    constantEqualText "false" "(let a = (x: x); in a == a)"
-
-case_function_equals4 =
-    constantEqualText "true" "(let a = {f = x: x;}; in a == a)"
-
-case_function_equals5 =
-    constantEqualText "true" "(let a = [(x: x)]; in a == a)"
+case_function_equals =
+    traverse_ (uncurry constantEqualText)
+      [ -- ( "true"
+        -- , "{f = x: x;} == {f = x: x;}"
+        -- )
+        -- ( "true"
+        -- , "[(x: x)] == [(x: x)]"
+        -- )
+        ( "false"
+        , "(let a = (x: x); in a == a)"
+        )
+      , ( "true"
+        , "(let a = {f = x: x;}; in a == a)"
+        )
+      , ( "true"
+        , "(let a = [(x: x)]; in a == a)"
+        )
+      , ( "false"
+        , "builtins.pathExists \"/var/empty/invalid-directory\""
+        )
+      ]
 
 case_directory_pathexists =
     constantEqualText "false" "builtins.pathExists \"/var/empty/invalid-directory\""
@@ -435,11 +447,16 @@ tests = $testGroupGenerator
 genEvalCompareTests = do
     td <- D.listDirectory (coerce testDir)
 
-    let unmaskedFiles = filter ((==".nix") . takeExtension) td
-    let files = unmaskedFiles \\ coerce maskedFiles
+    let
+      unmaskedFiles :: [String]
+      unmaskedFiles = filter ((==".nix") . takeExtension) td
+
+      files :: [String]
+      files = unmaskedFiles \\ coerce maskedFiles
 
     pure $ testGroup "Eval comparison tests" $ fmap (mkTestCase testDir) files
   where
+    mkTestCase :: Path -> TestName -> TestTree
     mkTestCase td f = testCase f $ assertEvalFileMatchesNix $ coerce $ coerce td </> f
 
 constantEqual :: NExprLoc -> NExprLoc -> Assertion
@@ -452,10 +469,11 @@ constantEqual expected actual = do
         actualNF <- normalForm =<< nixEvalExprLoc mempty actual
         eq <- valueEqM expectedNF actualNF
         pure (eq, expectedNF, actualNF)
-    let message =
-                "Inequal normal forms:\n"
-            <>  "Expected: " <> printNix expectedNF <> "\n"
-            <>  "Actual:   " <> printNix actualNF
+    let
+      message =
+        "Inequal normal forms:\n"
+        <> "Expected: " <> printNix expectedNF <> "\n"
+        <>  "Actual:   " <> printNix actualNF
     assertBool message eq
 
 constantEqualText' :: Text -> Text -> Assertion

--- a/tests/EvalTests.hs
+++ b/tests/EvalTests.hs
@@ -443,15 +443,16 @@ case_concat_thunk_rigth =
 tests :: TestTree
 tests = $testGroupGenerator
 
-genEvalCompareTests = do
-    td <- D.listDirectory (coerce testDir)
+genEvalCompareTests =
+  do
+    td :: [FilePath] <- D.listDirectory (coerce testDir)
 
     let
-      unmaskedFiles :: [String]
-      unmaskedFiles = filter ((==".nix") . takeExtension) td
+      unmaskedFiles :: [Path]
+      unmaskedFiles = filter ((==".nix") . takeExtension) $ coerce td
 
-      files :: [String]
-      files = unmaskedFiles \\ coerce maskedFiles
+      files :: [TestName]
+      files = coerce $ unmaskedFiles \\ maskedFiles
 
     pure $ testGroup "Eval comparison tests" $ fmap (mkTestCase testDir) files
   where

--- a/tests/EvalTests.hs
+++ b/tests/EvalTests.hs
@@ -445,19 +445,19 @@ tests = $testGroupGenerator
 
 genEvalCompareTests =
   do
-    td :: [FilePath] <- D.listDirectory (coerce testDir)
+    (coerce -> files :: [Path]) <- D.listDirectory (coerce testDir)
 
     let
       unmaskedFiles :: [Path]
-      unmaskedFiles = filter ((==".nix") . takeExtension) $ coerce td
+      unmaskedFiles = filter ((== ".nix") . takeExtension) files
 
-      files :: [TestName]
-      files = coerce $ unmaskedFiles \\ maskedFiles
+      testFiles :: [Path]
+      testFiles = unmaskedFiles \\ maskedFiles
 
-    pure $ testGroup "Eval comparison tests" $ fmap (mkTestCase testDir) files
+    pure $ testGroup "Eval comparison tests" $ fmap (mkTestCase testDir) testFiles
   where
-    mkTestCase :: Path -> TestName -> TestTree
-    mkTestCase td f = testCase f $ assertEvalFileMatchesNix $ td </> coerce f
+    mkTestCase :: Path -> Path -> TestTree
+    mkTestCase dir f = testCase (coerce f :: TestName) $ assertEvalFileMatchesNix $ dir </> f
 
 constantEqual :: NExprLoc -> NExprLoc -> Assertion
 constantEqual expected actual =

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -73,17 +73,18 @@ ensureNixpkgsCanParse =
             stub
     v -> fail $ "Unexpected parse from default.nix: " <> show v
  where
-  getExpr   k m = let Just (Just r) = lookup k m in r
+  getExpr   k m =
+    let Just (Just r) = lookup k m in
+    r
   getString k m =
-      let Fix (NStr (DoubleQuoted [Plain str])) = getExpr k m in str
+    let Fix (NStr (DoubleQuoted [Plain str])) = getExpr k m in
+    str
 
   consider path action k =
-    do
-      x <- action
-      either
-        (\ err -> errorWithoutStackTrace $ "Parsing " <> coerce @Path path <> " failed: " <> show err)
-        k
-        x
+    either
+      (\ err -> errorWithoutStackTrace $ "Parsing " <> coerce @Path path <> " failed: " <> show err)
+      k
+      =<< action
 
 main :: IO ()
 main = do

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -27,7 +27,7 @@ import qualified PrettyParseTests
 import           System.Directory
 import           System.Environment (setEnv)
 import           System.FilePath.Glob
-import           System.Posix.Files
+import           System.PosixCompat.Files
 import           Test.Tasty
 import           Test.Tasty.HUnit
 

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -26,7 +26,7 @@ import qualified ReduceExprTests
 import qualified PrettyParseTests
 import           System.Directory
 import           System.Environment (setEnv)
-import           System.FilePath.Glob
+import           System.FilePath.Glob (compile, globDir1)
 import           System.PosixCompat.Files
 import           Test.Tasty
 import           Test.Tasty.HUnit

--- a/tests/NixLanguageTests.hs
+++ b/tests/NixLanguageTests.hs
@@ -74,12 +74,12 @@ deprecatedRareNixQuirkTests = Set.fromList
 
 genTests :: IO TestTree
 genTests = do
-  testFiles :: [FilePath] <-
+  (coerce -> testFiles :: [FilePath]) <-
     sort
     -- Disabling the not yet done tests cases.
-    . filter ((`Set.notMember` (newFailingTests `Set.union` deprecatedRareNixQuirkTests)) . takeBaseName . coerce)
+    . filter ((`Set.notMember` (newFailingTests `Set.union` deprecatedRareNixQuirkTests)) . takeBaseName)
     . filter ((/= ".xml") . takeExtension)
-    <$> globDir1 (compile "*-*-*.*") "data/nix/tests/lang"
+    <$> coerce (globDir1 (compile "*-*-*.*") "data/nix/tests/lang")
   let
     testsByName :: Map FilePath [FilePath]
     testsByName = groupBy (coerce (takeFileName . dropExtensions)) testFiles
@@ -89,6 +89,7 @@ genTests = do
 
     testGroups :: [TestTree]
     testGroups  = mkTestGroup <$> coerce (Map.toList testsByType)
+
   pure $ localOption (mkTimeout 2000000) $
     testGroup
       "Nix (upstream) language tests"

--- a/tests/NixLanguageTests.hs
+++ b/tests/NixLanguageTests.hs
@@ -21,7 +21,12 @@ import           Nix.String
 import           Nix.XML
 import qualified Options.Applicative           as Opts
 import           System.Environment
-import           System.FilePath
+import           System.FilePath                ( takeBaseName
+                                                , takeExtension
+                                                , takeFileName
+                                                , takeExtensions
+                                                , dropExtensions
+                                                )
 import           System.FilePath.Glob           ( compile
                                                 , globDir1
                                                 )

--- a/tests/NixLanguageTests.hs
+++ b/tests/NixLanguageTests.hs
@@ -23,7 +23,6 @@ import qualified Options.Applicative           as Opts
 import           System.Environment
 import           System.FilePath                ( takeBaseName
                                                 , takeExtension
-                                                , takeFileName
                                                 , takeExtensions
                                                 , dropExtensions
                                                 )

--- a/tests/NixLanguageTests.hs
+++ b/tests/NixLanguageTests.hs
@@ -22,7 +22,6 @@ import           Nix.XML
 import qualified Options.Applicative           as Opts
 import           System.Environment
 import           System.FilePath                ( takeBaseName
-                                                , takeExtensions
                                                 , dropExtensions
                                                 )
 import           System.FilePath.Glob           ( compile

--- a/tests/NixLanguageTests.hs
+++ b/tests/NixLanguageTests.hs
@@ -184,8 +184,7 @@ assertEval _opts files =
       (fmap toString $ fixup $ Text.splitOn " " flags')
 
   name :: Path
-  name =
-    "data/nix/tests/lang/" <> the (takeFileName . dropExtensions <$> files)
+  name = coerce nixTestDir <> the (takeFileName . dropExtensions <$> files)
 
   fixup :: [Text] -> [Text]
   fixup ("--arg"    : x : y : rest) = "--arg"    : (x <> "=" <> y) : fixup rest
@@ -200,3 +199,6 @@ assertEvalFail file =
     time       <- liftIO getCurrentTime
     evalResult <- printNix <$> hnixEvalFile (defaultOptions time) file
     evalResult `seq` assertFailure $ "File: ''" <> coerce file <> "'' should not evaluate.\nThe evaluation result was `" <> evalResult <> "`."
+
+nixTestDir :: FilePath
+nixTestDir = "data/nix/tests/lang/"

--- a/tests/NixLanguageTests.hs
+++ b/tests/NixLanguageTests.hs
@@ -20,7 +20,7 @@ import           Nix.Pretty
 import           Nix.String
 import           Nix.XML
 import qualified Options.Applicative           as Opts
-import           System.Environment
+import           System.Environment             ( setEnv )
 import           System.FilePath.Glob           ( compile
                                                 , globDir1
                                                 )

--- a/tests/NixLanguageTests.hs
+++ b/tests/NixLanguageTests.hs
@@ -89,7 +89,7 @@ genTests = do
     testsByType = groupBy testType (Map.toList testsByName)
 
     testGroups :: [TestTree]
-    testGroups  = mkTestGroup . coerce <$> Map.toList testsByType
+    testGroups  = mkTestGroup <$> coerce (Map.toList testsByType)
   pure $ localOption (mkTimeout 2000000) $
     testGroup
       "Nix (upstream) language tests"
@@ -152,7 +152,7 @@ assertEval _opts files =
   do
     time <- liftIO getCurrentTime
     let opts = defaultOptions time
-    case delete ".nix" $ sort $ fromString @Text . takeExtensions . coerce <$> files of
+    case delete ".nix" $ sort $ fromString @Text . takeExtensions <$> coerce files of
       []                  -> void $ hnixEvalFile opts (name <> ".nix")
       [".exp"          ]  -> assertLangOk    opts name
       [".exp.xml"      ]  -> assertLangOkXml opts name
@@ -185,7 +185,7 @@ assertEval _opts files =
 
   name :: Path
   name = coerce $
-    "data/nix/tests/lang/" <> the (takeFileName . dropExtensions . coerce <$> files)
+    "data/nix/tests/lang/" <> the (takeFileName . dropExtensions <$> coerce files)
 
   fixup :: [Text] -> [Text]
   fixup ("--arg"    : x : y : rest) = "--arg"    : (x <> "=" <> y) : fixup rest

--- a/tests/NixLanguageTests.hs
+++ b/tests/NixLanguageTests.hs
@@ -21,8 +21,6 @@ import           Nix.String
 import           Nix.XML
 import qualified Options.Applicative           as Opts
 import           System.Environment
-import           System.FilePath                ( takeBaseName
-                                                )
 import           System.FilePath.Glob           ( compile
                                                 , globDir1
                                                 )

--- a/tests/NixLanguageTests.hs
+++ b/tests/NixLanguageTests.hs
@@ -82,7 +82,7 @@ genTests = do
     <$> globDir1 (compile "*-*-*.*") "data/nix/tests/lang"
   let
     testsByName :: Map FilePath [FilePath]
-    testsByName = groupBy (takeFileName . dropExtensions) testFiles
+    testsByName = groupBy (takeFileName . coerce dropExtensions) testFiles
 
     testsByType :: Map [String] [(FilePath, [FilePath])]
     testsByType = groupBy testType (Map.toList testsByName)
@@ -184,7 +184,7 @@ assertEval _opts files =
 
   name :: Path
   name = coerce $
-    "data/nix/tests/lang/" <> the (takeFileName . dropExtensions <$> coerce files)
+    "data/nix/tests/lang/" <> the (takeFileName . coerce dropExtensions <$> files)
 
   fixup :: [Text] -> [Text]
   fixup ("--arg"    : x : y : rest) = "--arg"    : (x <> "=" <> y) : fixup rest

--- a/tests/NixLanguageTests.hs
+++ b/tests/NixLanguageTests.hs
@@ -74,10 +74,10 @@ deprecatedRareNixQuirkTests = Set.fromList
 
 genTests :: IO TestTree
 genTests = do
-  testFiles <-
+  testFiles :: [FilePath] <-
     sort
     -- Disabling the not yet done tests cases.
-    . filter ((`Set.notMember` (newFailingTests `Set.union` deprecatedRareNixQuirkTests)) . takeBaseName)
+    . filter ((`Set.notMember` (newFailingTests `Set.union` deprecatedRareNixQuirkTests)) . takeBaseName . coerce)
     . filter ((/= ".xml") . takeExtension)
     <$> globDir1 (compile "*-*-*.*") "data/nix/tests/lang"
   let

--- a/tests/NixLanguageTests.hs
+++ b/tests/NixLanguageTests.hs
@@ -152,7 +152,7 @@ assertEval _opts files =
   do
     time <- liftIO getCurrentTime
     let opts = defaultOptions time
-    case delete ".nix" $ sort $ fromString @Text . takeExtensions <$> coerce files of
+    case delete ".nix" $ sort $ fromString @Text . takeExtensions <$> files of
       []                  -> void $ hnixEvalFile opts (name <> ".nix")
       [".exp"          ]  -> assertLangOk    opts name
       [".exp.xml"      ]  -> assertLangOkXml opts name

--- a/tests/NixLanguageTests.hs
+++ b/tests/NixLanguageTests.hs
@@ -22,7 +22,6 @@ import           Nix.XML
 import qualified Options.Applicative           as Opts
 import           System.Environment
 import           System.FilePath                ( takeBaseName
-                                                , takeExtension
                                                 , takeExtensions
                                                 , dropExtensions
                                                 )

--- a/tests/NixLanguageTests.hs
+++ b/tests/NixLanguageTests.hs
@@ -82,7 +82,7 @@ genTests = do
     <$> globDir1 (compile "*-*-*.*") "data/nix/tests/lang"
   let
     testsByName :: Map FilePath [FilePath]
-    testsByName = groupBy (takeFileName . coerce dropExtensions) testFiles
+    testsByName = groupBy (coerce (takeFileName . dropExtensions)) testFiles
 
     testsByType :: Map [String] [(FilePath, [FilePath])]
     testsByType = groupBy testType (Map.toList testsByName)
@@ -95,14 +95,14 @@ genTests = do
       testGroups
  where
   testType :: (FilePath, b) -> [String]
-  testType (fullpath, _files) = take 2 $ splitOn "-" $ takeFileName fullpath
+  testType (fullpath, _files) = take 2 $ splitOn "-" $ coerce takeFileName fullpath
 
   mkTestGroup :: ([String], [(String, [Path])]) -> TestTree
   mkTestGroup (kind, tests) =
     testGroup (String.unwords kind) $ mkTestCase kind <$> tests
 
   mkTestCase :: [String] -> (String, [Path]) -> TestTree
-  mkTestCase kind (basename, files) = testCase (takeFileName basename) $
+  mkTestCase kind (basename, files) = testCase (coerce takeFileName basename) $
     do
       time <- liftIO getCurrentTime
       let opts = defaultOptions time
@@ -183,8 +183,8 @@ assertEval _opts files =
       (fmap toString $ fixup $ Text.splitOn " " flags')
 
   name :: Path
-  name = coerce $
-    "data/nix/tests/lang/" <> the (takeFileName . coerce dropExtensions <$> files)
+  name =
+    "data/nix/tests/lang/" <> the (takeFileName . dropExtensions <$> files)
 
   fixup :: [Text] -> [Text]
   fixup ("--arg"    : x : y : rest) = "--arg"    : (x <> "=" <> y) : fixup rest

--- a/tests/NixLanguageTests.hs
+++ b/tests/NixLanguageTests.hs
@@ -22,7 +22,6 @@ import           Nix.XML
 import qualified Options.Applicative           as Opts
 import           System.Environment
 import           System.FilePath                ( takeBaseName
-                                                , dropExtensions
                                                 )
 import           System.FilePath.Glob           ( compile
                                                 , globDir1

--- a/tests/PrettyParseTests.hs
+++ b/tests/PrettyParseTests.hs
@@ -108,21 +108,25 @@ genExpr =
     \(Size n) -> Fix <$>
       if n < 2
         then Gen.choice [genConstant, genStr, genSym, genLiteralPath, genEnvPath]
-        else Gen.frequency
+        else
+          let
+            sizeBy i = Size $ n `div` i
+          in
+          Gen.frequency
           [ (1 , genConstant)
           , (1 , genSym)
-          , (4 , Gen.resize (Size (n `div` 3)) genIf)
+          , (4 , Gen.resize (sizeBy 3) genIf)
           , (10, genRecSet)
           , (20, genSet)
           , (5 , genList)
           , (2 , genUnary)
-          , (2 , Gen.resize (Size (n `div` 3)) genBinary)
-          , (3 , Gen.resize (Size (n `div` 3)) genSelect)
-          , (20, Gen.resize (Size (n `div` 2)) genAbs)
-          , (2 , Gen.resize (Size (n `div` 2)) genHasAttr)
-          , (10, Gen.resize (Size (n `div` 2)) genLet)
-          , (10, Gen.resize (Size (n `div` 2)) genWith)
-          , (1 , Gen.resize (Size (n `div` 2)) genAssert)
+          , (2 , Gen.resize (sizeBy 3) genBinary)
+          , (3 , Gen.resize (sizeBy 3) genSelect)
+          , (20, Gen.resize (sizeBy 2) genAbs)
+          , (2 , Gen.resize (sizeBy 2) genHasAttr)
+          , (10, Gen.resize (sizeBy 2) genLet)
+          , (10, Gen.resize (sizeBy 2) genWith)
+          , (1 , Gen.resize (sizeBy 2) genAssert)
           ]
  where
   genConstant    = NConstant                         <$> genAtom
@@ -147,7 +151,7 @@ genExpr =
 --   it divides the size by the length of the generated list.
 fairList :: Gen a -> Gen [a]
 fairList g = Gen.sized $ \s -> do
-  k <- Gen.int (Range.linear 0 (unSize s))
+  k <- Gen.int $ Range.linear 0 $ unSize s
   -- Use max here to avoid dividing by zero when there is the empty list
   Gen.resize (Size (unSize s `div` max 1 k)) $ Gen.list (Range.singleton k) g
 

--- a/tests/PrettyParseTests.hs
+++ b/tests/PrettyParseTests.hs
@@ -81,10 +81,14 @@ genAttrPath =
 genParams :: Gen (Params NExpr)
 genParams = Gen.choice
   [ Param . coerce <$> asciiText
-  , liftA3 (\ a b c -> ParamSet (pure $ coerce c) (bool Closed Variadic b) (coerce a))
-      (Gen.list (Range.linear 0 10) $ liftA2 (,) asciiText $ Gen.maybe genExpr)
-      Gen.bool
+  , liftA3 (\ c b a -> ParamSet (pure $ coerce c) (Variadic `whenTrue` b) (coerce a))
       (Gen.choice [stub, asciiText])
+      Gen.bool
+      (Gen.list (Range.linear 0 10) $
+        liftA2 (,)
+          asciiText
+          (Gen.maybe genExpr)
+      )
   ]
 
 genAtom :: Gen NAtom

--- a/tests/PrettyParseTests.hs
+++ b/tests/PrettyParseTests.hs
@@ -30,6 +30,9 @@ asciiString = Gen.list (Range.linear 1 15) Gen.lower
 asciiText :: Gen Text
 asciiText = fromString <$> asciiString
 
+asciiVarName :: Gen VarName
+asciiVarName = coerce <$> asciiText
+
 -- Might want to replace this instance with a constant value
 genPos :: Gen Pos
 genPos = mkPos <$> Gen.int (Range.linear 1 256)
@@ -43,7 +46,7 @@ genSourcePos =
 
 genKeyName :: Gen (NKeyName NExpr)
 genKeyName =
-  Gen.choice [DynamicKey <$> genAntiquoted genString, StaticKey . coerce <$> asciiText]
+  Gen.choice [DynamicKey <$> genAntiquoted genString, StaticKey <$> asciiVarName]
 
 genAntiquoted :: Gen a -> Gen (Antiquoted a NExpr)
 genAntiquoted gen =
@@ -57,7 +60,7 @@ genBinding = Gen.choice
       genSourcePos
   , liftA3 Inherit
       (Gen.maybe genExpr)
-      (Gen.list (Range.linear 0 5) (coerce <$> asciiText))
+      (Gen.list (Range.linear 0 5) asciiVarName)
       genSourcePos
   ]
 
@@ -80,8 +83,8 @@ genAttrPath =
 
 genParams :: Gen (Params NExpr)
 genParams = Gen.choice
-  [ Param . coerce <$> asciiText
   , liftA3 (\ c b a -> ParamSet (pure $ coerce c) (Variadic `whenTrue` b) (coerce a))
+  [ Param <$> asciiVarName
       (Gen.choice [stub, asciiText])
       Gen.bool
       (Gen.list (Range.linear 0 10) $

--- a/tests/PrettyParseTests.hs
+++ b/tests/PrettyParseTests.hs
@@ -83,16 +83,17 @@ genAttrPath =
 
 genParams :: Gen (Params NExpr)
 genParams = Gen.choice
-  , liftA3 (\ c b a -> ParamSet (pure $ coerce c) (Variadic `whenTrue` b) (coerce a))
   [ Param <$> asciiVarName
+  , liftA3 (mkGeneralParamSet . pure)
       (Gen.choice [stub, asciiText])
-      Gen.bool
       (Gen.list (Range.linear 0 10) $
         liftA2 (,)
           asciiText
           (Gen.maybe genExpr)
       )
+      Gen.bool
   ]
+
 
 genAtom :: Gen NAtom
 genAtom = Gen.choice

--- a/tests/PrettyParseTests.hs
+++ b/tests/PrettyParseTests.hs
@@ -221,8 +221,7 @@ normalize = foldFix $ \case
 
 -- | Test that parse . pretty == id up to attribute position information.
 prop_prettyparse :: Monad m => NExpr -> PropertyT m ()
-prop_prettyparse p = do
-  let prog = show $ prettyNix p
+prop_prettyparse p =
   either
     (\ s -> do
       footnote $ show $ vsep
@@ -263,6 +262,8 @@ prop_prettyparse p = do
     )
     (parse $ fromString prog)
  where
+  prog = show $ prettyNix p
+
   parse     = parseNixText
 
   normalise s = String.unlines $ reverse . dropWhile isSpace . reverse <$> String.lines s
@@ -271,6 +272,6 @@ prop_prettyparse p = do
   ldiff s1 s2 = getDiff ((: mempty) <$> String.lines s1) ((: mempty) <$> String.lines s2)
 
 tests :: TestLimit -> TestTree
-tests n = testProperty "Pretty/Parse Property" $ withTests n $ property $ do
-  x <- forAll genExpr
-  prop_prettyparse x
+tests n =
+  testProperty "Pretty/Parse Property" $
+    withTests n $ property $ prop_prettyparse =<< forAll genExpr

--- a/tests/PrettyParseTests.hs
+++ b/tests/PrettyParseTests.hs
@@ -66,14 +66,16 @@ genBinding = Gen.choice
 
 genString :: Gen (NString NExpr)
 genString = Gen.choice
-  [ DoubleQuoted <$> Gen.list (Range.linear 0 5) (genAntiquoted asciiText)
+  [ DoubleQuoted <$> genLines
   , liftA2 Indented
-      (Gen.int (Range.linear 0 10))
-      (Gen.list
-        (Range.linear 0 5)
-        (genAntiquoted asciiText)
-      )
+      (Gen.int $ Range.linear 0 10)
+      genLines
   ]
+ where
+  genLines =
+    Gen.list
+      (Range.linear 0 5)
+      (genAntiquoted asciiText)
 
 genAttrPath :: Gen (NAttrPath NExpr)
 genAttrPath =

--- a/tests/TestCommon.hs
+++ b/tests/TestCommon.hs
@@ -10,8 +10,8 @@ import           Nix.Standard
 import           Nix.Fresh.Basic
 import           System.Environment
 import           System.IO
-import           System.Posix.Files
-import           System.Posix.Temp
+import           System.PosixCompat.Files
+import           System.PosixCompat.Temp
 import           System.Process
 import           Test.Tasty.HUnit
 


### PR DESCRIPTION
Specialization of former `FilePath` functions to `Path` happens mainly to:
1. Prune String from code as much as possible and to maximally avoid conversions in the end.
2. To have typesafe code (I/somebody still should remove `Monoid` for `Path`).
3. Main reason: further to have an easy decision making how to control & process `Path`s and to have breather migration to `path` package (probably), which would make it even more realistic & typesafe code.