### PR TITLE
coercion to NixString; iterNValue': flip 1st arg; unflip runFreshIdT

### DIFF
--- a/src/Nix/Atoms.hs
+++ b/src/Nix/Atoms.hs
@@ -11,7 +11,7 @@ import           Data.Binary                    ( Binary )
 import           Data.Aeson.Types               ( FromJSON
                                                 , ToJSON
                                                 )
---  2021-08-01: NOTE: Check the order efficience of NAtom constructors.
+--  2021-08-01: NOTE: Check the order effectiveness of NAtom constructors.
 
 -- | Atoms are values that evaluate to themselves.
 -- In other words - this is a constructors that are literals in Nix.

--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -447,7 +447,7 @@ nixPathNix =
             <> rest
 
 toStringNix :: MonadNix e t f m => NValue t f m -> m (NValue t f m)
-toStringNix = toValue <=< coerceToString callFunc DontCopyToStore CoerceAny
+toStringNix = toValue <=< coerceAnyToNixString callFunc DontCopyToStore
 
 hasAttrNix
   :: forall e t f m

--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -825,7 +825,7 @@ catAttrsNix attrName xs =
 baseNameOfNix :: MonadNix e t f m => NValue t f m -> m (NValue t f m)
 baseNameOfNix x =
   do
-    ns <- coerceToString callFunc DontCopyToStore CoerceStringy x
+    ns <- coerceStringlikeToNixString callFunc DontCopyToStore x
     pure $
       nvStr $
         modifyNixContents
@@ -1210,7 +1210,7 @@ isFunctionNix nv =
 throwNix :: MonadNix e t f m => NValue t f m -> m (NValue t f m)
 throwNix =
   throwError . ErrorCall . toString . stringIgnoreContext
-    <=< coerceToString callFunc CopyToStore CoerceStringy
+    <=< coerceStringlikeToNixString callFunc CopyToStore
 
 -- | Implementation of Nix @import@ clause.
 --
@@ -1626,12 +1626,11 @@ execNix
   :: forall e t f m . MonadNix e t f m => NValue t f m -> m (NValue t f m)
 execNix xs =
   do
-    ls <- fromValue @[NValue t f m] xs
-    xs <- traverse (coerceToString callFunc DontCopyToStore CoerceStringy) ls
+    xs' <- traverse (coerceStringlikeToNixString callFunc DontCopyToStore) =<< fromValue @[NValue t f m] xs
     -- 2018-11-19: NOTE: Still need to do something with the context here
     -- See prim_exec in nix/src/libexpr/primops.cc
     -- Requires the implementation of EvalState::realiseContext
-    exec $ stringIgnoreContext <$> xs
+    exec $ stringIgnoreContext <$> xs'
 
 fetchurlNix
   :: forall e t f m . MonadNix e t f m => NValue t f m -> m (NValue t f m)

--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -825,7 +825,7 @@ catAttrsNix attrName xs =
 baseNameOfNix :: MonadNix e t f m => NValue t f m -> m (NValue t f m)
 baseNameOfNix x =
   do
-    ns <- coerceStringlikeToNixString callFunc DontCopyToStore x
+    ns <- coerceStringlikeToNixString DontCopyToStore x
     pure $
       nvStr $
         modifyNixContents
@@ -1210,7 +1210,7 @@ isFunctionNix nv =
 throwNix :: MonadNix e t f m => NValue t f m -> m (NValue t f m)
 throwNix =
   throwError . ErrorCall . toString . stringIgnoreContext
-    <=< coerceStringlikeToNixString callFunc CopyToStore
+    <=< coerceStringlikeToNixString CopyToStore
 
 -- | Implementation of Nix @import@ clause.
 --
@@ -1626,7 +1626,7 @@ execNix
   :: forall e t f m . MonadNix e t f m => NValue t f m -> m (NValue t f m)
 execNix xs =
   do
-    xs' <- traverse (coerceStringlikeToNixString callFunc DontCopyToStore) =<< fromValue @[NValue t f m] xs
+    xs' <- traverse (coerceStringlikeToNixString DontCopyToStore) =<< fromValue @[NValue t f m] xs
     -- 2018-11-19: NOTE: Still need to do something with the context here
     -- See prim_exec in nix/src/libexpr/primops.cc
     -- Requires the implementation of EvalState::realiseContext

