### PR TITLE
refactors & hlint rules

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -2743,3 +2743,12 @@
 - warn: {lhs: "head $ x <> one y", rhs: "headDef y x"}
 - warn: {lhs: "pictures (one p)", rhs: p, name: Evaluate}
 
+- hint:
+    lhs: "x : mempty"
+    note: "Use `one`"
+    rhs: one x
+- hint:
+    lhs: "x :| mempty"
+    note: "Use `one`"
+    rhs: one x
+

--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -2752,3 +2752,23 @@
     note: "Use `one`"
     rhs: one x
 
+- hint:
+    lhs: "join . fmap join"
+    note: "Monad law"
+    rhs: join . join
+
+- hint:
+    lhs: "join . fmap pure"
+    note: "Monad law"
+    rhs: id
+
+- hint:
+    lhs: "join . pure"
+    note: "Monad law"
+    rhs: id
+
+- hint:
+    lhs: "join . (f <<$>>)"
+    note: "Monad law"
+    rhs: fmap f . join
+

--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -2696,3 +2696,9 @@
     lhs: "maybe mempty a b"
     note: "Use `whenJust`"
     rhs: a `whenJust` b
+
+- hint:
+    lhs: "(mempty, mempty)"
+    note: "Is `mempty`"
+    rhs: mempty
+

--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -2728,3 +2728,18 @@
     note: "Use `=<<`"
     rhs: f =<< e
 
+- warn: {lhs: "init (one x)", rhs: "mempty", name: Evaluate}
+- warn: {lhs: "null (one x)", rhs: "False", name: Evaluate}
+- warn: {lhs: "foldr1 f (one x)", rhs: x, name: Evaluate}
+- warn: {lhs: "scanr f z mempty", rhs: "one z", name: Evaluate}
+- warn: {lhs: "scanr1 f mempty", rhs: "mempty", name: Evaluate}
+- warn: {lhs: "scanr1 f (one x)", rhs: "one x", name: Evaluate}
+- warn: {lhs: "fold (one a)", rhs: a, name: Evaluate}
+- warn: {lhs: "cycle (one x)", rhs: repeat x}
+- hint: {lhs: "\\x -> one x", rhs: "(one x)"}
+- hint: {lhs: "elem x (one y)", rhs: x == y, note: ValidInstance Eq a}
+- hint: {lhs: "notElem x (one y)", rhs: x /= y, note: ValidInstance Eq a}
+- warn: {lhs: "sequenceA (one a)", rhs: "pure <$> a"}
+- warn: {lhs: "head $ x <> one y", rhs: "headDef y x"}
+- warn: {lhs: "pictures (one p)", rhs: p, name: Evaluate}
+

--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -2722,3 +2722,9 @@
     note: "Use `one`"
     rhs: (one a)
 
+# Submitted upstream: https://github.com/ndmitchell/hlint/pull/1309 remove when merges
+- hint:
+    lhs: "either Left f e"
+    note: "Use `=<<`"
+    rhs: f =<< e
+

--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -2702,3 +2702,18 @@
     note: "Is `mempty`"
     rhs: mempty
 
+- hint:
+    lhs: "concat a"
+    note: "Use `fold`"
+    rhs: fold a
+
+- hint:
+    lhs: "mconcat a"
+    note: "Use `fold`"
+    rhs: fold a
+
+- hint:
+    lhs: "concatMap a"
+    note: "Use `foldMap`"
+    rhs: foldMap a
+

--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -2717,3 +2717,8 @@
     note: "Use `foldMap`"
     rhs: foldMap a
 
+- hint:
+    lhs: "[a]"
+    note: "Use `one`"
+    rhs: (one a)
+

--- a/benchmarks/Main.hs
+++ b/benchmarks/Main.hs
@@ -5,4 +5,4 @@ import           Criterion.Main
 import qualified ParserBench
 
 main :: IO ()
-main = defaultMain [ParserBench.benchmarks]
+main = defaultMain $ one ParserBench.benchmarks

--- a/main/Main.hs
+++ b/main/Main.hs
@@ -123,7 +123,7 @@ main' opts@Options{..} = runWithBasicEffectsIO opts execContentsFilesOrRepl
                 (\ ty  -> liftIO $ putStrLn $ "Type of expression: " <>
                   ppShow (maybeToMonoid $ Map.lookup @VarName @[Scheme] "it" $ coerce ty)
                 )
