### PR TITLE
Upd Nix-dev-env rev

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -93,7 +93,7 @@
 #   , nixos-20.03  # Last stable release, gets almost no updates to recipes, gets only required backports
 #   ...
 #   }
-, rev ? "9df2cb074d72ea80ac9fd225b29060c8cf13dd39"
+, rev ? "b165ce0c4efbb74246714b5c66b6bcdce8cde175"
 
 , pkgs ?
     if builtins.compareVersions builtins.nixVersion "2.0" > 0

--- a/default.nix
+++ b/default.nix
@@ -1,7 +1,7 @@
 {
 # For current default and explicitly supported GHCs https://search.nixos.org/packages?query=ghc&from=0&size=500&channel=unstable, Nixpkgs implicitly supports older minor versions also, until the configuration departs from compatibility with them.
 # Compiler in a form ghc8101 <- GHC 8.10.1, just remove spaces and dots
-  compiler    ? "ghc8104"
+  compiler    ? "ghc8107"
 
 # Deafult.nix is a unit package abstraciton that allows to abstract over packages even in monorepos:
 # Example: pass --arg cabalName --arg packageRoot "./subprojectDir", or map default.nix over a list of tiples for subprojects.

--- a/shell.nix
+++ b/shell.nix
@@ -2,6 +2,6 @@ attrs@{...}:
 let defaultAttrs = {
   # Defaults are put in this form deliberately. Details: #748
   withHoogle = true;
-  compiler = "ghc8104";
+  compiler = "ghc8107";
 };
 in (import ./. (defaultAttrs // attrs)).env


### PR DESCRIPTION
How I tried it, with `install-nix-action` we were not able to bind the Nix version to old version, `install-nix-action` throws error.

After `Nix 2.3.15` release with `Nix 2.4` release, there is also a Cabal release and a Cabal2Nix release  - there are still several errors in the pipeline. I would need to merge work done without green CI, navigating on syndromes until this error layering resolves.

This seems to resolve `Nix-dev-env` builds at least.