--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -1208,11 +1208,9 @@ isFunctionNix nv =
         _           -> False
 
 throwNix :: MonadNix e t f m => NValue t f m -> m (NValue t f m)
-throwNix mnv =
-  do
-    ns <- coerceToString callFunc CopyToStore CoerceStringy mnv
-
-    throwError . ErrorCall . toString $ stringIgnoreContext ns
+throwNix =
+  throwError . ErrorCall . toString . stringIgnoreContext
+    <=< coerceToString callFunc CopyToStore CoerceStringy
 
 -- | Implementation of Nix @import@ clause.
 --

--- a/src/Nix/Effects.hs
+++ b/src/Nix/Effects.hs
@@ -432,6 +432,8 @@ addTextToStore a b c d =
     pure
     =<< addTextToStore' a b c d
 
+--  2021-10-30: NOTE: Misleading name, please rename.
+-- | Add @Path@ into the Nix Store
 addPath :: (Framed e m, MonadStore m) => Path -> m StorePath
 addPath p =
   either

--- a/src/Nix/Effects/Derivation.hs
+++ b/src/Nix/Effects/Derivation.hs
@@ -372,7 +372,7 @@ buildDerivationWithContext drvAttrs = do
           rawString :: Text <- extractNixString jsonString
           pure $ one ("__json", rawString)
         else