-                (HM.inferTop mempty [("it", stripAnnotation expr')])
+                (HM.inferTop mempty (one ("it", stripAnnotation expr')))
 
                 -- liftIO $ putStrLn $ runST $
                 --     runLintM opts . renderSymbolic =<< lint opts expr

--- a/main/Repl.hs
+++ b/main/Repl.hs
@@ -111,7 +111,7 @@ main' iniVal =
         (words <$> lines f)
 
   handleMissing e
-    | Error.isDoesNotExistError e = pure ""
+    | Error.isDoesNotExistError e = pure mempty
     | otherwise = throwM e
 
   -- Replicated and slightly adjusted `optMatcher` from `System.Console.Repline`
@@ -356,8 +356,7 @@ setConfig args =
 -- | Prefix tab completer
 defaultMatcher :: MonadIO m => [(String, CompletionFunc m)]
 defaultMatcher =
-  [ (":load", Console.fileCompleter)
-  ]
+  one (":load", Console.fileCompleter)
 
 completion
   :: (MonadNix e t f m, MonadIO m)
@@ -424,7 +423,7 @@ completeFunc reversedPrev word
           shortBuiltins = M.keys builtins
 
       pure $ listCompletion $ toString <$>
-        ["__includes"]
+        one "__includes"
           <> contextKeys
           <> shortBuiltins
 
@@ -475,12 +474,12 @@ helpOptions :: (MonadNix e t f m, MonadIO m) => HelpOptions e t f m
 helpOptions =
   [ HelpOption
       "help"
-      ""
+      mempty
       "Print help text"
       (help helpOptions . fromString)
   , HelpOption
       "paste"
-      ""
+      mempty
       "Enter multi-line mode"
       (error "Unreachable")
   , HelpOption
@@ -490,7 +489,7 @@ helpOptions =
       (load . fromString)
   , HelpOption
       "browse"
-      ""
+      mempty
       "Browse bindings in interpreter context"
       (browse . fromString)
   , HelpOption
@@ -500,12 +499,12 @@ helpOptions =
       (typeof . fromString)
   , HelpOption
       "quit"
-      ""
+      mempty
       "Quit interpreter"
       quit
   , HelpOption
       "set"
-      ""
+      mempty
       ("Set REPL option"
         <> Prettyprinter.line
         <> "Available options:"
@@ -527,32 +526,32 @@ helpSetOptions :: [HelpSetOption]
 helpSetOptions =
   [ HelpSetOption
       "strict"
-      ""
+      mempty
       "Enable strict evaluation of REPL expressions"
       (\x -> x { cfgStrict = True})
   , HelpSetOption
       "lazy"
-      ""
+      mempty
       "Disable strict evaluation of REPL expressions"
       (\x -> x { cfgStrict = False})
   , HelpSetOption
       "values"
-      ""
+      mempty
       "Enable printing of value provenance information"
       (\x -> x { cfgValues = True})
   , HelpSetOption
       "novalues"
-      ""
+      mempty
       "Disable printing of value provenance information"
       (\x -> x { cfgValues = False})
   , HelpSetOption
       "debug"
-      ""
+      mempty
       "Enable printing of REPL debug information"
       (\x -> x { cfgDebug = True})
   , HelpSetOption
       "nodebug"
-      ""
+      mempty
       "Disable REPL debugging"
       (\x -> x { cfgDebug = False})
   ]

--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -1140,13 +1140,13 @@ toFileNix name s =
         (stringIgnoreContext s')
 
     let
-      storepath  = coerce $ toText @FilePath $ coerce mres
+      storepath  = coerce (fromString @Text) mres
       sc = StringContext storepath DirectPath
 
     toValue $ mkNixStringWithSingletonContext storepath sc
 
 toPathNix :: MonadNix e t f m => NValue t f m -> m (NValue t f m)
-toPathNix = toValue @Path <=< fromValue @Path
+toPathNix = inHask @Path id
 
 pathExistsNix :: MonadNix e t f m => NValue t f m -> m (NValue t f m)
 pathExistsNix nvpath =

--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -303,7 +303,7 @@ splitDrvName s =
   breakAfterFirstItem :: (a -> Bool) -> [a] -> ([a], [a])
   breakAfterFirstItem f =
     list
-      (mempty, mempty)
+      mempty
       (\ (h : t) -> let (a, b) = break f t in (h : a, b))
   (namePieces, versionPieces) =
     breakAfterFirstItem isFirstVersionPiece pieces

--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -280,7 +280,7 @@ splitVersion s =
 
 compareVersions :: Text -> Text -> Ordering
 compareVersions s1 s2 =
-  mconcat $ (alignWith cmp `on` splitVersion) s1 s2
+  fold $ (alignWith cmp `on` splitVersion) s1 s2
  where
   z = VersionComponentString ""
   cmp = uncurry compare . fromThese z z

--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -689,8 +689,8 @@ matchNix pat str =
             traverse
               mkMatch
               (case submatches of
-                 [] -> []
-                 [a] -> [a]
+                 [] -> mempty
+                 [a] -> one a
                  _:xs -> xs -- return only the matched groups, drop the full string
               )
       _ -> pure nvNull
@@ -2010,7 +2010,7 @@ builtins
 builtins =
   do
     ref <- defer $ nvSet mempty <$> buildMap
-    lst <- ([("builtins", ref)] <>) <$> topLevelBuiltins
+    lst <- (one ("builtins", ref) <>) <$> topLevelBuiltins
     pushScope (coerce (M.fromList lst)) currentScopes
  where
   buildMap :: m (HashMap VarName (NValue t f m))

--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -1700,7 +1700,7 @@ getContextNix v =
     case v' of
       (NVStr ns) -> do
         let context = getNixLikeContext $ toNixLikeContext $ getContext ns
-        valued :: AttrSet (NValue t f m) <- sequenceA $ toValue <$> context
+        valued :: AttrSet (NValue t f m) <- traverseToValue context
         pure $ nvSet mempty valued
       x -> throwError $ ErrorCall $ "Invalid type for builtins.getContext: " <> show x
 

--- a/src/Nix/Cited/Basic.hs
+++ b/src/Nix/Cited/Basic.hs
@@ -94,7 +94,7 @@ instance
                 let e' = AnnF s (Nothing <$ e) in
                 [Provenance scope e']
               go _ = mempty
-              ps = concatMap (go . frame) frames
+              ps = foldMap (go . frame) frames
 
             cite ps t
         )

--- a/src/Nix/Cited/Basic.hs
+++ b/src/Nix/Cited/Basic.hs
@@ -90,9 +90,9 @@ instance
             -- Gather the current evaluation context at the time of thunk
             -- creation, and record it along with the thunk.
             let
+              go :: SomeException -> [Provenance m (NValue u f m)]
               go (fromException -> Just (EvaluatingExpr scope (Ann s e))) =
-                let e' = AnnF s (Nothing <$ e) in
-                [Provenance scope e']
+                one $ Provenance scope $ AnnF s (Nothing <$ e)
               go _ = mempty
               ps = foldMap (go . frame) frames
 

--- a/src/Nix/Convert.hs
+++ b/src/Nix/Convert.hs
@@ -59,10 +59,7 @@ inHaskM f = toValue <=< f <=< fromValue
 
 -- | Maybe transform Nix -> Hask. Run function. Convert Hask -> Nix.
 inHaskMay :: forall a1 a2 v b m . (Monad m, FromValue a1 m v, ToValue a2 m b) => (Maybe a1 -> a2) -> v -> m b
-inHaskMay f a =
-  do
-    v <- fromValueMay a
-    toValue $ f v
+inHaskMay f = toValue . f <=< fromValueMay
 
 
 -- * FromValue

--- a/src/Nix/Convert.hs
+++ b/src/Nix/Convert.hs
@@ -93,12 +93,10 @@ fromMayToValue
   -> NValue' t f m (NValue t f m)
   -> m a
 fromMayToValue t v =
-  do
-    v' <- fromValueMay v
-    maybe
-      (throwError $ Expectation @t @f @m t (Free v))
-      pure
-      v'
+  maybe
+    (throwError $ Expectation @t @f @m t (Free v))
+    pure
+    =<< fromValueMay v
 
 fromMayToDeeperValue
   :: forall t f m a e m1
@@ -109,12 +107,10 @@ fromMayToDeeperValue
   -> Deeper (NValue' t f m (NValue t f m))
   -> m (m1 a)
 fromMayToDeeperValue t v =
-  do
-    v' <- fromValueMay v
-    maybe
-      (throwError $ Expectation @t @f @m t $ Free $ (coerce :: CoerceDeeperToNValue' t f m) v)
-      pure
-      v'
+  maybe
+    (throwError $ Expectation @t @f @m t $ Free $ (coerce :: CoerceDeeperToNValue' t f m) v)
+    pure
+    =<< fromValueMay v
 
 instance ( Convertible e t f m
          , MonadValue (NValue t f m) m

--- a/src/Nix/Effects.hs
+++ b/src/Nix/Effects.hs
@@ -134,7 +134,7 @@ instance MonadExec IO where
   exec' = \case
     []            -> pure $ Left $ ErrorCall "exec: missing program"
     (prog : args) -> do
-      (exitCode, out, _) <- liftIO $ readProcessWithExitCode (toString prog) (toString <$> args) ""
+      (exitCode, out, _) <- liftIO $ readProcessWithExitCode (toString prog) (toString <$> args) mempty
       let
         t    = Text.strip $ fromString out
         emsg = "program[" <> prog <> "] args=" <> show args
@@ -185,7 +185,7 @@ instance MonadInstantiate IO where
         readProcessWithExitCode
           "nix-instantiate"
           ["--eval", "--expr", toString expr]
-          ""
+          mempty
 
       pure $
         case exitCode of

--- a/src/Nix/Effects/Basic.hs
+++ b/src/Nix/Effects/Basic.hs
@@ -244,15 +244,14 @@ defaultImportPath
   :: (MonadNix e t f m, MonadState (HashMap Path NExprLoc, b) m)
   => Path
   -> m (NValue t f m)
-defaultImportPath path = do
-  traceM $ "Importing file " <> coerce path
-  withFrame
-    Info
-    (ErrorCall $ "While importing file " <> show path)
-    $ do
-        imports <- gets fst
-        evalExprLoc =<<
-          maybe
+defaultImportPath path =
+  do
+    traceM $ "Importing file " <> coerce path
+    withFrame
+      Info
+      (ErrorCall $ "While importing file " <> show path)
+      $ evalExprLoc =<<
+          (maybe
             (either
               (\ err -> throwError $ ErrorCall . show $ fillSep ["Parse during import failed:", err])
               (\ expr ->
@@ -263,7 +262,8 @@ defaultImportPath path = do
               =<< parseNixFileLoc path
             )
             pure  -- return expr
-            (M.lookup path imports)
+            . M.lookup path
+          ) =<< gets fst
 
 defaultPathToDefaultNix :: MonadNix e t f m => Path -> m Path
 defaultPathToDefaultNix = pathToDefaultNixFile

--- a/src/Nix/Effects/Basic.hs
+++ b/src/Nix/Effects/Basic.hs
@@ -91,8 +91,7 @@ findEnvPathM name =
     (fail "impossible")
     (\ v ->
       do
-        nv <- demand v
-        l <- fromValue @[NValue t f m] nv
+        l <- fromValue @[NValue t f m] =<< demand v
         findPathBy nixFilePath l name
     )
     =<< lookupVar "__nixPath"
@@ -134,8 +133,7 @@ findPathBy finder ls name =
         do
           (s :: HashMap VarName (NValue t f m)) <- fromValue =<< demand nv
           p <- resolvePath s
-          nvpath <- demand p
-          path <- fromValue nvpath
+          path <- fromValue =<< demand p
 
           maybe
             (tryPath path mempty)
@@ -215,8 +213,7 @@ fetchTarball =
       )
       (\ v ->
         do
-          nv <- demand v
-          nsSha <- fromValue nv
+          nsSha <- fromValue =<< demand v
 
           let sha = stringIgnoreContext nsSha
 

--- a/src/Nix/Effects/Basic.hs
+++ b/src/Nix/Effects/Basic.hs
@@ -98,16 +98,17 @@ findEnvPathM name =
 
  where
   nixFilePath :: MonadEffects t f m => Path -> m (Maybe Path)
-  nixFilePath path = do
-    absPath <- toAbsolutePath @t @f path
-    isDir   <- doesDirectoryExist absPath
-    absFile <-
-      bool
-        (pure absPath)
-        (toAbsolutePath @t @f $ absPath </> "default.nix")
-        isDir
-    exists <- doesFileExist absFile
-    pure $ pure absFile `whenTrue` exists
+  nixFilePath path =
+    do
+      absPath <- toAbsolutePath @t @f path
+      isDir   <- doesDirectoryExist absPath
+      absFile <-
+        bool
+          (pure absPath)
+          (toAbsolutePath @t @f $ absPath </> "default.nix")
+          isDir
+
+      (pure absFile `whenTrue`) <$> doesFileExist absFile
 
 findPathBy
   :: forall e t f m

--- a/src/Nix/Effects/Basic.hs
+++ b/src/Nix/Effects/Basic.hs
@@ -115,7 +115,7 @@ findPathBy
   -> [NValue t f m]
   -> Path
   -> m Path
-findPathBy finder ls name = do
+findPathBy finder ls name =
   maybe
     (throwError $ ErrorCall $ "file ''" <> coerce name <> "'' was not found in the Nix search path (add it's using $NIX_PATH or -I)")
     pure
@@ -253,15 +253,14 @@ defaultImportPath path = do
         imports <- gets fst
         evalExprLoc =<<
           maybe
-            (do
-              either
-                (\ err -> throwError $ ErrorCall . show $ fillSep ["Parse during import failed:", err])
-                (\ expr ->
-                  do
-                    modify $ first $ M.insert path expr
-                    pure expr
-                )
-                =<< parseNixFileLoc path
+            (either
+              (\ err -> throwError $ ErrorCall . show $ fillSep ["Parse during import failed:", err])
+              (\ expr ->
+                do
+                  modify $ first $ M.insert path expr
+                  pure expr
+              )
+              =<< parseNixFileLoc path
             )
             pure  -- return expr
             (M.lookup path imports)

--- a/src/Nix/Effects/Derivation.hs
+++ b/src/Nix/Effects/Derivation.hs
@@ -305,7 +305,7 @@ defaultDerivationStrict val = do
       pure $ pathToText $ Store.makeStorePath "/nix/store" ("output:" <> encodeUtf8 o) h name
 
     toStorePaths :: HashSet StringContext -> (Set Text, Map Text [Text])
-    toStorePaths ctx = foldl (flip addToInputs) (mempty, mempty) ctx
+    toStorePaths ctx = foldl (flip addToInputs) mempty ctx
 
     addToInputs :: Bifunctor p => StringContext -> p (Set Text) (Map Text [Text])  -> p (Set Text) (Map Text [Text])
     addToInputs (StringContext path kind) = case kind of
@@ -378,7 +378,7 @@ buildDerivationWithContext drvAttrs = do
         , name = drvName
         , outputs = Map.fromList $ (, mempty) <$> outputs
         , mFixed = mFixedOutput
-        , inputs = (mempty, mempty) -- stub for now
+        , inputs = mempty -- stub for now
         }
   where
 

--- a/src/Nix/Effects/Derivation.hs
+++ b/src/Nix/Effects/Derivation.hs
@@ -92,7 +92,7 @@ hashDerivationModulo
       Hash.hash @ByteString @Hash.SHA256 $
         encodeUtf8 $
           "fixed:out"
-          <> (if hashMode == Recursive then ":r" else "")
+          <> (if hashMode == Recursive then ":r" else mempty)
           <> ":" <> (Store.algoName @hashType)
           <> ":" <> Store.encodeDigestWith Store.Base16 digest
           <> ":" <> path
@@ -145,7 +145,7 @@ unparseDrv Derivation{..} =
       ]
   where
     produceOutputInfo (outputName, outputPath) =
-      let prefix = if hashMode == Recursive then "r:" else "" in
+      let prefix = if hashMode == Recursive then "r:" else mempty in
       parens $ (s <$>) $ ([outputName, outputPath] <>) $
         maybe
           [mempty, mempty]
@@ -200,8 +200,8 @@ derivationParser = do
 
   let outputs = Map.fromList $ (\(a, b, _, _) -> (a, b)) <$> fullOutputs
   let (mFixed, hashMode) = parseFixed fullOutputs
-  let name = "" -- FIXME (extract from file path ?)
-  let useJson = ["__json"] == Map.keys env
+  let name = mempty -- FIXME (extract from file path ?)
+  let useJson = one "__json" == Map.keys env
 
   pure $ Derivation {inputs = (inputSrcs, inputDrvs), ..}
  where
@@ -219,12 +219,13 @@ derivationParser = do
     string o *> sepBy p (string ",") <* string c
 
   parens :: Parsec () Text a -> Parsec () Text [a]
-  parens p = wrap "(" ")" p
-  serializeList p = wrap "[" "]" p
+  parens = wrap "(" ")"
+  serializeList :: Parsec () Text a -> Parsec () Text [a]
+  serializeList = wrap "[" "]"
 
   parseFixed :: [(Text, Text, Text, Text)] -> (Maybe Store.SomeNamedDigest, HashMode)
   parseFixed fullOutputs = case fullOutputs of
-    [("out", _path, rht, hash)] | rht /= "" && hash /= "" ->
+    [("out", _path, rht, hash)] | rht /= mempty && hash /= mempty ->
       let
         (hashType, hashMode) = case Text.splitOn ":" rht of
           ["r", ht] -> (ht, Recursive)
@@ -267,7 +268,7 @@ defaultDerivationStrict val = do
               ifNotJsonModEnv
                 (\ baseEnv ->
                   foldl'
-                    (\m k -> Map.insert k "" m)
+                    (\m k -> Map.insert k mempty m)
                     baseEnv
                     (Map.keys $ outputs drv)
                 )
@@ -301,16 +302,16 @@ defaultDerivationStrict val = do
     pathToText = decodeUtf8 . Store.storePathToRawFilePath
 
     makeOutputPath o h n = do
-      name <- makeStorePathName $ Store.unStorePathName n <> if o == "out" then "" else "-" <> o
+      name <- makeStorePathName $ Store.unStorePathName n <> if o == "out" then mempty else "-" <> o
       pure $ pathToText $ Store.makeStorePath "/nix/store" ("output:" <> encodeUtf8 o) h name
 
     toStorePaths :: HashSet StringContext -> (Set Text, Map Text [Text])
-    toStorePaths ctx = foldl (flip addToInputs) mempty ctx
+    toStorePaths = foldl (flip addToInputs) mempty
 
     addToInputs :: Bifunctor p => StringContext -> p (Set Text) (Map Text [Text])  -> p (Set Text) (Map Text [Text])
     addToInputs (StringContext path kind) = case kind of
       DirectPath -> first (Set.insert (coerce path))
-      DerivationOutput o -> second (Map.insertWith (<>) (coerce path) [o])
+      DerivationOutput o -> second (Map.insertWith (<>) (coerce path) $ one o)
       AllOutputs ->
         -- TODO: recursive lookup. See prim_derivationStrict
         -- XXX: When is this really used ?
@@ -334,13 +335,13 @@ buildDerivationWithContext drvAttrs = do
       platform    <- getAttr   "system"                    $ assertNonNull <=< extractNoCtx
       mHash       <- getAttrOr "outputHash"        mempty  $ (pure . pure) <=< extractNoCtx
       hashMode    <- getAttrOr "outputHashMode"    Flat    $ parseHashMode <=< extractNoCtx
-      outputs     <- getAttrOr "outputs"           ["out"] $ traverse (extractNoCtx <=< fromValue')
+      outputs     <- getAttrOr "outputs"       (one "out") $ traverse (extractNoCtx <=< fromValue')
 
       mFixedOutput <-
         maybe
           (pure Nothing)
           (\ hash -> do
-            when (outputs /= ["out"]) $ lift $ throwError $ ErrorCall "Multiple outputs are not supported for fixed-output derivations"
+            when (outputs /= one "out") $ lift $ throwError $ ErrorCall "Multiple outputs are not supported for fixed-output derivations"
             hashType <- getAttr "outputHashAlgo" extractNoCtx
             digest <- lift $ either (throwError . ErrorCall) pure $ Store.mkNamedDigest hashType hash
             pure $ pure digest)
@@ -399,7 +400,7 @@ buildDerivationWithContext drvAttrs = do
       Just v  -> withFrame' Info (ErrorCall $ "While evaluating attribute '" <> show n <> "'") $
                    f =<< fromValue' v
 
-    getAttrOr n d f = getAttrOr' n (pure d) f
+    getAttrOr n = getAttrOr' n . pure
 
     getAttr n = getAttrOr' n (throwError $ ErrorCall $ "Required attribute '" <> show n <> "' not found.")
 

--- a/src/Nix/Eval.hs
+++ b/src/Nix/Eval.hs
@@ -147,14 +147,9 @@ eval (NList l           ) =
     scope <- currentScopes
     toValue =<< traverse (defer @v @m . withScopes @v scope) l
 
-eval (NSet NonRecursive binds) =
+eval (NSet r binds) =
   do
-    attrSet <- evalBinds False $ desugarBinds (eval . NSet mempty) binds
-    toValue attrSet
-
-eval (NSet Recursive binds) =
-  do
-    attrSet <- evalBinds True $ desugarBinds (eval . NSet mempty) binds
+    attrSet <- evalBinds (r == Recursive) $ desugarBinds (eval . NSet mempty) binds
     toValue attrSet
 
 eval (NLet binds body    ) =

--- a/src/Nix/Eval.hs
+++ b/src/Nix/Eval.hs
@@ -327,7 +327,7 @@ evalBinds recursive binds =
     -> m (AttrSet v, PositionSet)
   buildResult scopes bindings =
     do
-      (coerce -> scope, p) <- foldM insert (mempty, mempty) bindings
+      (coerce -> scope, p) <- foldM insert mempty bindings
       res <-
         bool
           (traverse mkThunk scope)
@@ -369,7 +369,7 @@ evalBinds recursive binds =
     processAttrSetKeys (h :| t) =
       maybe
         -- Empty attrset - return a stub.
-        (pure ( mempty, nullPos, toValue @(AttrSet v, PositionSet) (mempty, mempty)) )
+        (pure (mempty, nullPos, toValue @(AttrSet v, PositionSet) mempty) )
         (\ k ->
           list
             -- No more keys in the attrset - return the result

--- a/src/Nix/Eval.hs
+++ b/src/Nix/Eval.hs
@@ -507,7 +507,7 @@ buildArgument params arg =
             inject =
               maybe
                 id
-                (\ n -> M.insert n $ const argThunk) -- why insert into const? Thunk value getting magic point?
+                (`M.insert` const argThunk) -- why insert into const? Thunk value getting magic point?
                 mname
           loebM $
             inject $
@@ -527,11 +527,11 @@ buildArgument params arg =
   assemble _ Variadic _ (This _) = Nothing
   assemble scope _ k t =
     pure $
-    case t of
-      That Nothing -> const $ evalError @v $ ErrorCall $ "Missing value for parameter: ''" <> show k
-      That (Just f) -> coerce $ \ args -> defer $ withScopes scope $ pushScope args f
-      This _ -> const $ evalError @v $ ErrorCall $ "Unexpected parameter: " <> show k
-      These x _ -> const $ pure x
+      case t of
+        That Nothing -> const $ evalError @v $ ErrorCall $ "Missing value for parameter: ''" <> show k
+        That (Just f) -> coerce $ defer . withScopes scope . (`pushScope` f)
+        This _ -> const $ evalError @v $ ErrorCall $ "Unexpected parameter: " <> show k
+        These x _ -> const $ pure x
 
 -- | Add source positions to @NExprLoc@.
 --

--- a/src/Nix/Eval.hs
+++ b/src/Nix/Eval.hs
@@ -318,7 +318,7 @@ evalBinds recursive binds =
   do
     scope <- currentScopes :: m (Scopes m v)
 
-    buildResult scope . concat =<< traverse (applyBindToAdt scope) (moveOverridesLast binds)
+    buildResult scope . fold =<< (`traverse` moveOverridesLast binds) (applyBindToAdt scope)
 
  where
   buildResult
@@ -480,8 +480,11 @@ assembleString
   -> m (Maybe NixString)
 assembleString = fromParts . stringParts
  where
-  fromParts xs = mconcat <<$>> traverseM go xs
-  go =
+  fromParts :: [Antiquoted Text (m v)] -> m (Maybe NixString)
+  fromParts xs = fold <<$>> traverseM fun xs
+
+  fun :: Antiquoted Text (m v) -> m (Maybe NixString)
+  fun =
     runAntiquoted
       "\n"
       (pure . pure . mkNixStringWithoutContext)

--- a/src/Nix/Exec.hs
+++ b/src/Nix/Exec.hs
@@ -322,7 +322,7 @@ execUnaryOp
   -> NUnaryOp
   -> NValue t f m
   -> m (NValue t f m)
-execUnaryOp scope span op arg = do
+execUnaryOp scope span op arg =
   case arg of
     NVConstant c ->
       case (op, c) of

--- a/src/Nix/Expr/Shorthands.hs
+++ b/src/Nix/Expr/Shorthands.hs
@@ -66,7 +66,7 @@ mkSynHole :: Text -> NExpr
 mkSynHole = Fix . mkSynHoleF
 
 mkSelector :: Text -> NAttrPath NExpr
-mkSelector = (:| mempty) . StaticKey . coerce
+mkSelector = one . StaticKey . coerce
 
 -- | Put an unary operator.
 --  @since 0.15.0
@@ -312,7 +312,7 @@ letsE pairs = mkLets $ uncurry ($=) <$> pairs
 
 -- | Wrapper for a single-variable @let@.
 letE :: Text -> NExpr -> NExpr -> NExpr
-letE varName varExpr = letsE [(varName, varExpr)]
+letE varName varExpr = letsE $ one (varName, varExpr)
 
 -- | Make a non-recursive attribute set.
 attrsE :: [(Text, NExpr)] -> NExpr

--- a/src/Nix/Expr/Strings.hs
+++ b/src/Nix/Expr/Strings.hs
@@ -41,7 +41,8 @@ runAntiquoted _  _ k (Antiquoted r) = k r
 -- | Split a stream representing a string with antiquotes on line breaks.
 splitLines :: [Antiquoted Text r] -> [[Antiquoted Text r]]
 splitLines = uncurry (flip (:)) . go where
-  go (Plain t : xs) = (Plain l :) <$> foldr f (go xs) ls   where
+  go (Plain t : xs) = (Plain l :) <$> foldr f (go xs) ls
+   where
     (l : ls) = T.split (== '\n') t
     f prefix (finished, current) = ((Plain prefix : current) : finished, mempty)
   go (Antiquoted a   : xs) = (Antiquoted a :) <$> go xs
@@ -51,7 +52,7 @@ splitLines = uncurry (flip (:)) . go where
 -- | Join a stream of strings containing antiquotes again. This is the inverse
 -- of 'splitLines'.
 unsplitLines :: [[Antiquoted Text r]] -> [Antiquoted Text r]
-unsplitLines = intercalate [Plain "\n"]
+unsplitLines = intercalate $ one $ Plain "\n"
 
 -- | Form an indented string by stripping spaces equal to the minimal indent.
 stripIndent :: [Antiquoted Text r] -> NString r

--- a/src/Nix/Expr/Strings.hs
+++ b/src/Nix/Expr/Strings.hs
@@ -46,7 +46,7 @@ splitLines = uncurry (flip (:)) . go where
     f prefix (finished, current) = ((Plain prefix : current) : finished, mempty)
   go (Antiquoted a   : xs) = (Antiquoted a :) <$> go xs
   go (EscapedNewline : xs) = (EscapedNewline :) <$> go xs
-  go []                    = (mempty, mempty)
+  go []                    = mempty
 
 -- | Join a stream of strings containing antiquotes again. This is the inverse
 -- of 'splitLines'.

--- a/src/Nix/Json.hs
+++ b/src/Nix/Json.hs
@@ -19,7 +19,7 @@ toEncodingSorted :: A.Value -> A.Encoding
 toEncodingSorted = \case
   A.Object m ->
     A.pairs
-      . mconcat
+      . fold
       . ((\(k, v) -> A.pair k $ toEncodingSorted v) <$>)
       . sortWith fst
       $ HM.toList m

--- a/src/Nix/Lint.hs
+++ b/src/Nix/Lint.hs
@@ -102,7 +102,7 @@ mkSymbolic
   :: MonadAtomicRef m
   => [NTypeF m (Symbolic m)]
   -> m (Symbolic m)
-mkSymbolic xs = packSymbolic (NMany xs)
+mkSymbolic = packSymbolic . NMany
 
 packSymbolic
   :: MonadAtomicRef m
@@ -427,21 +427,23 @@ lintBinaryOp op lsym rarg =
           NUpdate -> one $ TSet mempty
 
           NConcat -> one $ TList y
-
-
-
 #if __GLASGOW_HASKELL__ < 900
           _ -> fail "Should not be possible"  -- symerr or this fun signature should be changed to work in type scope
 #endif
+
+
+
  where
   check lsym rsym xs =
     do
-      let e = NBinary op lsym rsym
+      let
+        e = NBinary op lsym rsym
+        unifyE = unify (void e)
 
       m <- mkSymbolic xs
-      _ <- unify (void e) lsym m
-      _ <- unify (void e) rsym m
-      unify (void e) lsym rsym
+      _ <- unifyE lsym m
+      _ <- unifyE rsym m
+      unifyE lsym rsym
 
 infixl 1 `lintApp`
 lintApp

--- a/src/Nix/Lint.hs
+++ b/src/Nix/Lint.hs
@@ -272,7 +272,7 @@ unify context (SV x) (SV y) = do
           writeRef y   (NMany m)
           packSymbolic (NMany m)
         )
-        (do
+        (
               -- x' <- renderSymbolic (Symbolic x)
               -- y' <- renderSymbolic (Symbolic y)
           throwError $ ErrorCall "Cannot unify "

--- a/src/Nix/Options/Parser.hs
+++ b/src/Nix/Options/Parser.hs
@@ -227,4 +227,4 @@ nixOptionsInfo :: UTCTime -> ParserInfo Options
 nixOptionsInfo current =
   info
     (helper <*> versionOpt <*> nixOptions current)
-    (fullDesc <> progDesc "" <> header "hnix")
+    (fullDesc <> progDesc mempty <> header "hnix")

--- a/src/Nix/Options/Parser.hs
+++ b/src/Nix/Options/Parser.hs
@@ -212,7 +212,7 @@ versionOpt = shortVersionOpt <*> debugVersionOpt
   debugVersionOpt :: Parser (a -> a)
   debugVersionOpt =
     infoOption
-      ( concat
+      ( fold
           [ "Version: ", showVersion version
           , "\nCommit: ", $(gitHash)
           , "\n  date: ", $(gitCommitDate)

--- a/src/Nix/Parser.hs
+++ b/src/Nix/Parser.hs
@@ -618,7 +618,7 @@ detectPrecedence spec = (mapOfOpWithPrecedence Map.!)
           (foldMap . spec)
           [1 ..]
           l
-    where
+   where
     l :: [[(NOperatorDef, Operator Parser NExprLoc)]]
     l = nixOperators $ fail "unused"
 

--- a/src/Nix/Parser.hs
+++ b/src/Nix/Parser.hs
@@ -292,7 +292,7 @@ nixString' = label "string" $ lexeme $ doubleQuoted <|> indented
   indented =
     label "indented string" $
       stripIndent <$>
-        inIndentedQuotation (many $ stringChar indentedQuotationMark indentedQuotationMark indentedEscape)
+        inIndentedQuotation (many $ join stringChar indentedQuotationMark indentedEscape)
    where
     indentedEscape :: Parser (Antiquoted Text r)
     indentedEscape =
@@ -541,21 +541,21 @@ nixOperators selector =
     -- ]
 
     {-  2 -}
-    [ ( NBinaryDef NAssocLeft NApp " "
+    one
+      ( NBinaryDef NAssocLeft NApp " "
       ,
         -- Thanks to Brent Yorgey for showing me this trick!
-        InfixL $ annNApp <$ symbols ""
+        InfixL $ annNApp <$ symbols mempty
       )
-    ]
   , {-  3 -}
-    [ prefix  NNeg "-" ]
+    one $ prefix  NNeg "-"
   , {-  4 -}
-    [ ( NSpecialDef NAssocLeft NHasAttrOp "?"
+    one
+      ( NSpecialDef NAssocLeft NHasAttrOp "?"
       , Postfix $ symbol '?' *> (flip annNHasAttr <$> selector)
       )
-    ]
   , {-  5 -}
-    [ binaryR NConcat "++" ]
+    one $ binaryR NConcat "++"
   , {-  6 -}
     [ binaryL NMult "*"
     , binaryL NDiv  "/"
@@ -565,9 +565,9 @@ nixOperators selector =
     , binaryL NMinus "-"
     ]
   , {-  8 -}
-    [ prefix  NNot "!" ]
+    one $ prefix  NNot "!"
   , {-  9 -}
-    [ binaryR NUpdate "//" ]
+    one $ binaryR NUpdate "//"
   , {- 10 -}
     [ binaryL NLt "<"
     , binaryL NGt ">"
@@ -579,11 +579,11 @@ nixOperators selector =
     , binaryN NNEq "!="
     ]
   , {- 12 -}
-    [ binaryL NAnd "&&" ]
+    one $ binaryL NAnd "&&"
   , {- 13 -}
-    [ binaryL NOr "||" ]
+    one $ binaryL NOr "||"
   , {- 14 -}
-    [ binaryR NImpl "->" ]
+    one $ binaryR NImpl "->"
   ]
 
 --  2021-08-10: NOTE:
@@ -628,7 +628,7 @@ getUnaryOperator = detectPrecedence spec
   spec :: Int -> (NOperatorDef, b) -> [(NUnaryOp, OperatorInfo)]
   spec i =
     \case
-      (NUnaryDef op name, _) -> [(op, OperatorInfo i NAssocNone name)]
+      (NUnaryDef op name, _) -> one (op, OperatorInfo i NAssocNone name)
       _                      -> mempty
 
 getBinaryOperator :: NBinaryOp -> OperatorInfo
@@ -637,7 +637,7 @@ getBinaryOperator = detectPrecedence spec
   spec :: Int -> (NOperatorDef, b) -> [(NBinaryOp, OperatorInfo)]
   spec i =
     \case
-      (NBinaryDef assoc op name, _) -> [(op, OperatorInfo i assoc name)]
+      (NBinaryDef assoc op name, _) -> one (op, OperatorInfo i assoc name)
       _                             -> mempty
 
 getSpecialOperator :: NSpecialOp -> OperatorInfo
@@ -647,7 +647,7 @@ getSpecialOperator o         = detectPrecedence spec o
   spec :: Int -> (NOperatorDef, b) -> [(NSpecialOp, OperatorInfo)]
   spec i =
       \case
-        (NSpecialDef assoc op name, _) -> [(op, OperatorInfo i assoc name)]
+        (NSpecialDef assoc op name, _) -> one (op, OperatorInfo i assoc name)
         _                              -> mempty
 
 -- ** x: y lambda function
@@ -711,7 +711,7 @@ argExpr =
                 identifier
                 (optional $ exprAfterSymbol '?')
 
-            let args = acc <> [pair]
+            let args = acc <> one pair
 
             -- Either return this, or attempt to get a comma and restart.
             option (args, mempty) $ symbol ',' *> go args
@@ -736,7 +736,7 @@ nixLet =
       (exprAfterReservedWord "in")
   -- Let expressions `let {..., body = ...}' are just desugared
   -- into `(rec {..., body = ...}).body'.
-  letBody    = (\x -> NSelect Nothing x (StaticKey "body" :| mempty)) <$> aset
+  letBody    = (\x -> NSelect Nothing x (one $ StaticKey "body")) <$> aset
   aset       = annotateLocation $ NSet Recursive <$> braces nixBinders
 
 -- ** if then else
@@ -850,7 +850,7 @@ nixTerm =
                 [ nixUri | isAlpha c ]
                 <> [ nixBool | c == 't' || c == 'f' ]
                 <> [ nixNull | c == 'n' ]
-                <> [ nixSelect nixSym ]
+                <> one (nixSelect nixSym)
 
 -- | Nix expression algebra parser.
 -- "Expression algebra" is to explain @megaparsec@ use of the term "Expression" (parser for language algebraic coperators without any statements (without @let@ etc.)), which is essentially an algebra inside the language.

--- a/src/Nix/Parser.hs
+++ b/src/Nix/Parser.hs
@@ -613,9 +613,9 @@ detectPrecedence spec = (mapOfOpWithPrecedence Map.!)
  where
   mapOfOpWithPrecedence =
     Map.fromList $
-      concat $
+      fold $
         zipWith
-          (concatMap . spec)
+          (foldMap . spec)
           [1 ..]
           l
     where

--- a/src/Nix/Pretty.hs
+++ b/src/Nix/Pretty.hs
@@ -109,8 +109,8 @@ prettyString (DoubleQuoted parts) = "\"" <> foldMap prettyPart parts <> "\""
   escape '"' = "\\\""
   escape x   =
     maybe
-      [x]
-      (('\\' :) . (: mempty))
+      (one x)
+      (('\\' :) . one)
       (toEscapeCode x)
 prettyString (Indented _ parts) = group $ nest 2 $ vcat
   ["''", content, "''"]
@@ -144,7 +144,7 @@ prettyParamSet variadic args =
     "{ "
     (align " }")
     sep
-    (fmap prettySetArg args <> ["..."] `whenTrue` (variadic == Variadic))
+    (fmap prettySetArg args <> one "..." `whenTrue` (variadic == Variadic))
  where
   prettySetArg (n, maybeDef) =
     maybe
@@ -168,7 +168,7 @@ prettyKeyName (StaticKey key) | HashSet.member key reservedNames = "\"" <> prett
 prettyKeyName (StaticKey  key) = prettyVarName key
 prettyKeyName (DynamicKey key) =
   runAntiquoted
-    (DoubleQuoted [Plain "\n"])
+    (DoubleQuoted $ one $ Plain "\n")
     prettyString
     (\ x -> "${" <> withoutParens x <> "}")
     key
@@ -291,7 +291,7 @@ exprFNixDoc = \case
   prettyContainer h f t c =
     list
       (simpleExpr (h <> t))
-      (const $ simpleExpr $ group $ nest 2 $ vsep $ [h] <> (f <$> c) <> [t])
+      (const $ simpleExpr $ group $ nest 2 $ vsep $ one h <> (f <$> c) <> one t)
       c
 
   prettyAddScope h c b =

--- a/src/Nix/Pretty.hs
+++ b/src/Nix/Pretty.hs
@@ -225,22 +225,25 @@ exprFNixDoc = \case
     mkNixDoc
       opInfo $
       hsep
-        [ wrapParens (f NAssocLeft) r1
+        [ f NAssocLeft r1
         , pretty $ operatorName opInfo
-        , wrapParens (f NAssocRight) r2
+        , f NAssocRight r2
         ]
    where
     opInfo = getBinaryOperator op
+    f :: NAssoc -> NixDoc ann1 -> Doc ann1
     f x =
-      bool
-        opInfo
-        (opInfo { associativity = NAssocNone })
-        (associativity opInfo /= x)
+      wrapParens
+        $ bool
+            opInfo
+            (opInfo { associativity = NAssocNone })
+            (associativity opInfo /= x)
   NUnary op r1 ->
     mkNixDoc
-      opInfo
-      (pretty (operatorName opInfo) <> wrapParens opInfo r1)
-    where opInfo = getUnaryOperator op
+      opInfo $
+      pretty (operatorName opInfo) <> wrapParens opInfo r1
+   where
+    opInfo = getUnaryOperator op
   NSelect o r' attr ->
     maybe
       (mkNixDoc selectOp)

--- a/src/Nix/Pretty.hs
+++ b/src/Nix/Pretty.hs
@@ -99,11 +99,11 @@ wrapPath op sub =
     (wasPath sub)
 
 prettyString :: NString (NixDoc ann) -> Doc ann
-prettyString (DoubleQuoted parts) = "\"" <> (mconcat . fmap prettyPart $ parts) <> "\""
+prettyString (DoubleQuoted parts) = "\"" <> foldMap prettyPart parts <> "\""
  where
   -- It serializes Text -> String, because the helper code is done for String,
   -- please, can someone break that code.
-  prettyPart (Plain t)      = pretty . concatMap escape . toString $ t
+  prettyPart (Plain t)      = pretty . foldMap escape . toString $ t
   prettyPart EscapedNewline = "''\\n"
   prettyPart (Antiquoted r) = "${" <> withoutParens r <> "}"
   escape '"' = "\\\""
@@ -337,7 +337,7 @@ prettyNValueProv v =
       fillSep
         [ prettyNVal
         , indent 2 $
-          "(" <> mconcat ("from: " : (prettyOriginExpr . _originExpr <$> ps)) <> ")"
+          "(" <> fold ("from: " : (prettyOriginExpr . _originExpr <$> ps)) <> ")"
         ]
     )
     (citations @m @(NValue t f m) v)
@@ -361,7 +361,7 @@ prettyNThunk t =
       fillSep
         [ v'
         , indent 2 $
-          "(" <> mconcat ( "thunk from: " : (prettyOriginExpr . _originExpr <$> ps)) <> ")"
+          "(" <> fold ( "thunk from: " : (prettyOriginExpr . _originExpr <$> ps)) <> ")"
         ]
 
 -- | This function is used only by the testing code.
@@ -376,7 +376,7 @@ printNix = iterNValueByDiscardWith thk phi
   phi (NVList'     l ) = toString $ "[ " <> unwords (fmap fromString l) <> " ]"
   phi (NVSet' _ s) =
     "{ " <>
-      concat
+      fold
         [ check (toString k) <> " = " <> v <> "; "
         | (k, v) <- sort $ toList s
         ] <> "}"

--- a/src/Nix/Pretty.hs
+++ b/src/Nix/Pretty.hs
@@ -192,15 +192,15 @@ prettyOriginExpr
 prettyOriginExpr = withoutParens . go
  where
   go = exprFNixDoc . stripAnnF . fmap render
-
-  render :: Maybe (NValue t f m) -> NixDoc ann
-  render Nothing = simpleExpr "_"
-  render (Just (Free (reverse . citations @m -> p:_))) = go (_originExpr p)
-  render _       = simpleExpr "?"
-    -- render (Just (NValue (citations -> ps))) =
-        -- simpleExpr $ foldr ((\x y -> vsep [x, y]) . parens . indent 2 . withoutParens
-        --                           . go . originExpr)
-        --     mempty (reverse ps)
+   where
+    render :: Maybe (NValue t f m) -> NixDoc ann
+    render Nothing = simpleExpr "_"
+    render (Just (Free (reverse . citations @m -> p:_))) = go (_originExpr p)
+    render _       = simpleExpr "?"
+      -- render (Just (NValue (citations -> ps))) =
+          -- simpleExpr $ foldr ((\x y -> vsep [x, y]) . parens . indent 2 . withoutParens
+          --                           . go . originExpr)
+          --     mempty (reverse ps)
 
 exprFNixDoc :: NExprF (NixDoc ann) -> NixDoc ann
 exprFNixDoc = \case

--- a/src/Nix/Pretty.hs
+++ b/src/Nix/Pretty.hs
@@ -118,9 +118,13 @@ prettyString (Indented _ parts) = group $ nest 2 $ vcat
   ["''", content, "''"]
  where
   content = vsep . fmap prettyLine . stripLastIfEmpty . splitLines $ parts
-  stripLastIfEmpty = reverse . f . reverse   where
-    f ([Plain t] : xs) | Text.null (strip t) = xs
-    f xs = xs
+  stripLastIfEmpty :: [[Antiquoted Text r]] -> [[Antiquoted Text r]]
+  stripLastIfEmpty = filter flt
+   where
+    flt :: [Antiquoted Text r] -> Bool
+    flt [Plain t] | Text.null (strip t) = False
+    flt _ = True
+
   prettyLine = hcat . fmap prettyPart
   prettyPart (Plain t) =
     pretty . replace "${" "''${" . replace "''" "'''" $ t

--- a/src/Nix/Pretty.hs
+++ b/src/Nix/Pretty.hs
@@ -309,15 +309,15 @@ valueToExpr = iterNValueByDiscardWith thk (Fix . phi)
 
   phi :: NValue' t f m NExpr -> NExprF NExpr
   phi (NVConstant' a     ) = NConstant a
-  phi (NVStr'      ns    ) = NStr $ DoubleQuoted [Plain $ stringIgnoreContext ns]
+  phi (NVStr'      ns    ) = NStr $ DoubleQuoted $ one $ Plain $ stringIgnoreContext ns
   phi (NVList'     l     ) = NList l
   phi (NVSet'      p    s) = NSet mempty
-    [ NamedVar (StaticKey k :| mempty) v (fromMaybe nullPos $ (`M.lookup` p) $ coerce k)
+    [ NamedVar (one $ StaticKey k) v (fromMaybe nullPos $ (`M.lookup` p) k)
     | (k, v) <- toList s
     ]
   phi (NVClosure'  _    _) = NSym "<closure>"
   phi (NVPath'     p     ) = NLiteralPath p
-  phi (NVBuiltin'  name _) = NSym $ coerce @Text $ "builtins." <> coerce name
+  phi (NVBuiltin'  name _) = NSym $ coerce ((mappend @Text) "builtins.") name
 
 prettyNValue
   :: forall t f m ann . MonadDataContext f m => NValue t f m -> Doc ann

--- a/src/Nix/Reduce.hs
+++ b/src/Nix/Reduce.hs
@@ -132,7 +132,7 @@ staticImport pann path =
 reduceExpr
   :: (MonadIO m, MonadFail m) => Maybe Path -> NExprLoc -> m NExprLoc
 reduceExpr mpath expr =
-  (`evalStateT` (mempty, mempty))
+  (`evalStateT` mempty)
     . (`runReaderT` (mpath, mempty))
     . runReducer
     $ foldFix reduce expr

--- a/src/Nix/Reduce.hs
+++ b/src/Nix/Reduce.hs
@@ -100,14 +100,14 @@ staticImport pann path =
           (\ err -> fail $ "Parse failed: " <> show err)
           (\ x -> do
             let
-              pos  = SourcePos "Reduce.hs" (mkPos 1) (mkPos 1)
-              span = SrcSpan pos pos
+              pos  = join (SourcePos "Reduce.hs") $ mkPos 1
+              span = join SrcSpan pos
               cur  =
                 NamedVar
-                  (StaticKey "__cur_file" :| mempty)
+                  (one $ StaticKey "__cur_file")
                   (NLiteralPathAnn pann path'')
                   pos
-              x' = NLetAnn span [cur] x
+              x' = NLetAnn span (one cur) x
             modify $ first $ HM.insert path'' x'
             local
               (const (pure path'', mempty)) $

--- a/src/Nix/Render.hs
+++ b/src/Nix/Render.hs
@@ -131,6 +131,6 @@ sourceContext path (unPos -> begLine) (unPos -> _begCol) (unPos -> endLine) (unP
         -- ATM some messages are so huge that they take prevalence over the source listing.
         -- ++ [ indent (length $ pad n) msg | n == endLine ]
 
-      ls' = concat $ zipWith composeLine [beg' ..] ls
+      ls' = fold $ zipWith composeLine [beg' ..] ls
 
     pure $ vsep $ ls' <> one (indent (Text.length $ pad begLine) msg)

--- a/src/Nix/Render.hs
+++ b/src/Nix/Render.hs
@@ -119,14 +119,16 @@ sourceContext path (unPos -> begLine) (unPos -> _begCol) (unPos -> endLine) (unP
           | n >= begLine && n <= endLine -> "  > " <> nsp <> " |  "
           | otherwise                    -> "    " <> nsp <> " |  "
       composeLine n l =
-        [pretty (pad n) <> l]
-        <> ([ pretty $
-              Text.replicate (Text.length (pad n) - 3) " "
-              <> "|"
-              <> Text.replicate (_begCol + 1) " "
-              <> Text.replicate (_endCol - _begCol) "^"
-            ] `whenTrue` (begLine == endLine && n == endLine)
-          )
+        one (pretty (pad n) <> l)
+        <> whenTrue
+            (one $
+              pretty $
+                Text.replicate (Text.length (pad n) - 3) " "
+                <> "|"
+                <> Text.replicate (_begCol + 1) " "
+                <> Text.replicate (_endCol - _begCol) "^"
+            )
+            (begLine == endLine && n == endLine)
         -- XXX: Consider inserting the message here when it is small enough.
         -- ATM some messages are so huge that they take prevalence over the source listing.
         -- ++ [ indent (length $ pad n) msg | n == endLine ]

--- a/src/Nix/Render/Frame.hs
+++ b/src/Nix/Render/Frame.hs
@@ -66,11 +66,12 @@ framePos
    . (Typeable m, Typeable v)
   => NixFrame
   -> Maybe SourcePos
-framePos (NixFrame _ f)
-  | Just (e :: EvalFrame m v) <- fromException f = case e of
+framePos (NixFrame _ f) =
+  (\case
     EvaluatingExpr _ (Ann (SrcSpan beg _) _) -> pure beg
     _ -> Nothing
-  | otherwise = Nothing
+  )
+  =<< fromException @(EvalFrame m v) f
 
 renderFrame
   :: forall v t f e m ann

--- a/src/Nix/Render/Frame.hs
+++ b/src/Nix/Render/Frame.hs
@@ -217,15 +217,10 @@ renderExecFrame
   => NixLevel
   -> ExecFrame t f m
   -> m [Doc ann]
-renderExecFrame level =
-  \case
-    Assertion ann v ->
-      fmap
-        (: mempty)
-        (do
-          d <- renderValue level "" "" v
-          renderLocation ann $ fillSep ["Assertion failed:", d]
-        )
+renderExecFrame level (Assertion ann v) =
+  fmap
+    one
+    $ renderLocation ann . fillSep . on (<>) one "Assertion failed:" =<< renderValue level mempty mempty v
 
 renderThunkLoop
   :: (MonadReader e m, Has e Options, MonadFile m, Show (ThunkId m))

--- a/src/Nix/Render/Frame.hs
+++ b/src/Nix/Render/Frame.hs
@@ -45,16 +45,16 @@ renderFrames (x : xs) = do
     | verbose opts <= ErrorsOnly -> renderFrame @v @t @f x
     | verbose opts <= Informational -> do
       f <- renderFrame @v @t @f x
-      pure $ concatMap go (reverse xs) <> f
-    | otherwise -> concat <$> traverse (renderFrame @v @t @f) (reverse (x : xs))
+      pure $ foldMap fun (reverse xs) <> f
+    | otherwise -> fold <$> traverse (renderFrame @v @t @f) (reverse (x : xs))
   pure $
     list
       mempty
       vsep
       frames
  where
-  go :: NixFrame -> [Doc ann]
-  go f =
+  fun :: NixFrame -> [Doc ann]
+  fun f =
     (\ pos -> ["While evaluating at " <> pretty (sourcePosPretty pos) <> colon]) `whenJust` framePos @v @m f
 
 framePos
@@ -169,7 +169,7 @@ renderValueFrame level = fmap (: mempty) . \case
   Multiplication _ _ -> pure "Multiplying"
 
   Coercion       x y -> pure
-    $ mconcat [desc, pretty (describeValue x), " to ", pretty (describeValue y)]
+    $ fold [desc, pretty (describeValue x), " to ", pretty (describeValue y)]
    where
     desc =
       bool

--- a/src/Nix/Render/Frame.hs
+++ b/src/Nix/Render/Frame.hs
@@ -171,7 +171,7 @@ renderValueFrame
   => NixLevel
   -> ValueFrame t f m
   -> m [Doc ann]
-renderValueFrame level = fmap (: mempty) . \case
+renderValueFrame level = fmap one . \case
   ForcingThunk    _t -> pure "ForcingThunk" -- jww (2019-03-18): NYI
   ConcerningValue _v -> pure "ConcerningValue"
   Comparison     _ _ -> pure "Comparing"
@@ -189,10 +189,10 @@ renderValueFrame level = fmap (: mempty) . \case
       (level <= Error)
 
   CoercionToJson v ->
-    ("CoercionToJson " <>) <$> renderValue level "" "" v
+    ("CoercionToJson " <>) <$> renderValue level mempty mempty v
   CoercionFromJson _j -> pure "CoercionFromJson"
   Expectation t v     ->
-    (msg <>) <$> renderValue @_ @t @f @m level "" "" v
+    (msg <>) <$> renderValue level mempty mempty v
    where
     msg = "Expected " <> pretty (describeValue t) <> ", but saw "
 

--- a/src/Nix/Render/Frame.hs
+++ b/src/Nix/Render/Frame.hs
@@ -235,9 +235,5 @@ renderNormalLoop
   => NixLevel
   -> NormalLoop t f m
   -> m [Doc ann]
-renderNormalLoop level =
-  fmap
-    one
-    . \case
-      NormalLoop v ->
-        ("Infinite recursion during normalization forcing " <>) <$> renderValue level mempty mempty v
+renderNormalLoop level (NormalLoop v) =
+  one . ("Infinite recursion during normalization forcing " <>) <$> renderValue level mempty mempty v

--- a/src/Nix/Render/Frame.hs
+++ b/src/Nix/Render/Frame.hs
@@ -232,7 +232,7 @@ renderThunkLoop
   => NixLevel
   -> ThunkLoop
   -> m [Doc ann]
-renderThunkLoop _level = pure . (: mempty) . \case
+renderThunkLoop _level = pure . one . \case
   ThunkLoop n -> pretty $ "Infinite recursion in thunk " <> n
 
 renderNormalLoop
@@ -242,7 +242,7 @@ renderNormalLoop
   -> m [Doc ann]
 renderNormalLoop level =
   fmap
-    (: mempty)
+    one
     . \case
       NormalLoop v ->
-        ("Infinite recursion during normalization forcing " <>) <$> renderValue level "" "" v
+        ("Infinite recursion during normalization forcing " <>) <$> renderValue level mempty mempty v

--- a/src/Nix/Render/Frame.hs
+++ b/src/Nix/Render/Frame.hs
@@ -184,9 +184,9 @@ renderValueFrame level = fmap one . \case
    where
     desc =
       bool
-      "While coercing "
-      "Cannot coerce "
-      (level <= Error)
+        "While coercing "
+        "Cannot coerce "
+        (level <= Error)
 
   CoercionToJson v ->
     ("CoercionToJson " <>) <$> renderValue level mempty mempty v
@@ -227,8 +227,8 @@ renderThunkLoop
   => NixLevel
   -> ThunkLoop
   -> m [Doc ann]
-renderThunkLoop _level = pure . one . \case
-  ThunkLoop n -> pretty $ "Infinite recursion in thunk " <> n
+renderThunkLoop _level (ThunkLoop n) =
+  pure . one . pretty $ "Infinite recursion in thunk " <> n
 
 renderNormalLoop
   :: (MonadReader e m, Has e Options, MonadFile m, MonadCitedThunks t f m)

--- a/src/Nix/String.hs
+++ b/src/Nix/String.hs
@@ -200,7 +200,7 @@ toNixLikeContextValue sc =
   , case scFlavor sc of
       DirectPath         -> NixLikeContextValue True False mempty
       AllOutputs         -> NixLikeContextValue False True mempty
-      DerivationOutput t -> NixLikeContextValue False False [t]
+      DerivationOutput t -> NixLikeContextValue False False $ one t
   )
 
 toNixLikeContext :: S.HashSet StringContext -> NixLikeContext

--- a/src/Nix/String/Coerce.hs
+++ b/src/Nix/String/Coerce.hs
@@ -78,7 +78,7 @@ coerceToString call ctsm clevel = go
           NVStr ns -> pure ns
           NVPath p ->
             bool
-              (castToNixString . toText)
+              (castToNixString . fromString . coerce)
               (fmap storePathToNixString . addPath)
               (ctsm == CopyToStore)
               p

--- a/src/Nix/String/Coerce.hs
+++ b/src/Nix/String/Coerce.hs
@@ -59,11 +59,7 @@ coerceToString call ctsm clevel = go
         case x' of
           -- TODO Return a singleton for "" and "1"
           NVConstant (NBool b) ->
-            castToNixString $
-              bool
-                ""
-                "1"
-                b
+            castToNixString $ "1" `whenTrue` b
           NVConstant (NInt n) ->
             castToNixString $
               show n
@@ -71,7 +67,7 @@ coerceToString call ctsm clevel = go
             castToNixString $
               show n
           NVConstant NNull ->
-            castToNixString ""
+            castToNixString mempty
           -- NVConstant: NAtom (NURI Text) is not matched
           NVList l ->
             nixStringUnwords <$> traverse go l

--- a/src/Nix/TH.hs
+++ b/src/Nix/TH.hs
@@ -18,18 +18,20 @@ import           Nix.Expr.Types.Annotated
 import           Nix.Parser
 
 quoteExprExp :: String -> ExpQ
-quoteExprExp s = do
-  expr <- parseExpr s
-  dataToExpQ
-    (extQOnFreeVars metaExp expr `extQ` (pure . (TH.lift :: Text -> Q Exp)))
-    expr
+quoteExprExp s =
+  do
+    expr <- parseExpr $ fromString s
+    dataToExpQ
+      (extQOnFreeVars metaExp expr `extQ` (pure . (TH.lift :: Text -> Q Exp)))
+      expr
 
 quoteExprPat :: String -> PatQ
-quoteExprPat s = do
-  expr <- parseExpr s
-  dataToPatQ
-    (extQOnFreeVars metaPat expr)
-    expr
+quoteExprPat s =
+  do
+    expr <- parseExpr $ fromString s
+    dataToPatQ
+      (extQOnFreeVars metaPat expr)
+      expr
 
 -- | Helper function.
 extQOnFreeVars
@@ -43,14 +45,14 @@ extQOnFreeVars
   -> NExpr
   -> b
   -> Maybe q
-extQOnFreeVars f e = extQ (const Nothing) (f $ freeVars e)
+extQOnFreeVars f = extQ (const Nothing) . f . freeVars
 
-parseExpr :: (MonadFail m, ToText a) => a -> m NExpr
-parseExpr s =
+parseExpr :: (MonadFail m) => Text -> m NExpr
+parseExpr =
   either
     (fail . show)
     pure
-    (parseNixText $ toText s)
+    . parseNixText
 
 freeVars :: NExpr -> Set VarName
 freeVars e = case unFix e of

--- a/src/Nix/Type/Env.hs
+++ b/src/Nix/Type/Env.hs
@@ -41,7 +41,7 @@ instance Monoid Env where
 
 instance One Env where
   type OneItem Env = (VarName, Scheme)
-  one = uncurry singleton
+  one (x, y) = TypeEnv $ one (x, one y)
 
 empty :: Env
 empty = TypeEnv mempty
@@ -68,7 +68,7 @@ mergeEnvs :: [Env] -> Env
 mergeEnvs = foldl' (<>) mempty
 
 singleton :: VarName -> Scheme -> Env
-singleton x y = TypeEnv $ one (x, [y])
+singleton = curry one
 
 keys :: Env -> [VarName]
 keys (TypeEnv env) = Map.keys env

--- a/src/Nix/Type/Env.hs
+++ b/src/Nix/Type/Env.hs
@@ -28,7 +28,7 @@ import qualified Data.Map                      as Map
 
 -- * Typing Environment
 
-newtype Env = TypeEnv (Map.Map VarName [Scheme])
+newtype Env = TypeEnv (Map VarName [Scheme])
   deriving (Eq, Show)
 
 instance Semigroup Env where
@@ -47,22 +47,22 @@ empty :: Env
 empty = TypeEnv mempty
 
 extend :: Env -> (VarName, [Scheme]) -> Env
-extend env (x, s) = TypeEnv $ Map.insert x s $ coerce env
+extend env (x, s) = coerce (Map.insert x s) env
 
 remove :: Env -> VarName -> Env
-remove (TypeEnv env) var = TypeEnv $ Map.delete var env
+remove env var = TypeEnv $ Map.delete var $ coerce env
 
 extends :: Env -> [(VarName, [Scheme])] -> Env
-extends env xs = TypeEnv $ Map.fromList xs <> coerce env
+extends env xs = fromList xs <> coerce env
 
 lookup :: VarName -> Env -> Maybe [Scheme]
-lookup key (TypeEnv tys) = Map.lookup key tys
+lookup key tys = Map.lookup key $ coerce tys
 
 merge :: Env -> Env -> Env
-merge (TypeEnv a) (TypeEnv b) = TypeEnv $ a <> b
+merge a b = TypeEnv $ coerce a <> coerce b
 
 mergeRight :: Env -> Env -> Env
-mergeRight (TypeEnv a) (TypeEnv b) = TypeEnv $ b <> a
+mergeRight = flip merge
 
 mergeEnvs :: [Env] -> Env
 mergeEnvs = foldl' (<>) mempty
@@ -74,7 +74,7 @@ keys :: Env -> [VarName]
 keys (TypeEnv env) = Map.keys env
 
 fromList :: [(VarName, [Scheme])] -> Env
-fromList xs = TypeEnv $ Map.fromList xs
+fromList xs = coerce $ Map.fromList xs
 
 toList :: Env -> [(VarName, [Scheme])]
 toList (TypeEnv env) = Map.toList env

--- a/src/Nix/Type/Infer.hs
+++ b/src/Nix/Type/Infer.hs
@@ -464,9 +464,10 @@ instance MonadInfer m => MonadEval (Judgment s) (InferT s m) where
       (join ((`Judgment` mempty) . curry one var))
       fresh
 
-  synHole var = do
-    tv <- fresh
-    pure $ Judgment (one (var, tv)) mempty tv
+  synHole var =
+    fmap
+      (join ((`Judgment` mempty) . curry one var))
+      fresh
 
   -- If we fail to look up an attribute, we just don't know the type.
   attrMissing _ _ = inferred <$> fresh

--- a/src/Nix/Type/Infer.hs
+++ b/src/Nix/Type/Infer.hs
@@ -531,17 +531,13 @@ instance MonadInfer m => MonadEval (Judgment s) (InferT s m) where
 
   evalBinary op (Judgment as1 cs1 t1) e2 = do
     Judgment as2 cs2 t2 <- e2
-    tv                  <- fresh
-    pure $
-      Judgment
-        (as1 <> as2)
-        ( cs1 <>
-          cs2 <>
-          binops
-            (t1 :~> t2 :~> tv)
-            op
-        )
-        tv
+    fmap
+      (join
+        $ Judgment
+          (as1 <> as2)
+          . (\ cs3 -> cs1 <> cs2 <> cs3) . (`binops` op) . (\ t3 -> t1 :~> t2 :~> t3)
+      )
+      fresh
 
   evalWith = Eval.evalWithAttrSet
 

--- a/src/Nix/Type/Infer.hs
+++ b/src/Nix/Type/Infer.hs
@@ -520,13 +520,14 @@ instance MonadInfer m => MonadEval (Judgment s) (InferT s m) where
   evalLiteralPath = const $ pure $ inferred typePath
   evalEnvPath     = const $ pure $ inferred typePath
 
-  evalUnary op (Judgment as1 cs1 t1) = do
-    tv <- fresh
-    pure $
-      Judgment
-        as1
-        (cs1 <> unops (t1 :~> tv) op)
-        tv
+  evalUnary op (Judgment as1 cs1 t1) =
+    fmap
+      (join
+        $ Judgment
+            as1
+            . (cs1 <>) . (`unops` op) . (t1 :~>)
+      )
+      fresh
 
   evalBinary op (Judgment as1 cs1 t1) e2 = do
     Judgment as2 cs2 t2 <- e2

--- a/src/Nix/Type/Infer.hs
+++ b/src/Nix/Type/Infer.hs
@@ -844,17 +844,15 @@ unifyMany []         []         = stub
 unifyMany (t1 : ts1) (t2 : ts2) = do
   su1 <- unifies t1 t2
   su2 <-
-    unifyMany
-      (apply su1 ts1)
-      (apply su1 ts2)
-  pure $ su2 `compose` su1
+    (unifyMany `on` apply su1) ts1 ts2
+  pure $ compose su1 su2
 unifyMany t1 t2 = throwError $ UnificationMismatch t1 t2
 
 nextSolvable :: [Constraint] -> (Constraint, [Constraint])
-nextSolvable xs = fromJust $ find solvable $ takeFirstOnes xs
+nextSolvable = fromJust . find solvable . pickFirstOne
  where
-  takeFirstOnes :: Eq a => [a] -> [(a, [a])]
-  takeFirstOnes xs = [ (x, ys) | x <- xs, let ys = delete x xs ]
+  pickFirstOne :: Eq a => [a] -> [(a, [a])]
+  pickFirstOne xs = [ (x, ys) | x <- xs, let ys = delete x xs ]
 
   solvable :: (Constraint, [Constraint]) -> Bool
   solvable (EqConst{}     , _) = True

--- a/src/Nix/Type/Infer.hs
+++ b/src/Nix/Type/Infer.hs
@@ -362,6 +362,19 @@ foldInitializedWith fld getter init =
   -- maybe here is some law?
   fmap fld . traverse (fmap getter . init)
 
+toJudgment :: forall t m s . (Traversable t, Monad m) => (t Type -> Type) -> t (Judgment s) -> InferT s m (Judgment s)
+toJudgment c xs =
+  liftA3 Judgment
+    (foldWith fold assumptions    )
+    (foldWith fold typeConstraints)
+    (foldWith c    inferredType   )
+   where
+    foldWith :: ((t a -> a) -> (Judgment s -> a) -> InferT s m a)
+    foldWith g f = uncurry (foldInitializedWith g f) tpl
+
+    tpl :: (Judgment s -> InferT s m (Judgment s), t (Judgment s))
+    tpl = (demand, xs)
+
 instance MonadInfer m
   => ToValue (AttrSet (Judgment s), PositionSet)
             (InferT s m) (Judgment s) where

--- a/src/Nix/Type/Infer.hs
+++ b/src/Nix/Type/Infer.hs
@@ -696,8 +696,7 @@ inferType env ex =
 -- | Solve for the toplevel type of an expression in a given environment
 inferExpr :: Env -> NExpr -> Either InferError [Scheme]
 inferExpr env ex =
-  (\ (subst, ty) -> closeOver $ subst `apply` ty) <<$>>
-    runInfer (inferType env ex)
+  closeOver . uncurry apply <<$>> runInfer (inferType env ex)
 
 unops :: Type -> NUnaryOp -> [Constraint]
 unops u1 op =

--- a/src/Nix/Type/Infer.hs
+++ b/src/Nix/Type/Infer.hs
@@ -80,9 +80,9 @@ normalizeScheme (Forall _ body) = Forall (snd <$> ord) (normtype body)
   fv (TVar a  ) = [a]
   fv (a :~> b ) = fv a <> fv b
   fv (TCon _  ) = mempty
-  fv (TSet _ a) = concatMap fv $ M.elems a
-  fv (TList a ) = concatMap fv a
-  fv (TMany ts) = concatMap fv ts
+  fv (TSet _ a) = foldMap fv $ M.elems a
+  fv (TList a ) = foldMap fv a
+  fv (TMany ts) = foldMap fv ts
 
   normtype (a :~> b ) = normtype a :~> normtype b
   normtype (TCon a  ) = TCon a

--- a/src/Nix/Type/Infer.hs
+++ b/src/Nix/Type/Infer.hs
@@ -767,7 +767,7 @@ binops u1 op =
       , typeString :| [typeString, typePath  ]
       ]
 
-  eqCnstMtx mtx = [EqConst u1 $ TMany $ map typeFun mtx]
+  eqCnstMtx mtx = [EqConst u1 $ TMany $ fmap typeFun mtx]
 
 liftInfer :: Monad m => m a -> InferT s m a
 liftInfer = InferT . lift . lift . lift

--- a/src/Nix/Type/Infer.hs
+++ b/src/Nix/Type/Infer.hs
@@ -459,9 +459,10 @@ instance MonadInfer m
 -}
 
 instance MonadInfer m => MonadEval (Judgment s) (InferT s m) where
-  freeVariable var = do
-    tv <- fresh
-    pure $ Judgment (one (var, tv)) mempty tv
+  freeVariable var =
+    fmap
+      (join ((`Judgment` mempty) . curry one var))
+      fresh
 
   synHole var = do
     tv <- fresh

--- a/src/Nix/Type/Infer.hs
+++ b/src/Nix/Type/Infer.hs
@@ -348,8 +348,7 @@ instance
   fromValueMay _ = stub
   fromValue =
     pure .
-      fromMaybe
-      (mempty, mempty)
+      maybeToMonoid
       <=< fromValueMay
 
 instance MonadInfer m
@@ -581,7 +580,7 @@ instance MonadInfer m => MonadEval (Judgment s) (InferT s m) where
 
     let
       f (as1, t1) (k, t) = (as1 <> one (k, t), M.insert k t t1)
-      (env, tys) = foldl' f (mempty, mempty) js
+      (env, tys) = foldl' f mempty js
       arg   = pure $ Judgment env mempty $ TSet Variadic tys
       call  = k arg $ \args b -> (args, ) <$> b
       names = fst <$> js
@@ -654,7 +653,7 @@ runInfer' :: MonadInfer m => InferT s m a -> m (Either InferError a)
 runInfer' =
   runExceptT
     . (`evalStateT` initInfer)
-    . (`runReaderT` (mempty, mempty))
+    . (`runReaderT` mempty)
     . getInfer
 
 runInfer :: (forall s . InferT s (FreshIdT Int (ST s)) a) -> Either InferError a

--- a/src/Nix/Type/Infer.hs
+++ b/src/Nix/Type/Infer.hs
@@ -703,13 +703,17 @@ inferExpr env ex =
 
 unops :: Type -> NUnaryOp -> [Constraint]
 unops u1 op =
-  [ EqConst u1
-   (case op of
-      NNot -> typeFun $ typeBool :| [typeBool]
-      NNeg -> TMany   [ typeFun $ typeInt :| [typeInt]
-                      , typeFun $ typeFloat :| [typeFloat] ]
-    )
-  ]
+  one $
+    EqConst u1 $
+      case op of
+        NNot -> mkUnaryConstr typeBool
+        NNeg -> TMany $ mkUnaryConstr <$> [typeInt, typeFloat]
+ where
+  mkUnaryConstr :: Type -> Type
+  mkUnaryConstr = typeFun . mk2same
+   where
+    mk2same :: a -> NonEmpty a
+    mk2same a = a :| one a
 
 binops :: Type -> NBinaryOp -> [Constraint]
 binops u1 op =

--- a/src/Nix/Type/Infer.hs
+++ b/src/Nix/Type/Infer.hs
@@ -800,13 +800,15 @@ newtype Solver m a = Solver (LogicT (StateT [TypeError] m) a)
     deriving (Functor, Applicative, Alternative, Monad, MonadPlus,
               MonadLogic, MonadState [TypeError])
 
-runSolver :: Monad m => Solver m a -> m (Either [TypeError] [a])
-runSolver (Solver s) = do
-  res <- runStateT (observeAllT s) mempty
-  pure $
-    case res of
-      (x : xs, _ ) -> pure (x : xs)
-      (_     , es) -> Left (ordNub es)
+runSolver :: forall m a . Monad m => Solver m a -> m (Either [TypeError] [a])
+runSolver (Solver s) =
+  uncurry report <$> runStateT (observeAllT s) mempty
+ where
+  report :: [a] -> [TypeError] -> Either [TypeError] [a]
+  report xs e =
+    if null xs
+      then Left (ordNub e)
+      else pure xs
 
 -- ** Instances
 

--- a/src/Nix/Type/Infer.hs
+++ b/src/Nix/Type/Infer.hs
@@ -201,9 +201,9 @@ newtype Subst = Subst (Map TVar Type)
 
 -- | Compose substitutions
 compose :: Subst -> Subst -> Subst
-Subst s1 `compose` Subst s2 =
-  Subst $
-    apply (Subst s1) <$>
+compose a@(Subst s2) (Subst s1) =
+  coerce $ --
+    apply a <$>
       (s2 <> s1)
 
 -- * class @Substitutable@

--- a/src/Nix/Type/Infer.hs
+++ b/src/Nix/Type/Infer.hs
@@ -789,10 +789,8 @@ infer = foldFix Eval.eval
 inferTop :: Env -> [(VarName, NExpr)] -> Either InferError Env
 inferTop env []                = pure env
 inferTop env ((name, ex) : xs) =
-  either
-    Left
-    (\ ty -> inferTop (extend env (name, ty)) xs)
-    (inferExpr env ex)
+  (\ ty -> inferTop (extend env (name, ty)) xs)
+    =<< inferExpr env ex
 
 -- * Other
 

--- a/src/Nix/Type/Infer.hs
+++ b/src/Nix/Type/Infer.hs
@@ -842,10 +842,9 @@ unifies (TList xs) (TList ys)
 -- Putting a statement that lists of different lengths containing various types would not
 -- be unified.
 unifies t1@(TList _    ) t2@(TList _    ) = throwError $ UnificationFail t1 t2
-unifies (TSet Variadic _) (TSet Variadic _)                                             = stub
-unifies (TSet Closed   b) (TSet Variadic s) | M.keys b `intersect` M.keys s == M.keys s = stub
-unifies (TSet Variadic s) (TSet Closed   b) | M.keys b `intersect` M.keys s == M.keys b = stub
-unifies (TSet Closed   s) (TSet Closed   b) | null (M.keys b \\ M.keys s)               = stub
+unifies (TSet Variadic _) (TSet Variadic _)                                 = stub
+unifies (TSet Closed   s) (TSet Closed   b) | null (M.keys b \\ M.keys s)   = stub
+unifies (TSet _ a) (TSet _ b) | (M.keys a `intersect` M.keys b) == M.keys b = stub
 unifies (t1 :~> t2) (t3 :~> t4) = unifyMany [t1, t2] [t3, t4]
 unifies (TMany t1s) t2          = considering t1s >>- (`unifies` t2)
 unifies t1          (TMany t2s) = considering t2s >>- unifies t1

--- a/src/Nix/Type/Infer.hs
+++ b/src/Nix/Type/Infer.hs
@@ -464,16 +464,16 @@ instance MonadInfer m
                            f =<< Judgment mempty mempty <$> fresh
 -}
 
-instance MonadInfer m => MonadEval (Judgment s) (InferT s m) where
-  freeVariable var =
+polymorphicVar :: MonadInfer m => VarName -> InferT s m (Judgment s)
+polymorphicVar var =
     fmap
       (join ((`Judgment` mempty) . curry one var))
       fresh
 
-  synHole var =
-    fmap
-      (join ((`Judgment` mempty) . curry one var))
-      fresh
+instance MonadInfer m => MonadEval (Judgment s) (InferT s m) where
+  freeVariable = polymorphicVar
+
+  synHole = polymorphicVar
 
   -- If we fail to look up an attribute, we just don't know the type.
   attrMissing _ _ = inferred <$> fresh

--- a/src/Nix/Type/Infer.hs
+++ b/src/Nix/Type/Infer.hs
@@ -357,6 +357,11 @@ instance
       maybeToMonoid
       <=< fromValueMay
 
+foldInitializedWith :: (Traversable t, Applicative f) => (t c -> c) -> (b -> c) -> (a -> f b) -> t a -> f c
+foldInitializedWith fld getter init =
+  -- maybe here is some law?
+  fmap fld . traverse (fmap getter . init)
+
 instance MonadInfer m
   => ToValue (AttrSet (Judgment s), PositionSet)
             (InferT s m) (Judgment s) where

--- a/src/Nix/Type/Type.hs
+++ b/src/Nix/Type/Type.hs
@@ -3,7 +3,7 @@
 --   Therefore -> from this the type inference follows.
 module Nix.Type.Type where
 
-import           Prelude                 hiding ( Type, TVar )
+import           Prelude                 hiding (Type, TVar)
 import           Nix.Expr.Types
 
 -- | Hindrey-Milner type interface
@@ -31,6 +31,15 @@ infixr 1 :~>
 data Scheme = Forall [TVar] Type -- ^ @Forall [TVar] Type@: the Nix type system @forall vars. type@.
   deriving (Show, Eq, Ord)
 
+-- | Concrete types in the Nix type system.
+typeNull, typeBool, typeInt, typeFloat, typeString, typePath :: Type
+typeNull   = TCon "null"
+typeBool   = TCon "boolean"
+typeInt    = TCon "integer"
+typeFloat  = TCon "float"
+typeString = TCon "string"
+typePath   = TCon "path"
+
 -- This models a set that unifies with any other set.
 typeSet :: Type
 typeSet = TSet mempty mempty
@@ -40,12 +49,3 @@ typeList = TList mempty
 
 typeFun :: NonEmpty Type -> Type
 typeFun (head_ :| tail_) = foldr (:~>) head_ tail_
-
--- | Concrete types in the Nix type system.
-typeInt, typeFloat, typeBool, typeString, typePath, typeNull :: Type
-typeInt    = TCon "integer"
-typeFloat  = TCon "float"
-typeBool   = TCon "boolean"
-typeString = TCon "string"
-typePath   = TCon "path"
-typeNull   = TCon "null"

--- a/src/Nix/XML.hs
+++ b/src/Nix/XML.hs
@@ -47,12 +47,7 @@ toXML = runWithStringContext . fmap pp . iterNValueByDiscardWith cyc phi
     NVStr' str ->
       mkEVal "string" <$> extractNixString str
     NVList' l ->
-      do
-        els <- sequenceA l
-        pure $
-          mkE
-            "list"
-            (Elem <$> els)
+      mkE "list" . fmap Elem <$> sequenceA l
 
     NVSet' _ s ->
       do

--- a/src/Nix/XML.hs
+++ b/src/Nix/XML.hs
@@ -50,28 +50,28 @@ toXML = runWithStringContext . fmap pp . iterNValueByDiscardWith cyc phi
       mkE "list" . fmap Elem <$> sequenceA l
 
     NVSet' _ s ->
-      do
-        kvs <- sequenceA s
-        pure $
-          mkE
-            "attrs"
-            ((\ (k, v) ->
-                Elem $
-                  Element
-                    (unqual "attr")
-                    (one $ Attr (unqual "name") $ toString k)
-                    (one $ Elem v)
-                    Nothing
-              ) <$>
-                sortWith fst (M.toList kvs)
-            )
+      mkE
+        "attrs"
+        . fmap
+            mkElem'
+            . sortWith fst . M.toList
+        <$> sequenceA s
+     where
+      mkElem' :: (VarName, Element) -> Content
+      mkElem' (k, v) =
+        Elem $
+          Element
+            (unqual "attr")
+            (one $ Attr (unqual "name") $ toString k)
+            (one $ Elem v)
+            Nothing
 
     NVClosure' p _ ->
       pure $
         mkE
           "function"
           (paramsXML p)
-    NVPath' fp        -> pure $ mkEVal "path" (fromString $ coerce fp)
+    NVPath' fp        -> pure $ mkEVal "path" $ fromString $ coerce fp
     NVBuiltin' name _ -> pure $ mkEName "function" name
 
 mkE :: Text -> [Content] -> Element

--- a/src/Nix/XML.hs
+++ b/src/Nix/XML.hs
@@ -20,13 +20,14 @@ toXML = runWithStringContext . fmap pp . iterNValueByDiscardWith cyc phi
  where
   cyc = pure $ mkEVal "string" "<expr>"
 
+  pp :: Element -> Text
   pp e =
     heading
     <> fromString
         (ppElement $
           mkE
             "expr"
-            [Elem e]
+            (one $ Elem e)
         )
     <> "\n"
    where
@@ -63,8 +64,8 @@ toXML = runWithStringContext . fmap pp . iterNValueByDiscardWith cyc phi
                 Elem $
                   Element
                     (unqual "attr")
-                    [Attr (unqual "name") (toString k)]
-                    [Elem v]
+                    (one $ Attr (unqual "name") $ toString k)
+                    (one $ Elem v)
                     Nothing
               ) <$>
                 sortWith fst (M.toList kvs)
@@ -90,7 +91,7 @@ mkElem :: String -> String -> String -> Element
 mkElem n a v =
   Element
     (unqual n)
-    [Attr (unqual a) v]
+    (one $ Attr (unqual a) v)
     mempty
     Nothing
 
@@ -101,14 +102,14 @@ mkEName :: String -> String -> Element
 mkEName = (`mkElem` "name")
 
 paramsXML :: Params r -> [Content]
-paramsXML (Param name) = [Elem $ mkEName "varpat" (toString name)]
+paramsXML (Param name) = one $ Elem $ mkEName "varpat" $ toString name
 paramsXML (ParamSet mname variadic pset) =
-  [Elem $ Element (unqual "attrspat") (battr <> nattr) (paramSetXML pset) Nothing]
+  one $ Elem $ Element (unqual "attrspat") (battr <> nattr) (paramSetXML pset) Nothing
  where
   battr =
-    [ Attr (unqual "ellipsis") "1" ] `whenTrue` (variadic == Variadic)
+    one (Attr (unqual "ellipsis") "1") `whenTrue` (variadic == Variadic)
   nattr =
-    ((: mempty) . Attr (unqual "name") . toString) `whenJust` mname
+    (one . Attr (unqual "name") . toString) `whenJust` mname
 
 paramSetXML :: ParamSet r -> [Content]
-paramSetXML = fmap (\(k, _) -> Elem $ mkEName "attr" (toString k))
+paramSetXML = fmap (Elem . mkEName "attr" . toString . fst)

--- a/tests/EvalTests.hs
+++ b/tests/EvalTests.hs
@@ -526,11 +526,10 @@ freeVarsEqual a xs =
       Right a' = parseNixText a
       xs' = S.fromList xs
       free' = freeVars a'
-    assertEqual "" xs' free'
+    assertEqual mempty xs' free'
 
 maskedFiles :: [Path]
-maskedFiles =
-  [ "builtins.fetchurl-01.nix" ]
+maskedFiles = one "builtins.fetchurl-01.nix"
 
 testDir :: Path
 testDir = "tests/eval-compare"

--- a/tests/EvalTests.hs
+++ b/tests/EvalTests.hs
@@ -22,10 +22,14 @@ import           Test.Tasty.TH
 import           TestCommon
 
 case_basic_sum =
-    constantEqualText "2" "1 + 1"
+  constantEqualText
+    "2"
+    "1 + 1"
 
 case_basic_div =
-    constantEqualText "3" "builtins.div 6 2"
+  constantEqualText
+    "3"
+    "builtins.div 6 2"
 
 case_zero_div =
   traverse_ assertNixEvalThrows
@@ -43,107 +47,157 @@ case_bit_ops =
     ]
 
 case_basic_function =
-    constantEqualText "2" "(a: a) 2"
+  constantEqualText
+    "2"
+    "(a: a) 2"
 
 case_set_attr =
-    constantEqualText "2" "{ a = 2; }.a"
+  constantEqualText
+    "2"
+    "{ a = 2; }.a"
 
 case_function_set_arg =
-    constantEqualText "2" "({ a }: 2) { a = 1; }"
+  constantEqualText
+    "2"
+    "({ a }: 2) { a = 1; }"
 
 case_function_set_two_arg =
-    constantEqualText "2" "({ a, b ? 3 }: b - a) { a = 1; }"
+  constantEqualText
+    "2"
+    "({ a, b ? 3 }: b - a) { a = 1; }"
 
 case_function_set_two_arg_default_scope =
-    constantEqualText "2" "({ x ? 1, y ? x * 3 }: y - x) {}"
+  constantEqualText
+    "2"
+    "({ x ? 1, y ? x * 3 }: y - x) {}"
 
 case_function_default_env =
-    constantEqualText "2" "let default = 2; in ({ a ? default }: a) {}"
+  constantEqualText
+    "2"
+    "let default = 2; in ({ a ? default }: a) {}"
 
 case_function_definition_uses_environment =
-    constantEqualText "3" "let f = (let a=1; in x: x+a); in f 2"
+  constantEqualText
+    "3"
+    "let f = (let a=1; in x: x+a); in f 2"
 
 case_function_atpattern =
-    -- jww (2018-05-09): This should be constantEqualText
-    constantEqualText' "2" "(({a}@attrs:attrs) {a=2;}).a"
+  -- jww (2018-05-09): This should be constantEqualText
+  constantEqualText'
+    "2"
+    "(({a}@attrs:attrs) {a=2;}).a"
 
 case_function_ellipsis =
-    -- jww (2018-05-09): This should be constantEqualText
-    constantEqualText' "2" "(({a, ...}@attrs:attrs) {a=0; b=2;}).b"
+  -- jww (2018-05-09): This should be constantEqualText
+  constantEqualText'
+    "2"
+    "(({a, ...}@attrs:attrs) {a=0; b=2;}).b"
 
 case_function_default_value_not_in_atpattern =
-    constantEqualText "false" "({a ? 2}@attrs: attrs ? a) {}"
+  constantEqualText
+    "false"
+    "({a ? 2}@attrs: attrs ? a) {}"
 
 case_function_arg_shadowing =
-    constantEqualText "6" "(y: y: x: x: x + y) 1 2 3 4"
+  constantEqualText
+    "6"
+    "(y: y: x: x: x + y) 1 2 3 4"
 
 case_function_recursive_args =
-    constantEqualText "2" "({ x ? 1, y ? x * 3}: y - x) {}"
+  constantEqualText
+    "2"
+    "({ x ? 1, y ? x * 3}: y - x) {}"
 
 case_function_recursive_sets =
-    constantEqualText "[ [ 6 4 100 ] 4 ]" [text|
-        let x = rec {
+  constantEqualText
+    "[ [ 6 4 100 ] 4 ]"
+    [text|
+      let x = rec {
 
-          y = 2;
-          z = { w = 4; };
-          v = rec {
-            u = 6;
-            t = [ u z.w s ];
-          };
+        y = 2;
+        z = { w = 4; };
+        v = rec {
+          u = 6;
+          t = [ u z.w s ];
+        };
 
-        }; s = 100; in [ x.v.t x.z.w ]
+      }; s = 100; in [ x.v.t x.z.w ]
     |]
 
 case_nested_with =
-    constantEqualText "2" "with { x = 1; }; with { x = 2; }; x"
+  constantEqualText
+    "2"
+    "with { x = 1; }; with { x = 2; }; x"
 
 case_with_strictness =
-    constantEqualText "5" "let x = with x; with { a = 5; }; a; in x"
+  constantEqualText
+    "5"
+    "let x = with x; with { a = 5; }; a; in x"
 
 case_match_failure_null =
-    constantEqualText "null" "builtins.match \"ab\" \"abc\""
+  constantEqualText
+    "null"
+    "builtins.match \"ab\" \"abc\""
 
 case_find_file_success_no_prefix =
-    constantEqualText "./tests/files/findFile.nix"
-                      "builtins.findFile [{ path=\"./tests/files\"; prefix=\"\"; }] \"findFile.nix\""
+  constantEqualText
+    "./tests/files/findFile.nix"
+    "builtins.findFile [{ path=\"./tests/files\"; prefix=\"\"; }] \"findFile.nix\""
 
 case_find_file_success_with_prefix =
-    constantEqualText "./tests/files/findFile.nix"
-                      "builtins.findFile [{ path=\"./tests/files\"; prefix=\"nix\"; }] \"nix/findFile.nix\""
+  constantEqualText
+    "./tests/files/findFile.nix"
+    "builtins.findFile [{ path=\"./tests/files\"; prefix=\"nix\"; }] \"nix/findFile.nix\""
 
 case_find_file_success_folder =
-    constantEqualText "./tests/files"
-                      "builtins.findFile [{ path=\"./tests\"; prefix=\"\"; }] \"files\""
+  constantEqualText
+    "./tests/files"
+    "builtins.findFile [{ path=\"./tests\"; prefix=\"\"; }] \"files\""
 
 case_find_file_failure_not_found =
-    assertNixEvalThrows "builtins.findFile [{ path=\"./tests/files\"; prefix=\"\"; }] \"not_found.nix\""
+  assertNixEvalThrows
+    "builtins.findFile [{ path=\"./tests/files\"; prefix=\"\"; }] \"not_found.nix\""
 
 case_find_file_failure_invalid_arg_1 =
-    assertNixEvalThrows "builtins.findFile 1 \"files\""
+  assertNixEvalThrows
+    "builtins.findFile 1 \"files\""
 
 case_find_file_failure_invalid_arg_2 =
-    assertNixEvalThrows "builtins.findFile [{ path=\"./tests/files\"; prefix=\"\"; }] 2"
+  assertNixEvalThrows
+    "builtins.findFile [{ path=\"./tests/files\"; prefix=\"\"; }] 2"
 
 case_find_file_failure_invalid_arg_no_path =
-    assertNixEvalThrows "builtins.findFile [{ prefix=\"\"; }] \"files\""
+  assertNixEvalThrows
+    "builtins.findFile [{ prefix=\"\"; }] \"files\""
 
 case_infinite_recursion =
-    assertNixEvalThrows "let foo = a: bar a; bar = a: foo a; in foo 3"
+  assertNixEvalThrows
+    "let foo = a: bar a; bar = a: foo a; in foo 3"
 
 case_nested_let =
-    constantEqualText "3" "let a = 3; x.x = 2; in a"
+  constantEqualText
+    "3"
+    "let a = 3; x.x = 2; in a"
 
 case_nested_nested_let =
-    constantEqualText "3" "let a = 3; x.x = let b = a; in b; c = x.x; in c"
+  constantEqualText
+    "3"
+    "let a = 3; x.x = let b = a; in b; c = x.x; in c"
 
 case_inherit_in_rec_set =
-    constantEqualText "1" "let x = 1; in (rec { inherit x; }).x"
+  constantEqualText
+    "1"
+    "let x = 1; in (rec { inherit x; }).x"
 
 case_lang_version =
-    constantEqualText "5" "builtins.langVersion"
+  constantEqualText
+    "5"
+    "builtins.langVersion"
 
 case_rec_set_attr_path_simpl =
-    constantEqualText "123" [text|
+  constantEqualText
+    "123"
+    [text|
       let x = rec {
         foo.number = 123;
         foo.function = y: foo.number;
@@ -151,7 +205,9 @@ case_rec_set_attr_path_simpl =
     |]
 
 case_inherit_from_set_has_no_scope =
-    constantEqualText' "false" [text|
+  constantEqualText'
+    "false"
+    [text|
       (builtins.tryEval (
         let x = 1;
             y = { z = 2; };
@@ -285,85 +341,100 @@ case_unsafegetattrpos =
     ]
 
 case_fixed_points =
-    constantEqualText [text|[
-  {
-    foobar = "foobar";
-    foo = "foo";
-    bar = "bar";
-  }
-  {
-    foobar = "foo + bar";
-    foo = "foo + ";
-    bar = "bar";
-  }
-]|] [text|
-    let
-      fix = f: let x = f x; in x;
-      extends = f: rattrs: self:
-        let super = rattrs self; in super // f self super;
-      f = self: { foo = "foo";
-                  bar = "bar";
-                  foobar = self.foo + self.bar; };
-      g = self: super: { foo = super.foo + " + "; };
-    in [ (fix f) (fix (extends g f)) ]
-|]
+  constantEqualText
+    [text|
+      [
+        {
+          foobar = "foobar";
+          foo = "foo";
+          bar = "bar";
+        }
+        {
+          foobar = "foo + bar";
+          foo = "foo + ";
+          bar = "bar";
+        }
+      ]
+    |]
+    [text|
+      let
+        fix = f: let x = f x; in x;
+        extends = f: rattrs: self:
+          let super = rattrs self; in super // f self super;
+        f = self: { foo = "foo";
+                    bar = "bar";
+                    foobar = self.foo + self.bar; };
+        g = self: super: { foo = super.foo + " + "; };
+      in [ (fix f) (fix (extends g f)) ]
+    |]
 
 case_fixed_points_and_fold =
-    constantEqualText [text|[ {} {} ]|] [text|
-let
-  extends = f: rattrs: self:
-    let super = rattrs self; in super // f self super;
-  flip = f: a: b: f b a;
-  toFixFold = builtins.foldl' (flip extends) (self: {}) ([(self: super: {})]);
-  toFix = extends (self: super: {}) (self: {});
-  fix = f: let x = f x; in x;
-in [ (fix toFixFold) (fix toFix) ]
-|]
+  constantEqualText
+    [text|
+      [ {} {} ]
+    |]
+    [text|
+      let
+        extends = f: rattrs: self:
+          let super = rattrs self; in super // f self super;
+        flip = f: a: b: f b a;
+        toFixFold = builtins.foldl' (flip extends) (self: {}) ([(self: super: {})]);
+        toFix = extends (self: super: {}) (self: {});
+        fix = f: let x = f x; in x;
+      in [ (fix toFixFold) (fix toFix) ]
+    |]
 
 case_fixed_points_attrsets =
-    constantEqualText "{ x = { y = { z = 100; }; z = { y = 100; }; }; }" [text|
+  constantEqualText
+    "{ x = { y = { z = 100; }; z = { y = 100; }; }; }"
+    [text|
       let fix = f: let x = f x; in x;
           f = self: { x.z.y = 100; x.y.z = self.x.z.y; };
       in fix f
     |]
 
 case_function_equals =
-    traverse_ (uncurry constantEqualText)
-      [ -- ( "true"
-        -- , "{f = x: x;} == {f = x: x;}"
-        -- )
-        -- ( "true"
-        -- , "[(x: x)] == [(x: x)]"
-        -- )
-        ( "false"
-        , "(let a = (x: x); in a == a)"
-        )
-      , ( "true"
-        , "(let a = {f = x: x;}; in a == a)"
-        )
-      , ( "true"
-        , "(let a = [(x: x)]; in a == a)"
-        )
-      , ( "false"
-        , "builtins.pathExists \"/var/empty/invalid-directory\""
-        )
-      ]
+  traverse_ (uncurry constantEqualText)
+    [ -- ( "true"
+      -- , "{f = x: x;} == {f = x: x;}"
+      -- )
+      -- ( "true"
+      -- , "[(x: x)] == [(x: x)]"
+      -- )
+      ( "false"
+      , "(let a = (x: x); in a == a)"
+      )
+    , ( "true"
+      , "(let a = {f = x: x;}; in a == a)"
+      )
+    , ( "true"
+      , "(let a = [(x: x)]; in a == a)"
+      )
+    , ( "false"
+      , "builtins.pathExists \"/var/empty/invalid-directory\""
+      )
+    ]
 
 case_directory_pathexists =
-    constantEqualText "false" "builtins.pathExists \"/var/empty/invalid-directory\""
+  constantEqualText
+    "false"
+    "builtins.pathExists \"/var/empty/invalid-directory\""
 
 -- jww (2018-05-02): This constantly changes!
 case_placeholder =
   constantEqualText
-      "\"/1rz4g4znpzjwh1xymhjpm42vipw92pr73vdgl6xs1hycac8kf2n9\""
-      "builtins.placeholder \"out\""
+    "\"/1rz4g4znpzjwh1xymhjpm42vipw92pr73vdgl6xs1hycac8kf2n9\""
+    "builtins.placeholder \"out\""
 
 case_rec_path_attr =
-    constantEqualText "10"
-        "let src = 10; x = rec { passthru.src = src; }; in x.passthru.src"
+  constantEqualText
+    "10"
+    "let src = 10; x = rec { passthru.src = src; }; in x.passthru.src"
 
 case_mapattrs_builtin =
-    constantEqualText' "{ a = \"afoo\"; b = \"bbar\"; }" [text|
+  constantEqualText'
+    "{ a = \"afoo\"; b = \"bbar\"; }"
+    [text|
       (builtins.mapAttrs (x: y: x + y) {
         a = "foo";
         b = "bar";
@@ -391,60 +462,102 @@ case_expression_split =
     "(x: builtins.deepSeq x x) (builtins.split \"(a)b\" \"abc\")"
 
 case_empty_string_equal_null_is_false =
-  constantEqualText "false" "\"\" == null"
+  constantEqualText
+    "false"
+    "\"\" == null"
 
 case_null_equal_empty_string_is_false =
-  constantEqualText "false" "null == \"\""
+  constantEqualText
+    "false"
+    "null == \"\""
 
 case_empty_string_not_equal_null_is_true =
-  constantEqualText "true" "\"\" != null"
+  constantEqualText
+    "true"
+    "\"\" != null"
 
 case_null_equal_not_empty_string_is_true =
-  constantEqualText "true" "null != \"\""
+  constantEqualText
+    "true"
+    "null != \"\""
 
 case_list_nested_bottom_diverges =
-  assertNixEvalThrows "let nested = [(let x = x; in x)]; in nested == nested"
+  assertNixEvalThrows
+    "let nested = [(let x = x; in x)]; in nested == nested"
 
 case_attrset_nested_bottom_diverges =
-  assertNixEvalThrows "let nested = { y = (let x = x; in x); }; in nested == nested"
+  assertNixEvalThrows
+    "let nested = { y = (let x = x; in x); }; in nested == nested"
 
 case_list_list_nested_bottom_equal =
-  constantEqualText "true" "let nested = [[(let x = x; in x)]]; in nested == nested"
+  constantEqualText
+    "true"
+    "let nested = [[(let x = x; in x)]]; in nested == nested"
 
 case_list_attrset_nested_bottom_equal =
-  constantEqualText "true" "let nested = [{ y = (let x = x; in x); }]; in nested == nested"
+  constantEqualText
+    "true"
+    "let nested = [{ y = (let x = x; in x); }]; in nested == nested"
 
 case_list_function_nested_bottom_equal =
-  constantEqualText "true" "let nested = [(_: let x = x; in x)]; in nested == nested"
+  constantEqualText
+    "true"
+    "let nested = [(_: let x = x; in x)]; in nested == nested"
 
 case_attrset_list_nested_bottom_equal =
-  constantEqualText "true" "let nested = { y = [(let x = x; in x)];}; in nested == nested"
+  constantEqualText
+    "true"
+    "let nested = { y = [(let x = x; in x)];}; in nested == nested"
 
 case_attrset_attrset_nested_bottom_equal =
-  constantEqualText "true" "let nested = { y = { y = (let x = x; in x); }; }; in nested == nested"
+  constantEqualText
+    "true"
+    "let nested = { y = { y = (let x = x; in x); }; }; in nested == nested"
 
 case_attrset_function_nested_bottom_equal =
-  constantEqualText "true" "let nested = { y = _: (let x = x; in x); }; in nested == nested"
+  constantEqualText
+    "true"
+    "let nested = { y = _: (let x = x; in x); }; in nested == nested"
 
 -- Regression test for #527
 
 case_add_string_thunk_left =
-  constantEqualText [text|"cygwin"|] [text|builtins.head ["cyg"] + "win"|]
+  constantEqualText
+    [text|
+      "cygwin"
+    |]
+    [text|
+      builtins.head ["cyg"] + "win"
+    |]
 
 case_add_string_thunk_right =
-  constantEqualText [text|"cygwin"|] [text|"cyg" + builtins.head ["win"]|]
+  constantEqualText
+    [text|
+      "cygwin"
+    |]
+    [text|
+      "cyg" + builtins.head ["win"]
+    |]
 
 case_add_int_thunk_left =
-  constantEqualText "3" "builtins.head [1] + 2"
+  constantEqualText
+    "3"
+    "builtins.head [1] + 2"
 
 case_add_int_thunk_right =
-  constantEqualText "3" "1 + builtins.head [2]"
+  constantEqualText
+    "3"
+    "1 + builtins.head [2]"
 
 case_concat_thunk_left =
-  constantEqualText "[1 2 3]" "builtins.tail [0 1 2] ++ [3]"
+  constantEqualText
+    "[1 2 3]"
+    "builtins.tail [0 1 2] ++ [3]"
 
 case_concat_thunk_rigth =
-  constantEqualText "[1 2 3]" "[1] ++ builtins.tail [1 2 3]"
+  constantEqualText
+    "[1 2 3]"
+    "[1] ++ builtins.tail [1 2 3]"
 
 ---------------------------------------------------------------------------------
 
@@ -453,7 +566,7 @@ tests = $testGroupGenerator
 
 genEvalCompareTests =
   do
-    (coerce -> files :: [Path]) <- D.listDirectory (coerce testDir)
+    (coerce -> files :: [Path]) <- D.listDirectory $ coerce testDir
 
     let
       unmaskedFiles :: [Path]
@@ -499,7 +612,7 @@ constantEqualText :: Text -> Text -> Assertion
 constantEqualText expected actual =
   do
     constantEqualText' expected actual
-    mres <- liftIO $ lookupEnv "ALL_TESTS" <|> lookupEnv "MATCHING_TESTS"
+    mres <- liftIO $ on (<|>) lookupEnv "ALL_TESTS" "MATCHING_TESTS"
     whenJust (const $ assertEvalMatchesNix actual) mres
 
 assertNixEvalThrows :: Text -> Assertion

--- a/tests/EvalTests.hs
+++ b/tests/EvalTests.hs
@@ -598,7 +598,7 @@ constantEqual expected actual =
         "Inequal normal forms:\n"
         <> "Expected: " <> printNix expectedNF <> "\n"
         <>  "Actual:   " <> printNix actualNF
-    assertBool message eq
+    assertBool (toString message) eq
  where
   getNormForm = normalForm <=< nixEvalExprLoc mempty
 

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -64,7 +64,7 @@ ensureNixpkgsCanParse =
         when (null files) $
           errorWithoutStackTrace $
             "Directory " <> show dir <> " does not have any files"
-        for_ files $ \file -> do
+        for_ files $ \file ->
           unless ("azure-cli/default.nix" `isSuffixOf` file ||
                   "os-specific/linux/udisks/2-default.nix"  `isSuffixOf` file) $ do
             -- Parse and deepseq the resulting expression tree, to ensure the

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -95,18 +95,18 @@ main = do
   prettyTestsEnv      <- lookupEnv "PRETTY_TESTS"
 
   pwd <- getCurrentDirectory
-  setEnv "NIX_REMOTE" (pwd <> "/real-store")
-  setEnv "NIX_DATA_DIR" (pwd <> "/data")
+  setEnv "NIX_REMOTE" $ pwd <> "/real-store"
+  setEnv "NIX_DATA_DIR" $ pwd <> "/data"
 
   defaultMain $ testGroup "hnix" $
     [ ParserTests.tests
     , EvalTests.tests
     , PrettyTests.tests
-    , ReduceExprTests.tests] <>
-    [ PrettyParseTests.tests
-        (fromIntegral (read (fromMaybe "0" prettyTestsEnv) :: Int)) ] <>
-    [ evalComparisonTests ] <>
-    [ testCase "Nix language tests present" ensureLangTestsPresent
+    , ReduceExprTests.tests
+    , PrettyParseTests.tests $ fromIntegral $ read @Int $ fromMaybe "0" prettyTestsEnv
+    , evalComparisonTests
+    , testCase "Nix language tests present" ensureLangTestsPresent
     , nixLanguageTests ] <>
     [ testCase "Nixpkgs parses without errors" ensureNixpkgsCanParse
-      | isJust nixpkgsTestsEnv ]
+      | isJust nixpkgsTestsEnv
+    ]

--- a/tests/NixLanguageTests.hs
+++ b/tests/NixLanguageTests.hs
@@ -66,11 +66,10 @@ newFailingTests = Set.fromList
 -- | Upstream tests that test cases that HNix disaded as a misfeature that is used so rarely
 -- that it more effective to fix it & lint it out of existance.
 deprecatedRareNixQuirkTests :: Set String
-deprecatedRareNixQuirkTests = Set.fromList
-  [
+deprecatedRareNixQuirkTests = Set.fromList $
+  one
     -- A rare quirk of Nix that is proper to fix&enforce then to support (see git commit history)
     "eval-okay-strings-as-attrs-names"
-  ]
 
 genTests :: IO TestTree
 genTests =
@@ -81,7 +80,7 @@ genTests =
       testsGroupedByName = groupBy (takeFileName . dropExtensions) testFiles
 
       testsGroupedByTypeThenName :: Map [String] [(Path, [Path])]
-      testsGroupedByTypeThenName = groupBy testType (Map.toList testsGroupedByName)
+      testsGroupedByTypeThenName = groupBy testType $ Map.toList testsGroupedByName
 
       testTree :: [TestTree]
       testTree = mkTestGroup <$> Map.toList testsGroupedByTypeThenName
@@ -159,14 +158,14 @@ assertLangOk opts fileBaseName =
   do
     actual   <- printNix <$> hnixEvalFile opts (addNixExt fileBaseName)
     expected <- read fileBaseName ".exp"
-    assertEqual "" expected $ fromString (actual <> "\n")
+    assertEqual mempty expected $ fromString (actual <> "\n")
 
 assertLangOkXml :: Options -> Path -> Assertion
 assertLangOkXml opts fileBaseName =
   do
     actual <- stringIgnoreContext . toXML <$> hnixEvalFile opts (addNixExt fileBaseName)
     expected <- read fileBaseName ".exp.xml"
-    assertEqual "" expected actual
+    assertEqual mempty expected actual
 
 assertEval :: Options -> [Path] -> Assertion
 assertEval _opts files =

--- a/tests/NixLanguageTests.hs
+++ b/tests/NixLanguageTests.hs
@@ -158,7 +158,7 @@ assertLangOk opts fileBaseName =
   do
     actual   <- printNix <$> hnixEvalFile opts (addNixExt fileBaseName)
     expected <- read fileBaseName ".exp"
-    assertEqual mempty expected $ fromString (actual <> "\n")
+    assertEqual mempty expected (actual <> "\n")
 
 assertLangOkXml :: Options -> Path -> Assertion
 assertLangOkXml opts fileBaseName =
@@ -218,7 +218,7 @@ assertEvalFail file =
   do
     time       <- liftIO getCurrentTime
     evalResult <- printNix <$> hnixEvalFile (defaultOptions time) file
-    evalResult `seq` assertFailure $ "File: ''" <> coerce file <> "'' should not evaluate.\nThe evaluation result was `" <> evalResult <> "`."
+    evalResult `seq` assertFailure $ "File: ''" <> coerce file <> "'' should not evaluate.\nThe evaluation result was `" <> toString evalResult <> "`."
 
 nixTestDir :: FilePath
 nixTestDir = "data/nix/tests/lang/"

--- a/tests/ParserTests.hs
+++ b/tests/ParserTests.hs
@@ -146,26 +146,26 @@ case_simple_set_syntax_mistakes =
 
 case_set_complex_keynames =
   checks
-    ( mkNonRecSet
-        [ NamedVar (DynamicKey (Plain (DoubleQuoted mempty)) :| mempty) mkNull nullPos ]
+    ( mkNonRecSet $
+        one (NamedVar (one (DynamicKey (Plain (DoubleQuoted mempty)))) mkNull nullPos)
     , "{ \"\" = null; }"
     )
     ( mkNonRecSet
-        [ NamedVar (StaticKey "a" :| [StaticKey "b"]) (mkInt 3) nullPos
-        , NamedVar (StaticKey "a" :| [StaticKey "c"]) (mkInt 4) nullPos
+        [ NamedVar (StaticKey "a" :| one (StaticKey "b")) (mkInt 3) nullPos
+        , NamedVar (StaticKey "a" :| one (StaticKey "c")) (mkInt 4) nullPos
         ]
     , "{ a.b = 3; a.c = 4; }"
     )
-    ( mkNonRecSet
-        [ NamedVar (DynamicKey (Antiquoted letExpr) :| mempty) (mkInt 4) nullPos ]
+    ( mkNonRecSet $
+        one (NamedVar (one (DynamicKey (Antiquoted letExpr))) (mkInt 4) nullPos)
     , "{ ${let a = \"b\"; in a} = 4; }"
     )
-    ( mkNonRecSet
-        [ NamedVar (DynamicKey (Plain str) :| [StaticKey "e"]) (mkInt 4) nullPos ]
+    ( mkNonRecSet $
+        one (NamedVar (DynamicKey (Plain str) :| one (StaticKey "e")) (mkInt 4) nullPos)
     , "{ \"a${let a = \"b\"; in a}c\".e = 4; }"
     )
  where
-  letExpr = mkLets ["a" $= mkStr "b"] (var "a")
+  letExpr = mkLets (one ("a" $= mkStr "b")) (var "a")
   str = DoubleQuoted [Plain "a", Antiquoted letExpr, Plain "c"]
 
 
@@ -191,7 +191,7 @@ case_set_inherit =
         ]
     , "{ e = 3; inherit a b; }"
     )
-    ( mkNonRecSet [ inherit mempty ]
+    ( mkNonRecSet $ one $ inherit mempty
     , "{ inherit; }"
     )
 
@@ -205,7 +205,7 @@ case_set_scoped_inherit =
 
 case_set_inherit_direct =
   checks
-    ( mkNonRecSet [ inheritFrom (mkNonRecSet ["a" $= mkInt 3]) mempty ]
+    ( mkNonRecSet $ one (inheritFrom (mkNonRecSet $ one ("a" $= mkInt 3)) mempty)
     , "{ inherit ({a = 3;}); }"
     )
 
@@ -235,7 +235,7 @@ case_int_null_list =
 case_mixed_list =
   checks
     ( mkList
-        [ mkNonRecSet ["a" $= mkInt 3] @. "a"
+        [ mkNonRecSet (one $ "a" $= mkInt 3) @. "a"
         , mkIf (mkBool True) mkNull (mkBool False)
         , mkNull
         , mkBool False
@@ -276,7 +276,7 @@ case_lambda_or_uri =
     ( mkFunction (Param "a") emptySet
     , "a:{}"
     )
-    ( mkFunction (Param "a") $ mkList [var "a"]
+    ( mkFunction (Param "a") $ mkList $ one $ var "a"
     , "a:[a]"
     )
 
@@ -308,7 +308,7 @@ case_lambda_pattern =
  where
   args  = [("b", Nothing), ("c", pure $ mkInt 1)]
   vargs = [("b", Nothing), ("c", pure $ mkInt 1)]
-  args2 = [("b", pure lam)]
+  args2 = one ("b", pure lam)
   lam = mkFunction (Param "x") $ var "x"
 
 case_lambda_pattern_syntax_mistakes =
@@ -327,7 +327,7 @@ case_lambda_app_int =
 
 case_simple_let =
   checks
-    ( mkLets ["a" $= mkInt 4] $ var "a"
+    ( mkLets (one $ "a" $= mkInt 4) $ var "a"
     , "let a = 4; in a"
     )
 
@@ -337,14 +337,14 @@ case_simple_let_syntax_mistakes =
 
 case_let_body =
   checks
-    ( mkRecSet ["body" $= mkInt 1] @. "body"
+    ( mkRecSet (one $ "body" $= mkInt 1) @. "body"
     , "let { body = 1; }"
     )
 
 case_nested_let =
   checks
-    ( mkLets ["a" $= mkInt 4] $
-        mkLets ["b" $= mkInt 5] $ var "a"
+    ( mkLets (one $ "a" $= mkInt 4) $
+        mkLets (one $ "b" $= mkInt 5) $ var "a"
     , "let a = 4; in let b = 5; in a"
     )
 
@@ -395,7 +395,7 @@ case_identifier_keyword_prefix_invariants =
 
 case_identifier_keyword_prefix =
   checks
-    ( mkList [ var "null-name" ]
+    ( mkList $ one $ var "null-name"
     , "[ null-name ]"
     )
 
@@ -462,7 +462,7 @@ case_indented_string =
     ( mkIndentedStr 2 "foo\nbar"
     , "''\n  foo\n  bar''"
     )
-    ( mkIndentedStr 0 ""
+    ( mkIndentedStr 0 mempty
     , "''        ''"
     )
     ( mkIndentedStr 0 "''"
@@ -495,21 +495,21 @@ case_select =
     , "a .  e .di. f"
     )
     ( Fix $ NSelect (pure mkNull) (var "a")
-        (StaticKey "e" :| [StaticKey "d"])
+        (StaticKey "e" :| one (StaticKey "d"))
     , "a.e . d    or null"
     )
     ( Fix $ NSelect (pure mkNull) emptySet
-        (DynamicKey (Plain $ DoubleQuoted mempty) :| mempty)
+        (one $ DynamicKey (Plain $ DoubleQuoted mempty))
     , "{}.\"\"or null"
     )
     ( Fix $ NBinary NConcat
         ((@.<|>)
-          (mkNonRecSet
-            [NamedVar
-              (mkSelector "a")
-              (mkList $ one $ mkInt 1)
-              nullPos
-            ]
+          (mkNonRecSet $
+            one $
+              NamedVar
+                (mkSelector "a")
+                (mkList $ one $ mkInt 1)
+                nullPos
           )
           "a"
           (mkList $ one $ mkInt 2)
@@ -529,13 +529,13 @@ case_select_path =
     ( emptySet @@ mkRelPath "./def"
     , "{}./def"
     )
-    ( Fix (NSelect Nothing emptySet (DynamicKey (Plain $ DoubleQuoted mempty) :| mempty)) @@ mkRelPath "./def"
+    ( Fix (NSelect Nothing emptySet $ one $ DynamicKey $ Plain $ DoubleQuoted mempty) @@ mkRelPath "./def"
     , "{}.\"\"./def"
     )
 
 case_select_keyword =
   checks
-    ( mkNonRecSet ["false" $= mkStr "foo"]
+    ( mkNonRecSet $ one $ "false" $= mkStr "foo"
     , "{ false = \"foo\"; }"
     )
 
@@ -604,7 +604,7 @@ case_operators =
     ( mkInt 1 $+ mkIf (mkBool True) (mkInt 2) (mkInt 3)
     , "1 + (if true then 2 else 3)"
     )
-    ( mkNonRecSet ["a" $= mkInt 3] $// mkRecSet ["b" $= mkInt 4]
+    ( mkNonRecSet (one $ "a" $= mkInt 3) $// mkRecSet (one $ "b" $= mkInt 4)
     , "{ a = 3; } // rec { b = 4; }"
     )
     ( mkNeg $ mkNeg $ var "a"
@@ -647,8 +647,9 @@ case_simpleLoc =
     |]
     (NLetAnn
       (mkSpan (1, 1) (4, 7))
-      [ NamedVar
-          (StaticKey "foo" :| [])
+      (one $
+        NamedVar
+          (one $ StaticKey "foo")
           (NBinaryAnn
             (mkSpan (2, 7) (3, 15))
             NApp
@@ -658,10 +659,10 @@ case_simpleLoc =
               (NSymAnn (mkSpan (2, 7) (2, 10)) "bar")
               (NSymAnn (mkSpan (3, 6) (3, 9 )) "baz")
             )
-            (NStrAnn (mkSpan (3, 10) (3, 15)) $ DoubleQuoted [Plain "qux"])
+            (NStrAnn (mkSpan (3, 10) (3, 15)) $ DoubleQuoted $ one $ Plain "qux")
           )
           (mkSPos 2 1)
-      ]
+      )
       (NSymAnn (mkSpan (4, 4) (4, 7)) "foo")
     )
 
@@ -694,7 +695,7 @@ throwParseError entity expr err =
       layoutSmart Prettyprinter.defaultLayoutOptions $
         nest 2 $
           vsep
-            [ ""
+            [ mempty
             , "Unexpected fail parsing " <> reflow entity <> ":"
             , nest 2 $ vsep
               [ "Expression:"
@@ -759,7 +760,8 @@ assertParsePrint src expect =
       . prettyNix
       . stripAnnotation $
         expr
-  in assertEqual "" expect result
+  in
+  assertEqual mempty expect result
 
 
 -----
@@ -777,7 +779,7 @@ instance VariadicAssertions (IO a) where
       pure $ error "never would be reached, cuz `I'm lazy`."
 
 instance (VariadicAssertions a) => VariadicAssertions ((ExpectedHask, NixLang) -> a) where
-  checkListPairs' f acc x = checkListPairs' f (acc <> [x])
+  checkListPairs' f acc x = checkListPairs' f (acc <> one x)
 
 checks :: (VariadicAssertions a) => a
 checks = checkListPairs' (uncurry assertParseText) []
@@ -793,7 +795,7 @@ instance VariadicArgs (IO a) where
       pure $ error "never would be reached, cuz `I'm lazy`."
 
 instance (VariadicArgs a) => VariadicArgs (NixLang -> a) where
-  checkList' f acc x = checkList' f (acc <> [x])
+  checkList' f acc x = checkList' f (acc <> one x)
 
 knownAs :: (VariadicArgs a) => (NixLang -> Assertion) -> a
 knownAs f = checkList' f []

--- a/tests/ParserTests.hs
+++ b/tests/ParserTests.hs
@@ -38,7 +38,7 @@ case_constant_int =
     , "234"
     )
 
-case_constant_bool = do
+case_constant_bool =
   checks
     ( mkBool True
     , "true"
@@ -47,7 +47,7 @@ case_constant_bool = do
     , "false"
     )
 
-case_constant_bool_respects_attributes = do
+case_constant_bool_respects_attributes =
   invariantVals
     "true-foo"
     "false-bar"

--- a/tests/PrettyTests.hs
+++ b/tests/PrettyTests.hs
@@ -9,29 +9,48 @@ import           Nix.Expr
 import           Nix.Pretty
 
 case_indented_antiquotation :: Assertion
-case_indented_antiquotation = do
-  assertPretty (mkIndentedStr 0 "echo $foo")   "''echo $foo''"
-  assertPretty (mkIndentedStr 0 "echo ${foo}") "''echo ''${foo}''"
+case_indented_antiquotation =
+  do
+    assertPretty
+      (mkIndentedStr 0 "echo $foo")
+      "''echo $foo''"
+    assertPretty
+      (mkIndentedStr 0 "echo ${foo}")
+      "''echo ''${foo}''"
 
 case_string_antiquotation :: Assertion
-case_string_antiquotation = do
-  assertPretty (mkStr "echo $foo")   "\"echo \\$foo\""
-  assertPretty (mkStr "echo ${foo}") "\"echo \\${foo}\""
+case_string_antiquotation =
+  do
+    assertPretty
+      (mkStr "echo $foo")
+      "\"echo \\$foo\""
+    assertPretty
+      (mkStr "echo ${foo}")
+      "\"echo \\${foo}\""
 
 case_function_params :: Assertion
 case_function_params =
-  assertPretty (mkFunction (mkVariadicParamSet mempty) (mkInt 3)) "{ ... }:\n  3"
+  assertPretty
+    (mkFunction (mkVariadicParamSet mempty) (mkInt 3))
+    "{ ... }:\n  3"
 
 case_paths :: Assertion
-case_paths = do
-  assertPretty (mkPath False "~/test.nix") "~/test.nix"
-  assertPretty (mkPath False "/test.nix")  "/test.nix"
-  assertPretty (mkPath False "./test.nix") "./test.nix"
+case_paths =
+  do
+    assertPretty
+      (mkPath False "~/test.nix")
+      "~/test.nix"
+    assertPretty
+      (mkPath False "/test.nix")
+      "/test.nix"
+    assertPretty
+      (mkPath False "./test.nix")
+      "./test.nix"
 
 tests :: TestTree
 tests = $testGroupGenerator
 
 ---------------------------------------------------------------------------------
-assertPretty :: NExpr -> String -> Assertion
+assertPretty :: NExpr -> Text -> Assertion
 assertPretty e s =
   assertEqual ("When pretty-printing " <> show e) s . show $ prettyNix e

--- a/tests/TestCommon.hs
+++ b/tests/TestCommon.hs
@@ -55,7 +55,7 @@ nixEvalString expr = do
   pure res
 
 nixEvalFile :: Path -> IO String
-nixEvalFile fp = readProcess "nix-instantiate" ["--eval", "--strict", coerce fp] ""
+nixEvalFile fp = readProcess "nix-instantiate" ["--eval", "--strict", coerce fp] mempty
 
 assertEvalFileMatchesNix :: Path -> Assertion
 assertEvalFileMatchesNix fp = do

--- a/tests/TestCommon.hs
+++ b/tests/TestCommon.hs
@@ -5,6 +5,7 @@ module TestCommon where
 import           GHC.Err                        ( errorWithoutStackTrace )
 import           Control.Monad.Catch
 import           Data.Time
+import           Data.Text.IO as Text
 import           Nix
 import           Nix.Standard
 import           Nix.Fresh.Basic
@@ -45,30 +46,31 @@ hnixEvalText opts src =
     )
     (parseNixText src)
 
-nixEvalString :: String -> IO String
-nixEvalString expr = do
-  (coerce -> fp, h) <- mkstemp "nix-test-eval"
-  hPutStr h expr
-  hClose h
-  res <- nixEvalFile fp
-  removeLink $ coerce fp
-  pure res
+nixEvalString :: Text -> IO Text
+nixEvalString expr =
+  do
+    (coerce -> fp, h) <- mkstemp "nix-test-eval"
+    Text.hPutStr h expr
+    hClose h
+    res <- nixEvalFile fp
+    removeLink $ coerce fp
+    pure res
 
-nixEvalFile :: Path -> IO String
-nixEvalFile fp = readProcess "nix-instantiate" ["--eval", "--strict", coerce fp] mempty
+nixEvalFile :: Path -> IO Text
+nixEvalFile fp = fromString <$> readProcess "nix-instantiate" ["--eval", "--strict", coerce fp] mempty
 
 assertEvalFileMatchesNix :: Path -> Assertion
-assertEvalFileMatchesNix fp = do
-  time    <- liftIO getCurrentTime
-  hnixVal <- (<> "\n") . printNix <$> hnixEvalFile (defaultOptions time) fp
-  nixVal  <- nixEvalFile fp
-  assertEqual (coerce fp) nixVal hnixVal
+assertEvalFileMatchesNix fp =
+  do
+    time    <- liftIO getCurrentTime
+    hnixVal <- (<> "\n") . printNix <$> hnixEvalFile (defaultOptions time) fp
+    nixVal  <- nixEvalFile fp
+    assertEqual (coerce fp) nixVal hnixVal
 
 assertEvalMatchesNix :: Text -> Assertion
-assertEvalMatchesNix expr = do
-  time    <- liftIO getCurrentTime
-  hnixVal <- (<> "\n") . printNix <$> hnixEvalText (defaultOptions time) expr
-  nixVal  <- nixEvalString expr'
-  assertEqual expr' nixVal hnixVal
- where
-  expr' = toString expr
+assertEvalMatchesNix expr =
+  do
+    time    <- liftIO getCurrentTime
+    hnixVal <- (<> "\n") . printNix <$> hnixEvalText (defaultOptions time) expr
+    nixVal  <- nixEvalString expr
+    assertEqual (toString expr) nixVal hnixVal


### PR DESCRIPTION
From what I know & in most cases `fold` is just as efficient as `{,m}concat` & `foldMap` as `concatMap`. I guard their effectiveness with supplying type signatures. `fold` enables `HLint` to provide further code refactoring instruction & to find function replacements by type signatures.

& further refactors, work actually started from `Inference` code refactors & tantrum spread, so currently trying to carve diff into small commits.