-          traverse (extractNixString <=< lift . coerceToString callFunc CopyToStore CoerceAny) $
+          traverse (extractNixString <=< lift . coerceAnyToNixString callFunc CopyToStore) $
             Map.fromList $ M.toList $ deleteKeys [ "args", "__ignoreNulls" ] attrs
 
       pure $ Derivation { platform, builder, args, env,  hashMode, useJson

--- a/src/Nix/Effects/Derivation.hs
+++ b/src/Nix/Effects/Derivation.hs
@@ -309,9 +309,9 @@ defaultDerivationStrict val = do
     toStorePaths = foldl (flip addToInputs) mempty
 
     addToInputs :: Bifunctor p => StringContext -> p (Set Text) (Map Text [Text])  -> p (Set Text) (Map Text [Text])
-    addToInputs (StringContext path kind) = case kind of
-      DirectPath -> first (Set.insert (coerce path))
-      DerivationOutput o -> second (Map.insertWith (<>) (coerce path) $ one o)
+    addToInputs (StringContext (coerce -> path) kind) = case kind of
+      DirectPath -> first $ Set.insert path
+      DerivationOutput o -> second $ Map.insertWith (<>) path $ one o
       AllOutputs ->
         -- TODO: recursive lookup. See prim_derivationStrict
         -- XXX: When is this really used ?

--- a/src/Nix/Eval.hs
+++ b/src/Nix/Eval.hs
@@ -565,7 +565,7 @@ framedEvalExprLoc
 framedEvalExprLoc =
   adi addMetaInfo evalContent
 
--- | Add source postionss & frame context system.
+-- | Add source positions & frame context system.
 addMetaInfo
   :: forall v m e a
   . (Framed e m, Scoped v m, Has e SrcSpan, Typeable m, Typeable v)

--- a/src/Nix/Exec.hs
+++ b/src/Nix/Exec.hs
@@ -440,10 +440,10 @@ execBinaryOpForced scope span op lval rval = case op of
 
       (ls@NVSet{}, NVStr rs) ->
         (\ls2 -> nvStrP prov (ls2 <> rs)) <$>
-          coerceToString callFunc DontCopyToStore CoerceStringy ls
+          coerceStringlikeToNixString callFunc DontCopyToStore ls
       (NVStr ls, rs@NVSet{}) ->
         (\rs2 -> nvStrP prov (ls <> rs2)) <$>
-          coerceToString callFunc DontCopyToStore CoerceStringy rs
+          coerceStringlikeToNixString callFunc DontCopyToStore rs
       _ -> unsupportedTypes
 
   NEq   -> alreadyHandled

--- a/src/Nix/Exec.hs
+++ b/src/Nix/Exec.hs
@@ -425,9 +425,9 @@ execBinaryOpForced scope span op lval rval = case op of
       (NVConstant _, NVConstant _) -> numBinOp (+)
 
       (NVStr ls, NVStr rs) -> pure $ nvStrP prov (ls <> rs)
-      (NVStr ls, rs@NVPath{}) ->
+      (NVStr ls, NVPath p) ->
         (\rs2 -> nvStrP prov (ls <> rs2)) <$>
-          coerceToString callFunc CopyToStore CoerceStringy rs
+          coercePathToNixString CopyToStore p
       (NVPath ls, NVStr rs) ->
         maybe
           (throwError $ ErrorCall "A string that refers to a store path cannot be appended to a path.") -- data/nix/src/libexpr/eval.cc:1412

--- a/src/Nix/Exec.hs
+++ b/src/Nix/Exec.hs
@@ -440,10 +440,10 @@ execBinaryOpForced scope span op lval rval = case op of
 
       (ls@NVSet{}, NVStr rs) ->
         (\ls2 -> nvStrP prov (ls2 <> rs)) <$>
-          coerceStringlikeToNixString callFunc DontCopyToStore ls
+          coerceAnyToNixString callFunc DontCopyToStore ls
       (NVStr ls, rs@NVSet{}) ->
         (\rs2 -> nvStrP prov (ls <> rs2)) <$>
-          coerceStringlikeToNixString callFunc DontCopyToStore rs
+          coerceAnyToNixString callFunc DontCopyToStore rs
       _ -> unsupportedTypes
 
   NEq   -> alreadyHandled

--- a/src/Nix/Expr/Types.hs
+++ b/src/Nix/Expr/Types.hs
@@ -267,7 +267,7 @@ data NString r
 -- | For the the 'IsString' instance, we use a plain doublequoted string.
 instance IsString (NString r) where
   fromString ""     = DoubleQuoted mempty
-  fromString string = DoubleQuoted [Plain $ fromString string]
+  fromString string = DoubleQuoted $ one $ Plain $ fromString string
 
 $(deriveShow1 ''NString)
 $(deriveRead1 ''NString)

--- a/src/Nix/Fresh.hs
+++ b/src/Nix/Fresh.hs
@@ -20,7 +20,6 @@ import           Control.Monad.Ref    ( MonadAtomicRef(..)
 
 import           Nix.Thunk
 
---  2021-06-02: NOTE: Remove singleton newtype accessor in favour of free coerce
 newtype FreshIdT i m a = FreshIdT (ReaderT (Ref m i) m a)
   deriving
     ( Functor
@@ -59,5 +58,5 @@ instance
     v <- ask
     atomicModifyRef v (\i -> (succ i, i))
 
-runFreshIdT :: Functor m => Ref m i -> FreshIdT i m a -> m a
-runFreshIdT i m = runReaderT (coerce m) i
+runFreshIdT :: Functor m => FreshIdT i m a -> Ref m i -> m a
+runFreshIdT = runReaderT . coerce

--- a/src/Nix/Lint.hs
+++ b/src/Nix/Lint.hs
@@ -500,9 +500,8 @@ instance MonadCatch (Lint s) where
   catch _m _h = Lint $ ReaderT $ const (fail "Cannot catch in 'Lint s'")
 
 runLintM :: Options -> Lint s a -> ST s a
-runLintM opts action = do
-  i <- newRef (1 :: Int)
-  runFreshIdT i $ (`runReaderT` newContext opts) $ runLint action
+runLintM opts action =
+  runFreshIdT ((`runReaderT` newContext opts) $ runLint action) =<< newRef (1 :: Int)
 
 symbolicBaseEnv
   :: Monad m

--- a/src/Nix/Standard.hs
+++ b/src/Nix/Standard.hs
@@ -368,11 +368,10 @@ runWithBasicEffects
   -> StandardT (StdIdT m) a
   -> m a
 runWithBasicEffects opts =
-  go . (`evalStateT` mempty) . (`runReaderT` newContext opts) . runStandardT
+  fun . (`evalStateT` mempty) . (`runReaderT` newContext opts) . runStandardT
  where
-  go action = do
-    i <- newRef (1 :: Int)
-    runFreshIdT i action
+  fun action =
+    runFreshIdT action =<< newRef (1 :: Int)
 
 runWithBasicEffectsIO :: Options -> StandardIO a -> IO a
 runWithBasicEffectsIO = runWithBasicEffects

--- a/src/Nix/Standard.hs
+++ b/src/Nix/Standard.hs
@@ -59,9 +59,12 @@ newtype StdCited m a =
 newtype StdThunk m =
   StdThunk
     (StdCited m (NThunkF m (StdValue m)))
-
 type StdValue' m = NValue' (StdThunk m) (StdCited m) m (StdValue m)
 type StdValue m = NValue (StdThunk m) (StdCited m) m
+type StandardIO = StandardT (StdIdT IO)
+type StdVal = StdValue StandardIO
+type StdThun = StdThunk StandardIO
+type StdIO = StandardIO ()
 
 -- | Type alias:
 --
@@ -371,5 +374,5 @@ runWithBasicEffects opts =
     i <- newRef (1 :: Int)
     runFreshIdT i action
 
-runWithBasicEffectsIO :: Options -> StandardT (StdIdT IO) a -> IO a
+runWithBasicEffectsIO :: Options -> StandardIO a -> IO a
 runWithBasicEffectsIO = runWithBasicEffects

--- a/src/Nix/String/Coerce.hs
+++ b/src/Nix/String/Coerce.hs
@@ -54,7 +54,6 @@ coerceToString call ctsm clevel =
     (coerceAnyToNixString call ctsm)
     (coerceStringlikeToNixString ctsm)
     (clevel == CoerceStringy)
-    <=< demand
 
 coerceAnyToNixString
   :: forall e t f m

--- a/src/Nix/String/Coerce.hs
+++ b/src/Nix/String/Coerce.hs
@@ -85,7 +85,6 @@ coerceAnyToNixString call ctsm = go
             castToNixString $ show n
           NVConstant NNull ->
             castToNixString mempty
-          -- NVConstant: NAtom (NURI Text) is not matched
           NVList l ->
             nixStringUnwords <$> traverse go l
           v@(NVSet _ s) ->

--- a/src/Nix/String/Coerce.hs
+++ b/src/Nix/String/Coerce.hs
@@ -118,16 +118,12 @@ coerceStringlikeToNixString
   => CopyToStoreMode
   -> NValue t f m
   -> m NixString
-coerceStringlikeToNixString ctsm = go <=< demand
- where
-  go :: NValue t f m -> m NixString
-  go =
-    \case
-      NVStr ns -> pure ns
-      NVPath p -> coercePathToNixString ctsm p
-      v -> err v
-     where
-      err v = throwError $ ErrorCall $ "Expected a path or string, but saw: " <> show v
+coerceStringlikeToNixString ctsm =
+  (\case
+    NVStr ns -> pure ns
+    NVPath p -> coercePathToNixString ctsm p
+    v -> throwError $ ErrorCall $ "Expected a path or string, but saw: " <> show v
+  ) <=< demand
 
 -- | Convert @Path@ into @NixString@.
 -- With an additional option to store the resolved path into Nix Store.

--- a/src/Nix/String/Coerce.hs
+++ b/src/Nix/String/Coerce.hs
@@ -19,8 +19,8 @@ import           GHC.DataSize
 
 -- | Data type to avoid boolean blindness on what used to be called coerceMore
 data CoercionLevel
-  = CoerceStringy
-  -- ^ Coerce only stringlike types: strings, paths, and appropriate sets
+  = CoerceStringlike
+  -- ^ Coerce only stringlike types: strings, paths
   | CoerceAny
   -- ^ Coerce everything but functions
   deriving (Eq,Ord,Enum,Bounded)
@@ -53,7 +53,7 @@ coerceToString call ctsm clevel =
   bool
     (coerceAnyToNixString call ctsm)
     (coerceStringlikeToNixString ctsm)
-    (clevel == CoerceStringy)
+    (clevel == CoerceStringlike)
 
 coerceAnyToNixString
   :: forall e t f m
@@ -97,14 +97,14 @@ coerceAnyToNixString call ctsm = go
             continueOnKey :: (NValue t f m -> m (NValue t f m)) -> VarName -> Maybe (m NixString)
             continueOnKey f = fmap (go <=< f) . (`M.lookup` s)
             err v' = throwError $ ErrorCall $ "Expected a Set that has `__toString` or `outpath`, but saw: " <> show v'
-          v -> coerceStringy v
+          v -> coerceStringlike v
        where
         castToNixString = pure . mkNixStringWithoutContext
 
         nixStringUnwords = intercalateNixString $ mkNixStringWithoutContext " "
 
-      coerceStringy :: NValue t f m -> m NixString
-      coerceStringy = coerceStringlikeToNixString ctsm
+      coerceStringlike :: NValue t f m -> m NixString
+      coerceStringlike = coerceStringlikeToNixString ctsm
 
 coerceStringlikeToNixString
   :: forall e t f m

--- a/src/Nix/String/Coerce.hs
+++ b/src/Nix/String/Coerce.hs
@@ -96,7 +96,7 @@ coerceAnyToNixString call ctsm = go
               <|> continueOnKey pure "outPath"
            where
             continueOnKey :: (NValue t f m -> m (NValue t f m)) -> VarName -> Maybe (m NixString)
-            continueOnKey f = fmap (go <=< f <=< demand) . (`M.lookup` s)
+            continueOnKey f = fmap (go <=< f) . (`M.lookup` s)
             err v' = throwError $ ErrorCall $ "Expected a Set that has `__toString` or `outpath`, but saw: " <> show v'
           v -> coerceStringy v
        where

--- a/src/Nix/TH.hs
+++ b/src/Nix/TH.hs
@@ -22,16 +22,17 @@ quoteExprExp s =
   do
     expr <- parseExpr $ fromString s
     dataToExpQ
-      (extQOnFreeVars metaExp expr `extQ` (pure . (TH.lift :: Text -> Q Exp)))
+      (extQOnFreeVars metaExp expr `extQ` (pure . (TH.lift :: Text -> ExpQ)))
       expr
 
 quoteExprPat :: String -> PatQ
 quoteExprPat s =
   do
-    expr <- parseExpr $ fromString s
-    dataToPatQ
-      (extQOnFreeVars metaPat expr)
+    expr <- parseExpr @Q $ fromString s
+    (dataToPatQ @NExpr)
+      (extQOnFreeVars @_ @NExprLoc @PatQ metaPat expr)
       expr
+
 
 -- | Helper function.
 extQOnFreeVars

--- a/src/Nix/Thunk/Basic.hs
+++ b/src/Nix/Thunk/Basic.hs
@@ -108,9 +108,7 @@ instance (MonadBasicThunk m, MonadCatch m)
 
   query :: m v -> NThunkF m v -> m v
   query vStub (Thunk _ _ lTValRef) =
-    do
-      v <- readRef lTValRef
-      deferred pure (const vStub) v
+    deferred pure (const vStub) =<< readRef lTValRef
 
   force :: NThunkF m v -> m v
   force = forceMain
@@ -120,12 +118,7 @@ instance (MonadBasicThunk m, MonadCatch m)
 
   further :: NThunkF m v -> m (NThunkF m v)
   further t@(Thunk _ _ ref) =
-    do
-      _ <-
-        atomicModifyRef
-          ref
-          dup
-      pure t
+    const (pure t) =<< atomicModifyRef ref dup
 
 
 -- *** United body of `force*`

--- a/src/Nix/Utils.hs
+++ b/src/Nix/Utils.hs
@@ -325,9 +325,13 @@ traverseM
   -> m (f (t b))
 traverseM f x = sequenceA <$> traverse f x
 
--- | Apply a function @n@ times to a given value.
-iterateN :: Int -> (a -> a) -> a -> a
-iterateN n f x = fix ((<*> (0 /=)) . ((bool x . f) .) . (. pred)) $ n -- It is hard to read - yes. It is a single action without recursion - yes.
+iterateN
+  :: forall a
+   . Int -- ^ times
+  -> (a -> a) -- ^ function apply
+  -> a -- ^ on value
+  -> a
+iterateN n f x = fix ((<*> (0 /=)) . ((bool x . f) .) . (. pred)) n -- It is hard to read - yes. It is a non-recursive momoized action - yes.
 
 -- | Apply Kleisli arrow N times, join 'm's.
 nestM :: Monad m => Int -> (a -> m a) -> a -> m a

--- a/src/Nix/Utils.hs
+++ b/src/Nix/Utils.hs
@@ -24,6 +24,7 @@ module Nix.Utils
   , addExtension
   , dropExtensions
   , replaceExtension
+  , readFile
 
   , Has(..)
   , trace
@@ -39,8 +40,8 @@ module Nix.Utils
   , dup
   , mapPair
   , both
-  , readFile
   , iterateN
+  , nestM
   , traverseM
   , lifted
   , loebM
@@ -78,6 +79,7 @@ import           Lens.Family2.Stock             ( _1
                                                 , _2
                                                 )
 import qualified System.FilePath              as FilePath
+import Control.Monad.List (foldM)
 
 #if ENABLE_TRACING
 import qualified Relude.Debug                 as X
@@ -328,3 +330,10 @@ iterateN  :: Int -> (a -> a) -> (a -> a)
 iterateN 0 _ = id
 iterateN 1 f = f
 iterateN n f = f . iterateN (pred n) f
+
+-- | Apply Kleisli arrow N times, join 'm's.
+nestM :: Monad m => Int -> (a -> m a) -> a -> m a
+nestM 0 _ x = pure x
+nestM n f x = foldM (\ xx () -> f xx) x $ replicate n () -- fuses. But also, can it be fix join?
+{-# INLINE nestM #-}
+

--- a/src/Nix/Utils.hs
+++ b/src/Nix/Utils.hs
@@ -326,10 +326,8 @@ traverseM
 traverseM f x = sequenceA <$> traverse f x
 
 -- | Apply a function @n@ times to a given value.
-iterateN  :: Int -> (a -> a) -> (a -> a)
-iterateN 0 _ = id
-iterateN 1 f = f
-iterateN n f = f . iterateN (pred n) f
+iterateN :: Int -> (a -> a) -> a -> a
+iterateN n f x = fix ((<*> (0 /=)) . ((bool x . f) .) . (. pred)) $ n -- It is hard to read - yes. It is a single action without recursion - yes.
 
 -- | Apply Kleisli arrow N times, join 'm's.
 nestM :: Monad m => Int -> (a -> m a) -> a -> m a

--- a/src/Nix/Utils.hs
+++ b/src/Nix/Utils.hs
@@ -40,6 +40,7 @@ module Nix.Utils
   , mapPair
   , both
   , readFile
+  , iterateN
   , traverseM
   , lifted
   , loebM
@@ -321,3 +322,9 @@ traverseM
   -> t a
   -> m (f (t b))
 traverseM f x = sequenceA <$> traverse f x
+
+-- | Apply a function @n@ times to a given value.
+iterateN  :: Int -> (a -> a) -> (a -> a)
+iterateN 0 _ = id
+iterateN 1 f = f
+iterateN n f = f . iterateN (pred n) f

--- a/src/Nix/Value.hs
+++ b/src/Nix/Value.hs
@@ -514,9 +514,9 @@ iterNValueByDiscardWith
   :: MonadDataContext f m
   => r
   -> (NValue' t f m r -> r)
-  -> Free (NValue' t f m) t
+  -> NValue t f m
   -> r
-iterNValueByDiscardWith dflt = iterNValue (\ _ _ -> dflt)
+iterNValueByDiscardWith = iterNValue . const . const
 
 
 -- | HOF of @iterM@ from @Free@

--- a/src/Nix/Value.hs
+++ b/src/Nix/Value.hs
@@ -207,10 +207,10 @@ sequenceNValueF transform = \case
 -- | @bind@
 bindNValueF
   :: (Monad m, Monad n)
-  => (forall x . n x -> m x)
-  -> (a -> n b)
-  -> NValueF p m a
-  -> n (NValueF p m b)
+  => (forall x . n x -> m x) -- ^ Transform @n@ into @m@.
+  -> (a -> n b) -- ^ A Kleisli arrow (see 'Control.Arrow.Kleisli' & Kleisli catagory).
+  -> NValueF p m a -- ^ "Unfixed" (openly recursive) value of an embedded Nix language.
+  -> n (NValueF p m b) -- ^ An implementation of @transform (f =<< x)@ for embedded Nix language values.
 bindNValueF transform f = \case
   NVConstantF a  -> pure $ NVConstantF a
   NVStrF      s  -> pure $ NVStrF s

--- a/src/Nix/Value.hs
+++ b/src/Nix/Value.hs
@@ -642,20 +642,20 @@ builtin
   => VarName -- ^ function name
   -> ( NValue t f m
     -> m (NValue t f m)
-    ) -- ^ function
+    ) -- ^ unary function
   -> m (NValue t f m)
 builtin = (pure .) . nvBuiltin
 
 
 builtin2
   :: (MonadThunk t m (NValue t f m), MonadDataContext f m)
-  => VarName
+  => VarName -- ^ function name
   -> ( NValue t f m
     -> NValue t f m
     -> m (NValue t f m)
-    )
+    ) -- ^ binary function
   -> m (NValue t f m)
-builtin2 name f = builtin name $ \a -> builtin name $ \b -> f a b
+builtin2 = ((.) <*> (.)) . builtin
 
 
 builtin3

--- a/src/Nix/Value.hs
+++ b/src/Nix/Value.hs
@@ -639,12 +639,12 @@ nvBuiltin name f = Free $ nvBuiltin' name f
 builtin
   :: forall m f t
    . (MonadThunk t m (NValue t f m), MonadDataContext f m)
-  => VarName
+  => VarName -- ^ function name
   -> ( NValue t f m
     -> m (NValue t f m)
-    )
+    ) -- ^ function
   -> m (NValue t f m)
-builtin name f = pure $ nvBuiltin name $ \a -> f a
+builtin = (pure .) . nvBuiltin
 
 
 builtin2

--- a/src/Nix/Value.hs
+++ b/src/Nix/Value.hs
@@ -504,11 +504,11 @@ type NValue t f m = Free (NValue' t f m) t
 iterNValue
   :: forall t f m r
    . MonadDataContext f m
-  => ((Free (NValue' t f m) t -> r) -> t -> r)
+  => ((NValue t f m -> r) -> t -> r)
   -> (NValue' t f m r -> r)
-  -> Free (NValue' t f m) t
+  -> NValue t f m
   -> r
-iterNValue k f = iter f . fmap (k (iterNValue k f))
+iterNValue k f = fix ((iter f .) . fmap . k) -- already almost iterNValue'
 
 iterNValueByDiscardWith
   :: MonadDataContext f m

--- a/src/Nix/Value.hs
+++ b/src/Nix/Value.hs
@@ -327,11 +327,11 @@ lmapNValueF f = \case
 iterNValue'
   :: forall t f m a r
    . MonadDataContext f m
-  => (a -> (NValue' t f m a -> r) -> r)
+  => ((NValue' t f m a -> r) -> a -> r)
   -> (NValue' t f m r -> r)
   -> NValue' t f m a
   -> r
-iterNValue' k f = f . fmap (\a -> k a (iterNValue' k f))
+iterNValue' k f = fix ((f .) . fmap . k)
 
 -- *** Utils
 

--- a/src/Nix/Value.hs
+++ b/src/Nix/Value.hs
@@ -527,10 +527,9 @@ iterNValueM
   -> (NValue' t f m (n r) -> n r)
   -> NValue t f m
   -> n r
-iterNValueM transform k f =
-    iterM f <=< go . (k (iterNValueM transform k f) <$>)
+iterNValueM transform k f = fix (((iterM f <=< go) .) . fmap . k)
   where
-    go (Pure x) = Pure <$> x
+    go (Pure x) = Pure <$> x -- It should be a 'sequenceA' if to remote 'transform' form function.
     go (Free fa) = Free <$> bindNValue' transform go fa
 
 -- *** Utils

--- a/src/Nix/Value.hs
+++ b/src/Nix/Value.hs
@@ -660,15 +660,14 @@ builtin2 = ((.) <*> (.)) . builtin
 
 builtin3
   :: (MonadThunk t m (NValue t f m), MonadDataContext f m)
-  => VarName
+  => VarName -- ^ function name
   -> ( NValue t f m
     -> NValue t f m
     -> NValue t f m
     -> m (NValue t f m)
-    )
+    ) -- ^ ternary function
   -> m (NValue t f m)
-builtin3 name f =
-  builtin name $ \a -> builtin name $ \b -> builtin name $ \c -> f a b c
+builtin3 = liftA3 (.) (.) ((.) . (.)) ((.) . (.)) . builtin
 
 -- *** @F: Evaluation -> NValue@
 

--- a/tests/TestCommon.hs
+++ b/tests/TestCommon.hs
@@ -47,11 +47,11 @@ hnixEvalText opts src =
 nixEvalString :: Text -> IO Text
 nixEvalString expr =
   do
-    (coerce -> fp, h) <- mkstemp "nix-test-eval"
+    (fp, h) <- mkstemp "nix-test-eval"
     Text.hPutStr h expr
     hClose h
-    res <- nixEvalFile fp
-    removeLink $ coerce fp
+    res <- nixEvalFile $ coerce fp
+    removeLink $ fp
     pure res
 
 nixEvalFile :: Path -> IO Text

--- a/tests/TestCommon.hs
+++ b/tests/TestCommon.hs
@@ -1,4 +1,3 @@
-{-# language PartialTypeSignatures #-}
 
 module TestCommon where
 
@@ -8,7 +7,6 @@ import           Data.Time
 import           Data.Text.IO as Text
 import           Nix
 import           Nix.Standard
-import           Nix.Fresh.Basic
 import           System.Environment
 import           System.IO
 import           System.PosixCompat.Files
@@ -16,7 +14,7 @@ import           System.PosixCompat.Temp
 import           System.Process
 import           Test.Tasty.HUnit
 
-hnixEvalFile :: Options -> Path -> IO (StdValue (StandardT (StdIdT IO)))
+hnixEvalFile :: Options -> Path -> IO StdVal
 hnixEvalFile opts file =
   do
     parseResult <- parseNixFileLoc file
@@ -31,20 +29,20 @@ hnixEvalFile opts file =
               NixException frames ->
                 errorWithoutStackTrace . show
                   =<< renderFrames
-                        @(StdValue (StandardT (StdIdT IO)))
-                        @(StdThunk (StandardT (StdIdT IO)))
-                        frames
+                      @StdVal
+                      @StdThun
+                      frames
       )
       parseResult
 
-hnixEvalText :: Options -> Text -> IO (StdValue (StandardT (StdIdT IO)))
+hnixEvalText :: Options -> Text -> IO StdVal
 hnixEvalText opts src =
   either
     (\ err -> fail $ toString $ "Parsing failed for expression `" <> src <> "`.\n" <> show err)
     (\ expr ->
       runWithBasicEffects opts $ normalForm =<< nixEvalExpr mempty expr
     )
-    (parseNixText src)
+    $ parseNixText src
 
 nixEvalString :: Text -> IO Text
 nixEvalString expr =


### PR DESCRIPTION
This PR is interesting in `Utils` & `Value` where things were updated to fixpoint combinators.

Which, if internally laziness is preserved - running the function & apply the argument to it only once & optimize during compilation.

In Haskell Core I found that `fix` sometimes roughly converts just to `let x = f x in x` (stays a basic `let`, `letrec` in terms of Core language).

So far I can not reason beyond Core, it is hard to say how `letrec` compiles.

This is a work I did before the `Nix 2.4` release, which broke the CI on all fronts. I decided to not run putting created by upstream fires. Decided to not overcomplicate the Git processes for myself, so decided to finish & contribute the work first & then go do fix things.