### PR TITLE
Upd {{Value, Eval Provenance, JSON} builders, Option getters, Utils}

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -270,25 +270,13 @@
     lhs: "MaybeT (pure m)"
     rhs: hoistMaybe m
 - warn:
-    lhs: "MaybeT (return m)"
-    rhs: hoistMaybe m
-- warn:
     lhs: MaybeT . pure
-    rhs: hoistMaybe
-- warn:
-    lhs: MaybeT . return
     rhs: hoistMaybe
 - warn:
     lhs: "ExceptT (pure m)"
     rhs: hoistEither m
 - warn:
-    lhs: "ExceptT (return m)"
-    rhs: hoistEither m
-- warn:
     lhs: ExceptT . pure
-    rhs: hoistEither
-- warn:
-    lhs: ExceptT . return
     rhs: hoistEither
 - warn:
     lhs: fromMaybe mempty

--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -2758,3 +2758,8 @@
     lhs: "()"
     note: "Use `mempty`"
     rhs: mempty
+
+- hint:
+    lhs: "return"
+    note: "Please, use `pure` instead. even GHC already deprecates `return` starting from `9.2`."
+    rhs: mempty

--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -225,40 +225,16 @@
     lhs: "maybe (Right r) Left"
     rhs: maybeToLeft r
 - warn:
-    lhs: "case m of [] -> return (); (x:xs) -> f (x :| xs)"
+    lhs: "case m of [] -> stub ; (x:xs) -> f (x :| xs)"
     rhs: whenNotNull m f
 - warn:
-    lhs: "case m of [] -> stub  ; (x:xs) -> f (x :| xs)"
+    lhs: "case m of (x:xs) -> f (x :| xs); [] -> stub"
     rhs: whenNotNull m f
 - warn:
-    lhs: "case m of [] -> stub     ; (x:xs) -> f (x :| xs)"
-    rhs: whenNotNull m f
-- warn:
-    lhs: "case m of (x:xs) -> f (x :| xs); [] -> return ()"
-    rhs: whenNotNull m f
-- warn:
-    lhs: "case m of (x:xs) -> f (x :| xs); [] -> stub  "
-    rhs: whenNotNull m f
-- warn:
-    lhs: "case m of (x:xs) -> f (x :| xs); [] -> stub     "
-    rhs: whenNotNull m f
-- warn:
-    lhs: "m >>= \\case [] -> stub     ; (x:xs) -> f (x :| xs)"
+    lhs: "m >>= \\case [] -> stub ; (x:xs) -> f (x :| xs)"
     rhs: whenNotNullM m f
 - warn:
-    lhs: "m >>= \\case [] -> stub  ; (x:xs) -> f (x :| xs)"
-    rhs: whenNotNullM m f
-- warn:
-    lhs: "m >>= \\case [] -> return (); (x:xs) -> f (x :| xs)"
-    rhs: whenNotNullM m f
-- warn:
-    lhs: "m >>= \\case (x:xs) -> f (x :| xs); [] -> stub     "
-    rhs: whenNotNullM m f
-- warn:
-    lhs: "m >>= \\case (x:xs) -> f (x :| xs); [] -> stub  "
-    rhs: whenNotNullM m f
-- warn:
-    lhs: "m >>= \\case (x:xs) -> f (x :| xs); [] -> return ()"
+    lhs: "m >>= \\case (x:xs) -> f (x :| xs); [] -> stub"
     rhs: whenNotNullM m f
 - warn:
     lhs: mapMaybe leftToMaybe

--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -2782,3 +2782,7 @@
     note: "Modern name is `sequenceA`"
     rhs: sequenceA
 
+- hint:
+    lhs: "()"
+    note: "Use `mempty`"
+    rhs: mempty

--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -33,13 +33,14 @@
     rhs: mempty
 
 - hint:
-    lhs: "(: [])"
+    lhs: "(: mempty)"
     note: "Use `one`"
     rhs: one
 - hint:
-    lhs: "(:| [])"
+    lhs: "(:| mempty)"
     note: "Use `one`"
     rhs: one
+
 - hint:
     lhs: Data.Sequence.singleton
     note: "Use `one`"

--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -111,19 +111,19 @@
     lhs: "foldl' (*) 1"
     rhs: product
 - hint:
-    lhs: "fmap and (sequence s)"
+    lhs: "fmap and (sequenceA s)"
     note: Applying this hint would mean that some actions that were being executed previously would no longer be executed.
     rhs: andM s
 - hint:
-    lhs: "and <$> sequence s"
+    lhs: "and <$> sequenceA s"
     note: Applying this hint would mean that some actions that were being executed previously would no longer be executed.
     rhs: andM s
 - hint:
-    lhs: "fmap or (sequence s)"
+    lhs: "fmap or (sequenceA s)"
     note: Applying this hint would mean that some actions that were being executed previously would no longer be executed.
     rhs: orM s
 - hint:
-    lhs: "or <$> sequence s"
+    lhs: "or <$> sequenceA s"
     note: Applying this hint would mean that some actions that were being executed previously would no longer be executed.
     rhs: orM s
 - hint:

--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -2735,3 +2735,8 @@
     lhs: "return"
     note: "Please, use `pure` instead. even GHC already deprecates `return` starting from `9.2`."
     rhs: mempty
+
+- hint:
+    lhs: "map"
+    note: "Use `fmap`"
+    rhs: fmap

--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -235,7 +235,7 @@
     lhs: "case m of [] -> stub  ; (x:xs) -> f (x :| xs)"
     rhs: whenNotNull m f
 - warn:
-    lhs: "case m of [] -> pass     ; (x:xs) -> f (x :| xs)"
+    lhs: "case m of [] -> stub     ; (x:xs) -> f (x :| xs)"
     rhs: whenNotNull m f
 - warn:
     lhs: "case m of (x:xs) -> f (x :| xs); [] -> return ()"
@@ -244,10 +244,10 @@
     lhs: "case m of (x:xs) -> f (x :| xs); [] -> stub  "
     rhs: whenNotNull m f
 - warn:
-    lhs: "case m of (x:xs) -> f (x :| xs); [] -> pass     "
+    lhs: "case m of (x:xs) -> f (x :| xs); [] -> stub     "
     rhs: whenNotNull m f
 - warn:
-    lhs: "m >>= \\case [] -> pass     ; (x:xs) -> f (x :| xs)"
+    lhs: "m >>= \\case [] -> stub     ; (x:xs) -> f (x :| xs)"
     rhs: whenNotNullM m f
 - warn:
     lhs: "m >>= \\case [] -> stub  ; (x:xs) -> f (x :| xs)"
@@ -256,7 +256,7 @@
     lhs: "m >>= \\case [] -> return (); (x:xs) -> f (x :| xs)"
     rhs: whenNotNullM m f
 - warn:
-    lhs: "m >>= \\case (x:xs) -> f (x :| xs); [] -> pass     "
+    lhs: "m >>= \\case (x:xs) -> f (x :| xs); [] -> stub     "
     rhs: whenNotNullM m f
 - warn:
     lhs: "m >>= \\case (x:xs) -> f (x :| xs); [] -> stub  "

--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -27,6 +27,11 @@
     note: "Use 'stub'"
     rhs: stub
 - hint:
+    lhs: "pure mempty"
+    note: "Use 'stub'"
+    rhs: stub
+
+- hint:
     lhs: "(: [])"
     note: "Use `one`"
     rhs: one

--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -2777,3 +2777,8 @@
     note: "Monad law"
     rhs: fmap f . join
 
+- hint:
+    lhs: "Data.Traversable.sequence"
+    note: "Modern name is `sequenceA`"
+    rhs: sequenceA
+

--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -2719,6 +2719,11 @@
     rhs: id
 
 - hint:
+    lhs: "join (f . pure)"
+    note: "Monad law"
+    rhs: (f =<< pure)
+
+- hint:
     lhs: "join . (f <<$>>)"
     note: "Monad law"
     rhs: fmap f . join

--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -23,10 +23,6 @@
     note: "Use 'stub'"
     rhs: stub
 - hint:
-    lhs: "return ()"
-    note: "Use 'stub'"
-    rhs: stub
-- hint:
     lhs: "pure mempty"
     note: "Use 'stub'"
     rhs: stub

--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -19,10 +19,6 @@
 - ignore:
     name: Use Foldable.forM_
 - hint:
-    lhs: "pure ()"
-    note: "Use 'stub'"
-    rhs: stub
-- hint:
     lhs: "pure mempty"
     note: "Use 'stub'"
     rhs: stub
@@ -98,7 +94,7 @@
     note: "Use `one`"
     rhs: one
 - warn:
-    lhs: "Control.Exception.evaluate (x `deepseq` ())"
+    lhs: "Control.Exception.evaluate (x `deepseq` mempty)"
     rhs: evaluateNF_ x
 - warn:
     lhs: "void (evaluateWHNF x)"
@@ -1480,16 +1476,16 @@
     note: "'writeIORef' is already exported from Relude"
     rhs: writeIORef
 - warn:
-    lhs: "atomicModifyIORef ref (\\a -> (f a, ()))"
+    lhs: "atomicModifyIORef ref (\\a -> (f a, mempty))"
     rhs: atomicModifyIORef_ ref f
 - warn:
-    lhs: "atomicModifyIORef ref $ \\a -> (f a, ())"
+    lhs: "atomicModifyIORef ref $ \\a -> (f a, mempty)"
     rhs: atomicModifyIORef_ ref f
 - warn:
-    lhs: "atomicModifyIORef' ref $ \\a -> (f a, ())"
+    lhs: "atomicModifyIORef' ref $ \\a -> (f a, mempty)"
     rhs: "atomicModifyIORef'_ ref f"
 - warn:
-    lhs: "atomicModifyIORef' ref (\\a -> (f a, ()))"
+    lhs: "atomicModifyIORef' ref (\\a -> (f a, mempty))"
     rhs: "atomicModifyIORef'_ ref f"
 - warn:
     lhs: Data.Text.IO.getLine

--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -232,7 +232,7 @@
     lhs: "case m of [] -> return (); (x:xs) -> f (x :| xs)"
     rhs: whenNotNull m f
 - warn:
-    lhs: "case m of [] -> pure ()  ; (x:xs) -> f (x :| xs)"
+    lhs: "case m of [] -> stub  ; (x:xs) -> f (x :| xs)"
     rhs: whenNotNull m f
 - warn:
     lhs: "case m of [] -> pass     ; (x:xs) -> f (x :| xs)"
@@ -241,7 +241,7 @@
     lhs: "case m of (x:xs) -> f (x :| xs); [] -> return ()"
     rhs: whenNotNull m f
 - warn:
-    lhs: "case m of (x:xs) -> f (x :| xs); [] -> pure ()  "
+    lhs: "case m of (x:xs) -> f (x :| xs); [] -> stub  "
     rhs: whenNotNull m f
 - warn:
     lhs: "case m of (x:xs) -> f (x :| xs); [] -> pass     "
@@ -250,7 +250,7 @@
     lhs: "m >>= \\case [] -> pass     ; (x:xs) -> f (x :| xs)"
     rhs: whenNotNullM m f
 - warn:
-    lhs: "m >>= \\case [] -> pure ()  ; (x:xs) -> f (x :| xs)"
+    lhs: "m >>= \\case [] -> stub  ; (x:xs) -> f (x :| xs)"
     rhs: whenNotNullM m f
 - warn:
     lhs: "m >>= \\case [] -> return (); (x:xs) -> f (x :| xs)"
@@ -259,7 +259,7 @@
     lhs: "m >>= \\case (x:xs) -> f (x :| xs); [] -> pass     "
     rhs: whenNotNullM m f
 - warn:
-    lhs: "m >>= \\case (x:xs) -> f (x :| xs); [] -> pure ()  "
+    lhs: "m >>= \\case (x:xs) -> f (x :| xs); [] -> stub  "
     rhs: whenNotNullM m f
 - warn:
     lhs: "m >>= \\case (x:xs) -> f (x :| xs); [] -> return ()"

--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -28,6 +28,11 @@
     rhs: stub
 
 - hint:
+    lhs: "[]"
+    note: "Use `mempty`"
+    rhs: mempty
+
+- hint:
     lhs: "(: [])"
     note: "Use `one`"
     rhs: one

--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -159,22 +159,6 @@
     lhs: "fmap (fmap f) x"
     note: "Use '(<<$>>)'"
     rhs: "f <<$>> x"
-- hint:
-    lhs: "(\\f -> f x) <$> ff"
-    note: Use flap operator
-    rhs: "ff ?? x"
-- hint:
-    lhs: "fmap (\\f -> f x) ff"
-    note: Use flap operator
-    rhs: "ff ?? x"
-- hint:
-    lhs: "fmap ($ x) ff"
-    note: Use flap operator
-    rhs: "ff ?? x"
-- hint:
-    lhs: "($ x) <$> ff"
-    note: Use flap operator
-    rhs: "ff ?? x"
 - warn:
     lhs: "fmap f (nonEmpty x)"
     rhs: viaNonEmpty f x

--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -2736,7 +2736,7 @@
 - hint:
     lhs: "return"
     note: "Please, use `pure` instead. even GHC already deprecates `return` starting from `9.2`."
-    rhs: mempty
+    rhs: pure
 
 - hint:
     lhs: "map"

--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -149,11 +149,11 @@
     note: "Use 'asumMap'"
     rhs: asumMap f
 - hint:
-    lhs: "asum (map f xs)"
+    lhs: "asum (fmap f xs)"
     note: "Use 'asumMap'"
     rhs: asumMap f xs
 - warn:
-    lhs: "map fst &&& map snd"
+    lhs: "fmap fst &&& fmap snd"
     rhs: unzip
 - hint:
     lhs: "fmap (fmap f) x"
@@ -169,10 +169,10 @@
     lhs: "f <$> nonEmpty x"
     rhs: viaNonEmpty f x
 - warn:
-    lhs: partitionEithers . map f
+    lhs: partitionEithers . fmap f
     rhs: partitionWith f
 - warn:
-    lhs: partitionEithers $ map f x
+    lhs: partitionEithers $ fmap f x
     rhs: partitionWith f x
 - warn:
     lhs: forever

--- a/main/Main.hs
+++ b/main/Main.hs
@@ -179,13 +179,13 @@ main' opts@Options{..} = runWithBasicEffectsIO opts execContentsFilesOrRepl
       | otherwise = printer'
      where
       printer'
-        | xml       = fun (stringIgnoreContext . toXML)                     normalForm
+        | xml       = fun (ignoreContext . toXML)                     normalForm
         -- 2021-05-27: NOTE: With naive fix of the #941
         -- This is overall a naive printer implementation, as options should interact/respect one another.
         -- A nice question: "Should respect one another to what degree?": Go full combinator way, for which
         -- old Nix CLI is nototrious for (and that would mean to reimplement the old Nix CLI),
         -- OR: https://github.com/haskell-nix/hnix/issues/172 and have some sane standart/default behaviour for (most) keys.
-        | json      = fun (stringIgnoreContext . mempty . nvalueToJSONNixString) normalForm
+        | json      = fun (ignoreContext . mempty . nvalueToJSONNixString) normalForm
         | strict    = fun (show . prettyNValue)                             normalForm
         | values    = fun (show . prettyNValueProv)                         removeEffects
         | otherwise = fun (show . prettyNValue)                             removeEffects

--- a/main/Main.hs
+++ b/main/Main.hs
@@ -185,7 +185,7 @@ main' opts@Options{..} = runWithBasicEffectsIO opts execContentsFilesOrRepl
         -- A nice question: "Should respect one another to what degree?": Go full combinator way, for which
         -- old Nix CLI is nototrious for (and that would mean to reimplement the old Nix CLI),
         -- OR: https://github.com/haskell-nix/hnix/issues/172 and have some sane standart/default behaviour for (most) keys.
-        | json      = fun (ignoreContext . mempty . nvalueToJSONNixString) normalForm
+        | json      = fun (ignoreContext . mempty . toJSONNixString) normalForm
         | strict    = fun (show . prettyNValue)                       normalForm
         | values    = fun (show . prettyNValueProv)                   removeEffects
         | otherwise = fun (show . prettyNValue)                       removeEffects

--- a/main/Main.hs
+++ b/main/Main.hs
@@ -151,9 +151,9 @@ main' opts@Options{..} = runWithBasicEffectsIO opts execContentsFilesOrRepl
   processCLIOptions mpath expr
     | evaluate =
       if
-        | tracing                       -> evaluateExprWithEvaluator nixTracingEvalExprLoc expr
-        | Just path <- reduce           -> evaluateExprWithEvaluator (reduction path . coerce) expr
-        | null arg || null argstr       -> evaluateExprWithEvaluator nixEvalExprLoc expr
+        | tracing                       -> evaluateExprWith nixTracingEvalExprLoc expr
+        | Just path <- reduce           -> evaluateExprWith (reduction path . coerce) expr
+        | null arg || null argstr       -> evaluateExprWith nixEvalExprLoc expr
         | otherwise                     -> processResult printer <=< nixEvalExprLoc (coerce mpath) $ expr
     | xml                        = fail "Rendering expression trees to XML is not yet implemented"
     | json                       = fail "Rendering expression trees to JSON is not implemented"
@@ -169,7 +169,7 @@ main' opts@Options{..} = runWithBasicEffectsIO opts execContentsFilesOrRepl
           . stripAnnotation
           $ expr
    where
-    evaluateExprWithEvaluator evaluator = evaluateExpression (coerce mpath) evaluator printer
+    evaluateExprWith evaluator = evaluateExpression (coerce mpath) evaluator printer
 
     printer
       :: StdVal
@@ -186,9 +186,9 @@ main' opts@Options{..} = runWithBasicEffectsIO opts execContentsFilesOrRepl
         -- old Nix CLI is nototrious for (and that would mean to reimplement the old Nix CLI),
         -- OR: https://github.com/haskell-nix/hnix/issues/172 and have some sane standart/default behaviour for (most) keys.
         | json      = fun (ignoreContext . mempty . nvalueToJSONNixString) normalForm
-        | strict    = fun (show . prettyNValue)                             normalForm
-        | values    = fun (show . prettyNValueProv)                         removeEffects
-        | otherwise = fun (show . prettyNValue)                             removeEffects
+        | strict    = fun (show . prettyNValue)                       normalForm
+        | values    = fun (show . prettyNValueProv)                   removeEffects
+        | otherwise = fun (show . prettyNValue)                       removeEffects
        where
         fun
           :: (b -> Text)

--- a/main/Main.hs
+++ b/main/Main.hs
@@ -36,8 +36,8 @@ import           Nix.Eval
 main :: IO ()
 main =
   do
-    time <- getCurrentTime
-    opts <- execParser $ nixOptionsInfo time
+    currentTime <- getCurrentTime
+    opts <- execParser $ nixOptionsInfo currentTime
 
     main' opts
 

--- a/main/Main.hs
+++ b/main/Main.hs
@@ -57,7 +57,7 @@ main' opts@Options{..} = runWithBasicEffectsIO opts execContentsFilesOrRepl
     -- | The base case: read expressions from the last CLI directive (@[FILE]@) listed on the command line.
     loadFromCliFilePathList :: StdIO
     loadFromCliFilePathList =
-      case filePaths of
+      case getFilePaths of
         []     -> runRepl
         ["-"]  -> readExpressionFromStdin
         _paths -> processSeveralFiles (coerce _paths)
@@ -80,11 +80,11 @@ main' opts@Options{..} = runWithBasicEffectsIO opts execContentsFilesOrRepl
         do
           let file = replaceExtension binaryCacheFile "nixc"
           processCLIOptions (pure file) =<< liftIO (readCache binaryCacheFile)
-      ) <$> readFrom
+      ) <$> getReadFrom
 
     -- | The `--expr` option: read expression from the argument string
     loadLiteralExpression :: Maybe StdIO
-    loadLiteralExpression = processExpr <$> expression
+    loadLiteralExpression = processExpr <$> getExpression
 
     -- | The `--file` argument: read expressions from the files listed in the argument file
     loadExpressionFromFile :: Maybe StdIO
@@ -96,7 +96,7 @@ main' opts@Options{..} = runWithBasicEffectsIO opts execContentsFilesOrRepl
         (\case
           "-" -> Text.getContents
           _fp -> readFile _fp
-        ) <$> fromFile
+        ) <$> getFromFile
 
   processExpr :: Text -> StdIO
   processExpr = handleResult mempty . parseNixTextLoc
@@ -110,13 +110,13 @@ main' opts@Options{..} = runWithBasicEffectsIO opts execContentsFilesOrRepl
         bool
           errorWithoutStackTrace
           (liftIO . hPutStrLn stderr)
-          ignoreErrors
+          isIgnoreErrors
           $ "Parse failed: " <> show err
       )
 
       (\ expr ->
         do
-          when check $
+          when isCheck $
             do
               expr' <- liftIO $ reduceExpr mpath expr
               either
@@ -138,28 +138,28 @@ main' opts@Options{..} = runWithBasicEffectsIO opts execContentsFilesOrRepl
                     @StdThun
                     frames
 
-          when repl $
+          when isRepl $
             withEmptyNixContext $
               bool
                 Repl.main
                 ((Repl.main' . pure) =<< nixEvalExprLoc (coerce mpath) expr)
-                evaluate
+                isEvaluate
       )
 
   --  2021-07-15: NOTE: Logic of CLI Option processing is scattered over several functions, needs to be consolicated.
   processCLIOptions :: Maybe Path -> NExprLoc -> StdIO
   processCLIOptions mpath expr
-    | evaluate =
+    | isEvaluate =
       if
-        | tracing                       -> evaluateExprWith nixTracingEvalExprLoc expr
-        | Just path <- reduce           -> evaluateExprWith (reduction path . coerce) expr
-        | null arg || null argstr       -> evaluateExprWith nixEvalExprLoc expr
+        | isTrace                       -> evaluateExprWith nixTracingEvalExprLoc expr
+        | Just path <- getReduce           -> evaluateExprWith (reduction path . coerce) expr
+        | null getArg || null getArgstr       -> evaluateExprWith nixEvalExprLoc expr
         | otherwise                     -> processResult printer <=< nixEvalExprLoc (coerce mpath) $ expr
-    | xml                        = fail "Rendering expression trees to XML is not yet implemented"
-    | json                       = fail "Rendering expression trees to JSON is not implemented"
-    | verbose >= DebugInfo       =  liftIO . putStr . ppShow . stripAnnotation $ expr
-    | cache , Just path <- mpath =  liftIO . writeCache (replaceExtension path "nixc") $ expr
-    | parseOnly                  =  void . liftIO . Exception.evaluate . force $ expr
+    | isXml                        = fail "Rendering expression trees to XML is not yet implemented"
+    | isJson                       = fail "Rendering expression trees to JSON is not implemented"
+    | getVerbosity >= DebugInfo       =  liftIO . putStr . ppShow . stripAnnotation $ expr
+    | isCache , Just path <- mpath =  liftIO . writeCache (replaceExtension path "nixc") $ expr
+    | isParseOnly                  =  void . liftIO . Exception.evaluate . force $ expr
     | otherwise                  =
       liftIO .
         renderIO
@@ -175,19 +175,19 @@ main' opts@Options{..} = runWithBasicEffectsIO opts execContentsFilesOrRepl
       :: StdVal
       -> StdIO
     printer
-      | finder    = findAttrs <=< fromValue @(AttrSet StdVal)
+      | isFinder    = findAttrs <=< fromValue @(AttrSet StdVal)
       | otherwise = printer'
      where
       printer'
-        | xml       = fun (ignoreContext . toXML)                     normalForm
+        | isXml       = fun (ignoreContext . toXML)                     normalForm
         -- 2021-05-27: NOTE: With naive fix of the #941
         -- This is overall a naive printer implementation, as options should interact/respect one another.
         -- A nice question: "Should respect one another to what degree?": Go full combinator way, for which
         -- old Nix CLI is nototrious for (and that would mean to reimplement the old Nix CLI),
         -- OR: https://github.com/haskell-nix/hnix/issues/172 and have some sane standart/default behaviour for (most) keys.
-        | json      = fun (ignoreContext . mempty . toJSONNixString) normalForm
-        | strict    = fun (show . prettyNValue)                       normalForm
-        | values    = fun (show . prettyNValueProv)                   removeEffects
+        | isJson      = fun (ignoreContext . mempty . toJSONNixString) normalForm
+        | isStrict    = fun (show . prettyNValue)                       normalForm
+        | isValues    = fun (show . prettyNValueProv)                   removeEffects
         | otherwise = fun (show . prettyNValue)                       removeEffects
        where
         fun

--- a/main/Repl.hs
+++ b/main/Repl.hs
@@ -111,7 +111,7 @@ main' iniVal =
         (words <$> lines f)
 
   handleMissing e
-    | Error.isDoesNotExistError e = pure mempty
+    | Error.isDoesNotExistError e = stub
     | otherwise = throwM e
 
   -- Replicated and slightly adjusted `optMatcher` from `System.Console.Repline`
@@ -190,65 +190,71 @@ exec
   => Bool
   -> Text
   -> Repl e t f m (Maybe (NValue t f m))
-exec update source = do
-  -- Get the current interpreter state
-  state <- get
+exec update source =
+  do
+    -- Get the current interpreter state
+    state <- get
 
-  when (cfgDebug $ replCfg state) $ liftIO $ print state
+    when (cfgDebug $ replCfg state) $ liftIO $ print state
 
-  -- Parser ( returns AST as `NExprLoc` )
-  case parseExprOrBinding source of
-    (Left err, _) -> do
-      liftIO $ print err
-      pure Nothing
-    (Right expr, isBinding) -> do
+    -- Parser ( returns AST as `NExprLoc` )
+    case parseExprOrBinding source of
+      (Left err, _) ->
+        do
+          liftIO $ print err
+          pure Nothing
+      (Right expr, isBinding) ->
+        do
 
-      -- Type Inference ( returns Typing Environment )
-      --
-      -- import qualified Nix.Type.Env                  as Env
-      -- import           Nix.Type.Infer
-      --
-      -- let tyctx' = inferTop mempty [("repl", stripAnnotation expr)]
-      -- liftIO $ print tyctx'
+          -- Type Inference ( returns Typing Environment )
+          --
+          -- import qualified Nix.Type.Env                  as Env
+          -- import           Nix.Type.Infer
+          --
+          -- let tyctx' = inferTop mempty [("repl", stripAnnotation expr)]
+          -- liftIO $ print tyctx'
 
-      mVal <- lift $ lift $ try $ pushScope (replCtx state) (evalExprLoc expr)
+          mVal <- lift $ lift $ try $ pushScope (replCtx state) (evalExprLoc expr)
 
-      either
-        (\ (NixException frames) -> do
-          lift $ lift $ liftIO . print =<< renderFrames @(NValue t f m) @t frames
-          pure Nothing)
-        (\ val -> do
-          -- Update the interpreter state
-          when (update && isBinding) $ do
-            -- Set `replIt` to last entered expression
-            put state { replIt = pure expr }
-
-            -- If the result value is a set, update our context with it
-            case val of
-              NVSet _ (coerce -> scope) -> put state { replCtx = scope <> replCtx state }
-              _          -> stub
-
-          pure $ pure val
-        )
-        mVal
-  where
-    -- If parsing fails, turn the input into singleton attribute set
-    -- and try again.
-    --
-    -- This allows us to handle assignments like @a = 42@
-    -- which get turned into @{ a = 42; }@
-    parseExprOrBinding i =
-      either
-        (\ e    ->
           either
-            (const (Left e, False)) -- return the first parsing failure
-            (\ e' -> (pure e', True))
-            (parseNixTextLoc $ toAttrSet i))
-        (\ expr -> (pure expr, False))
-        (parseNixTextLoc i)
+            (\ (NixException frames) ->
+              do
+                lift $ lift $ liftIO . print =<< renderFrames @(NValue t f m) @t frames
+                pure Nothing
+            )
+            (\ val ->
+              do
+                -- Update the interpreter state
+                when (update && isBinding) $ do
+                  -- Set `replIt` to last entered expression
+                  put state { replIt = pure expr }
 
-    toAttrSet i =
-      "{" <> i <> whenFalse ";" (Text.isSuffixOf ";" i) <> "}"
+                  -- If the result value is a set, update our context with it
+                  case val of
+                    NVSet _ (coerce -> scope) -> put state { replCtx = scope <> replCtx state }
+                    _          -> stub
+
+                pure $ pure val
+            )
+            mVal
+ where
+  -- If parsing fails, turn the input into singleton attribute set
+  -- and try again.
+  --
+  -- This allows us to handle assignments like @a = 42@
+  -- which get turned into @{ a = 42; }@
+  parseExprOrBinding i =
+    either
+      (\ e    ->
+        either
+          (const (Left e, False)) -- return the first parsing failure
+          (\ e' -> (pure e', True))
+          (parseNixTextLoc $ toAttrSet i))
+      (\ expr -> (pure expr, False))
+      (parseNixTextLoc i)
+
+  toAttrSet i =
+    "{" <> i <> whenFalse ";" (Text.isSuffixOf ";" i) <> "}"
 
 cmd
   :: (MonadNix e t f m, MonadIO m)

--- a/main/Repl.hs
+++ b/main/Repl.hs
@@ -168,8 +168,8 @@ initState mIni = do
       Nothing
       scope
       defReplConfig
-        { cfgStrict = strict opts
-        , cfgValues = values opts
+        { cfgStrict = isStrict opts
+        , cfgValues = isValues opts
         }
   where
     evalText :: (MonadNix e t f m) => Text -> m (NValue t f m)

--- a/main/Repl.hs
+++ b/main/Repl.hs
@@ -161,7 +161,7 @@ initState mIni = do
       M.fromList $
       ("builtins", builtins) : fmap ("input",) (maybeToList mIni)
 
-  opts :: Nix.Options <- asks $ view hasLens
+  opts :: Nix.Options <- askLocal
 
   pure $
     IState

--- a/main/Repl.hs
+++ b/main/Repl.hs
@@ -161,7 +161,7 @@ initState mIni = do
       M.fromList $
       ("builtins", builtins) : fmap ("input",) (maybeToList mIni)
 
-  opts :: Nix.Options <- askLocal
+  opts <- askOptions
 
   pure $
     IState

--- a/src/Nix.hs
+++ b/src/Nix.hs
@@ -108,8 +108,8 @@ evaluateExpression mpath evaluator handler expr =
     (coerce -> args) <-
       (traverse . traverse)
         eval'
-        $  (second parseArg <$> arg    opts)
-        <> (second mkStr    <$> argstr opts)
+        $  (second parseArg <$> getArg    opts)
+        <> (second mkStr    <$> getArgstr opts)
     f <- evaluator mpath expr
     f' <- demand f
     val <-
@@ -137,7 +137,7 @@ processResult h val = do
   maybe
     (h val)
     (\ (coerce . Text.splitOn "." -> keys) -> processKeys keys val)
-    (attr opts)
+    (getAttr opts)
  where
   processKeys :: [VarName] -> NValue t f m -> m a
   processKeys kys v =

--- a/src/Nix.hs
+++ b/src/Nix.hs
@@ -104,7 +104,7 @@ evaluateExpression
   -> m a
 evaluateExpression mpath evaluator handler expr =
   do
-    opts :: Options <- askLocal
+    opts <- askOptions
     (coerce -> args) <-
       (traverse . traverse)
         eval'
@@ -134,7 +134,7 @@ processResult
   -> m a
 processResult h val =
   do
-    opts :: Options <- askLocal
+    opts <- askOptions
     maybe
       (h val)
       (\ (coerce . Text.splitOn "." -> keys) -> processKeys keys val)

--- a/src/Nix.hs
+++ b/src/Nix.hs
@@ -114,7 +114,7 @@ evaluateExpression mpath evaluator handler expr =
     f' <- demand f
     val <-
       case f' of
-        NVClosure _ g -> g $ argmap args
+        NVClosure _ g -> g $ mkNVSet mempty $ M.fromList args
         _             -> pure f
     processResult handler val
  where
@@ -125,8 +125,6 @@ evaluateExpression mpath evaluator handler expr =
       (parseNixText s)
 
   eval' = normalForm <=< nixEvalExpr mpath
-
-  argmap args = mkNVSet mempty $ M.fromList args
 
 processResult
   :: forall e t f m a

--- a/src/Nix.hs
+++ b/src/Nix.hs
@@ -104,7 +104,7 @@ evaluateExpression
   -> m a
 evaluateExpression mpath evaluator handler expr =
   do
-    opts :: Options <- asks $ view hasLens
+    opts :: Options <- askLocal
     (coerce -> args) <-
       (traverse . traverse)
         eval'
@@ -132,12 +132,13 @@ processResult
   => (NValue t f m -> m a)
   -> NValue t f m
   -> m a
-processResult h val = do
-  opts :: Options <- asks $ view hasLens
-  maybe
-    (h val)
-    (\ (coerce . Text.splitOn "." -> keys) -> processKeys keys val)
-    (getAttr opts)
+processResult h val =
+  do
+    opts :: Options <- askLocal
+    maybe
+      (h val)
+      (\ (coerce . Text.splitOn "." -> keys) -> processKeys keys val)
+      (getAttr opts)
  where
   processKeys :: [VarName] -> NValue t f m -> m a
   processKeys kys v =

--- a/src/Nix.hs
+++ b/src/Nix.hs
@@ -126,7 +126,7 @@ evaluateExpression mpath evaluator handler expr =
 
   eval' = normalForm <=< nixEvalExpr mpath
 
-  argmap args = nvSet mempty $ M.fromList args
+  argmap args = mkNVSet mempty $ M.fromList args
 
 processResult
   :: forall e t f m a

--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -1550,7 +1550,7 @@ fromJSONNix nvjson =
     traverseToNValue f v = f <$> traverse jsonToNValue v
 
 toJSONNix :: MonadNix e t f m => NValue t f m -> m (NValue t f m)
-toJSONNix = (fmap mkNVStr . nvalueToJSONNixString) <=< demand
+toJSONNix = (fmap mkNVStr . toJSONNixString) <=< demand
 
 toXMLNix :: MonadNix e t f m => NValue t f m -> m (NValue t f m)
 toXMLNix = (fmap (mkNVStr . toXML) . normalForm) <=< demand

--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -87,7 +87,6 @@ import           Text.Regex.TDFA                ( Regex
                                                 , matchAllText
                                                 )
 
-
 -- This is a big module. There is recursive reuse:
 -- @builtins -> builtinsList -> scopedImport -> withNixContext -> builtins@,
 -- since @builtins@ is self-recursive: aka we ship @builtins.builtins.builtins...@.
@@ -676,7 +675,7 @@ matchNix pat str =
       re = makeRegex p :: Regex
       mkMatch t =
         bool
-          (toValue ()) -- Shorthand for Null
+          (pure nvNull)
           (toValue $ mkNixStringWithoutContext t)
           (not $ Text.null t)
 

--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -1139,7 +1139,7 @@ toFileNix name s =
 
     let
       storepath  = coerce (fromString @Text) mres
-      sc = StringContext storepath DirectPath
+      sc = StringContext DirectPath storepath
 
     toValue $ mkNixStringWithSingletonContext storepath sc
 

--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -1795,9 +1795,23 @@ langVersionNix = toValue (5 :: Int)
 
 builtinsList :: forall e t f m . MonadNix e t f m => m [Builtin (NValue t f m)]
 builtinsList = sequenceA
-  [ add0 Normal   "nixVersion"       nixVersionNix
+  [ add  TopLevel "abort"            throwNix -- for now
+  , add  TopLevel "baseNameOf"       baseNameOfNix
+  , add0 TopLevel "derivation"       derivationNix
+  , add  TopLevel "derivationStrict" derivationStrictNix
+  , add  TopLevel "dirOf"            dirOfNix
+  , add  TopLevel "import"           importNix
+  , add  TopLevel "isNull"           isNullNix
+  , add2 TopLevel "map"              mapNix
+  , add2 TopLevel "mapAttrs"         mapAttrsNix
+  , add  TopLevel "placeholder"      placeHolderNix
+  , add2 TopLevel "removeAttrs"      removeAttrsNix
+  , add2 TopLevel "scopedImport"     scopedImportNix
+  , add  TopLevel "throw"            throwNix
+  , add  TopLevel "toString"         toStringNix
+  , add2 TopLevel "trace"            traceNix
+  , add0 Normal   "nixVersion"       nixVersionNix
   , add0 Normal   "langVersion"      langVersionNix
-  , add  TopLevel "abort"            throwNix -- for now
   , add2 Normal   "add"              addNix
   , add2 Normal   "addErrorContext"  addErrorContextNix
   , add2 Normal   "all"              allNix
@@ -1805,7 +1819,6 @@ builtinsList = sequenceA
   , add2 Normal   "appendContext"    appendContextNix
   , add  Normal   "attrNames"        attrNamesNix
   , add  Normal   "attrValues"       attrValuesNix
-  , add  TopLevel "baseNameOf"       baseNameOfNix
   , add2 Normal   "bitAnd"           bitAndNix
   , add2 Normal   "bitOr"            bitOrNix
   , add2 Normal   "bitXor"           bitXorNix
@@ -1818,9 +1831,6 @@ builtinsList = sequenceA
   , add0 Normal   "currentSystem"    currentSystemNix
   , add0 Normal   "currentTime"      currentTimeNix
   , add2 Normal   "deepSeq"          deepSeqNix
-  , add0 TopLevel "derivation"       derivationNix
-  , add  TopLevel "derivationStrict" derivationStrictNix
-  , add  TopLevel "dirOf"            dirOfNix
   , add2 Normal   "div"              divNix
   , add2 Normal   "elem"             elemNix
   , add2 Normal   "elemAt"           elemAtNix
@@ -1846,7 +1856,6 @@ builtinsList = sequenceA
   , add  Normal   "hasContext"       hasContextNix
   , add' Normal   "hashString"       (hashStringNix @e @t @f @m)
   , add  Normal   "head"             headNix
-  , add  TopLevel "import"           importNix
   , add2 Normal   "intersectAttrs"   intersectAttrsNix
   , add  Normal   "isAttrs"          isAttrsNix
   , add  Normal   "isBool"           isBoolNix
@@ -1854,13 +1863,10 @@ builtinsList = sequenceA
   , add  Normal   "isFunction"       isFunctionNix
   , add  Normal   "isInt"            isIntNix
   , add  Normal   "isList"           isListNix
-  , add  TopLevel "isNull"           isNullNix
   , add  Normal   "isString"         isStringNix
   , add  Normal   "length"           lengthNix
   , add2 Normal   "lessThan"         lessThanNix
   , add  Normal   "listToAttrs"      listToAttrsNix
-  , add2 TopLevel "map"              mapNix
-  , add2 TopLevel "mapAttrs"         mapAttrsNix
   , add2 Normal   "match"            matchNix
   , add2 Normal   "mul"              mulNix
   , add0 Normal   "nixPath"          nixPathNix
@@ -1869,12 +1875,9 @@ builtinsList = sequenceA
   , add2 Normal   "partition"        partitionNix
   --, add  Normal   "path"             path
   , add  Normal   "pathExists"       pathExistsNix
-  , add  TopLevel "placeholder"      placeHolderNix
   , add  Normal   "readDir"          readDirNix
   , add  Normal   "readFile"         readFileNix
-  , add2 TopLevel "removeAttrs"      removeAttrsNix
   , add3 Normal   "replaceStrings"   replaceStringsNix
-  , add2 TopLevel "scopedImport"     scopedImportNix
   , add2 Normal   "seq"              seqNix
   , add2 Normal   "sort"             sortNix
   , add2 Normal   "split"            splitNix
@@ -1885,13 +1888,10 @@ builtinsList = sequenceA
   , add' Normal   "sub"              (arity2 ((-) @Integer))
   , add' Normal   "substring"        substringNix
   , add  Normal   "tail"             tailNix
-  , add  TopLevel "throw"            throwNix
   , add2 Normal   "toFile"           toFileNix
   , add  Normal   "toJSON"           toJSONNix
   , add  Normal   "toPath"           toPathNix
-  , add  TopLevel "toString"         toStringNix
   , add  Normal   "toXML"            toXMLNix
-  , add2 TopLevel "trace"            traceNix
   , add0 Normal   "true"             (pure $ mkNVBool True)
   , add  Normal   "tryEval"          tryEvalNix
   , add  Normal   "typeOf"           typeOfNix

--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -1068,7 +1068,7 @@ replaceStringsNix tfrom tto ts =
           updatedCtx     = ctx <> replacementCtx
 
           replacement    = Builder.fromText $ ignoreContext replacementNS
-          replacementCtx = getContext replacementNS
+          replacementCtx = getStringContext replacementNS
 
           -- The bug modifies the content => bug demands `pass` to be a real function =>
           -- `go` calls `pass` function && `pass` calls `go` function
@@ -1079,7 +1079,7 @@ replaceStringsNix tfrom tto ts =
               (\(c, i) -> go updatedCtx i $ output <> Builder.singleton c) -- If there are chars - pass one char & continue
               (Text.uncons input)  -- chip first char
 
-    toValue $ go (getContext string) (ignoreContext string) mempty
+    toValue $ go (getStringContext string) (ignoreContext string) mempty
 
 removeAttrsNix
   :: forall e t f m
@@ -1702,7 +1702,7 @@ getContextNix
 getContextNix =
   \case
     (NVStr ns) ->
-      mkNVSet mempty <$> traverseToValue (getNixLikeContext $ toNixLikeContext $ getContext ns)
+      mkNVSet mempty <$> traverseToValue (getNixLikeContext $ toNixLikeContext $ getStringContext ns)
     x -> throwError $ ErrorCall $ "Invalid type for builtins.getContext: " <> show x
   <=< demand
 
@@ -1769,7 +1769,7 @@ appendContextNix tx ty =
                       newContextValues
                       $ getNixLikeContext $
                           toNixLikeContext $
-                            getContext ns
+                            getStringContext ns
                 )
                 $ ignoreContext ns
 

--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -2016,7 +2016,7 @@ builtins
 builtins =
   do
     ref <- defer $ mkNVSet mempty <$> buildMap
-    (`pushScope` currentScopes) . coerce . M.fromList . (one ("builtins", ref) <>) =<< topLevelBuiltins
+    (`pushScope` askScopes) . coerce . M.fromList . (one ("builtins", ref) <>) =<< topLevelBuiltins
  where
   buildMap :: m (HashMap VarName (NValue t f m))
   buildMap         =  M.fromList . (mapping <$>) <$> builtinsList

--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -1693,7 +1693,7 @@ currentSystemNix =
 currentTimeNix :: MonadNix e t f m => m (NValue t f m)
 currentTimeNix =
   do
-    opts :: Options <- asks $ view hasLens
+    opts :: Options <- askLocal
     toValue @Integer $ round $ Time.utcTimeToPOSIXSeconds $ getTime opts
 
 derivationStrictNix :: MonadNix e t f m => NValue t f m -> m (NValue t f m)
@@ -1990,7 +1990,7 @@ withNixContext
 withNixContext mpath action =
   do
     base            <- builtins
-    opts :: Options <- asks $ view hasLens
+    opts :: Options <- askLocal
     let
       i = mkNVList $ mkNVStrWithoutContext . fromString . coerce <$> getInclude opts
 

--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -1694,7 +1694,7 @@ currentTimeNix :: MonadNix e t f m => m (NValue t f m)
 currentTimeNix =
   do
     opts :: Options <- asks $ view hasLens
-    toValue @Integer $ round $ Time.utcTimeToPOSIXSeconds $ currentTime opts
+    toValue @Integer $ round $ Time.utcTimeToPOSIXSeconds $ getTime opts
 
 derivationStrictNix :: MonadNix e t f m => NValue t f m -> m (NValue t f m)
 derivationStrictNix = derivationStrict
@@ -1991,7 +1991,7 @@ withNixContext mpath action =
     base            <- builtins
     opts :: Options <- asks $ view hasLens
     let
-      i = mkNVList $ mkNVStrWithoutContext . toText <$> include opts
+      i = mkNVList $ mkNVStrWithoutContext . toText <$> getInclude opts
 
     pushScope
       (coerce $ M.fromList $ one ("__includes", i))

--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -158,11 +158,6 @@ instance Comonad f => Ord (WValue t f m) where
 
 -- ** Helpers
 
-nvNull
-  :: MonadNix e t f m
-  => NValue t f m
-nvNull = mkNVConstant NNull
-
 mkNVBool
   :: MonadNix e t f m
   => Bool

--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -463,7 +463,7 @@ hasAttrNix x y =
     toValue $ M.member key aset
 
 hasContextNix :: MonadNix e t f m => NValue t f m -> m (NValue t f m)
-hasContextNix = inHask stringHasContext
+hasContextNix = inHask hasContext
 
 getAttrNix
   :: forall e t f m

--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -1991,10 +1991,10 @@ withNixContext mpath action =
     base            <- builtins
     opts :: Options <- asks $ view hasLens
     let
-      i = mkNVList $ mkNVStrWithoutContext . toText <$> getInclude opts
+      i = mkNVList $ mkNVStrWithoutContext . fromString . coerce <$> getInclude opts
 
     pushScope
-      (coerce $ M.fromList $ one ("__includes", i))
+      (one ("__includes", i))
       (pushScopes
         base $
         maybe
@@ -2002,8 +2002,7 @@ withNixContext mpath action =
           (\ path act ->
             do
               traceM $ "Setting __cur_file = " <> show path
-              let ref = mkNVPath path
-              pushScope (coerce $ M.fromList $ one ("__cur_file", ref)) act
+              pushScope (one ("__cur_file", mkNVPath path)) act
           )
           mpath
           action

--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -257,7 +257,7 @@ splitVersion s =
    (\ (x, xs) -> if
       | isRight eDigitsPart ->
           either
-            (\ e -> error $ "splitVersion: did hit impossible: '" <> toText e <> "' while parsing '" <> s <> "'.")
+            (\ e -> error $ "splitVersion: did hit impossible: '" <> fromString e <> "' while parsing '" <> s <> "'.")
             (\ res ->
               one (VersionComponentNumber $ fst res)
               <> splitVersion (snd res)
@@ -1488,6 +1488,7 @@ readDirNix nvpath =
     items          <- listDirectory path
 
     let
+      -- | Function indeed binds filepaths as keys ('VarNames') in Nix attrset.
       detectFileTypes :: Path -> m (VarName, FileType)
       detectFileTypes item =
         do
@@ -1500,7 +1501,7 @@ readDirNix nvpath =
                 | isSymbolicLink s -> FileTypeSymlink
                 | otherwise        -> FileTypeUnknown
 
-          pure (coerce @Text @VarName $ toText item, t) -- function indeed binds filepaths as keys (VarNames) in Nix attrset.
+          pure (coerce @(String -> Text) fromString item, t)
 
     itemsWithTypes <-
       traverse

--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -2017,8 +2017,7 @@ builtins
 builtins =
   do
     ref <- defer $ mkNVSet mempty <$> buildMap
-    lst <- (one ("builtins", ref) <>) <$> topLevelBuiltins
-    pushScope (coerce (M.fromList lst)) currentScopes
+    (`pushScope` currentScopes) . coerce . M.fromList . (one ("builtins", ref) <>) =<< topLevelBuiltins
  where
   buildMap :: m (HashMap VarName (NValue t f m))
   buildMap         =  M.fromList . (mapping <$>) <$> builtinsList
@@ -2032,5 +2031,5 @@ builtins =
     nameBuiltins :: Builtin v -> Builtin v
     nameBuiltins b@(Builtin TopLevel _) = b
     nameBuiltins (Builtin Normal nB) =
-      Builtin TopLevel $ first (coerce @Text . ("__" <>) . coerce @VarName) nB
+      Builtin TopLevel $ first (coerce @(Text -> Text) ("__" <>)) nB
 

--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -1693,7 +1693,7 @@ currentSystemNix =
 currentTimeNix :: MonadNix e t f m => m (NValue t f m)
 currentTimeNix =
   do
-    opts :: Options <- askLocal
+    opts <- askOptions
     toValue @Integer $ round $ Time.utcTimeToPOSIXSeconds $ getTime opts
 
 derivationStrictNix :: MonadNix e t f m => NValue t f m -> m (NValue t f m)
@@ -1989,13 +1989,11 @@ withNixContext
   -> m r
 withNixContext mpath action =
   do
-    base            <- builtins
-    opts :: Options <- askLocal
-    let
-      i = mkNVList $ mkNVStrWithoutContext . fromString . coerce <$> getInclude opts
+    base <- builtins
+    opts <- askOptions
 
     pushScope
-      (one ("__includes", i))
+      (one ("__includes", mkNVList $ mkNVStrWithoutContext . fromString . coerce <$> getInclude opts))
       (pushScopes
         base $
         maybe

--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -1098,10 +1098,10 @@ removeAttrsNix set v =
     (m, p) <- fromValue @(AttrSet (NValue t f m), PositionSet) set
     (nsToRemove :: [NixString]) <- fromValue $ Deeper v
     (coerce -> toRemove) <- traverse fromStringNoContext nsToRemove
-    toValue (go m toRemove, go p toRemove)
+    toValue (fun m toRemove, fun p toRemove)
  where
-  go :: forall k v . (Eq k, Hashable k) => HashMap k v -> [k] -> HashMap k v
-  go = foldl' (flip M.delete)
+  fun :: forall k v . (Eq k, Hashable k) => HashMap k v -> [k] -> HashMap k v
+  fun = foldl' (flip M.delete)
 
 intersectAttrsNix
   :: forall e t f m

--- a/src/Nix/Cited/Basic.hs
+++ b/src/Nix/Cited/Basic.hs
@@ -79,13 +79,13 @@ instance
   thunk :: m v -> m (Cited u f m t)
   thunk mv =
     do
-      opts :: Options <- asks $ view hasLens
+      opts :: Options <- askLocal
 
       bool
         (cite mempty)
         (\ t ->
           do
-            frames :: Frames <- asks $ view hasLens
+            frames :: Frames <- askLocal
 
             -- Gather the current evaluation context at the time of thunk
             -- creation, and record it along with the thunk.

--- a/src/Nix/Cited/Basic.hs
+++ b/src/Nix/Cited/Basic.hs
@@ -98,7 +98,7 @@ instance
 
             cite ps t
         )
-        (thunks opts)
+        (isThunks opts)
         (thunk mv)
 
   thunkId :: Cited u f m t -> ThunkId m

--- a/src/Nix/Cited/Basic.hs
+++ b/src/Nix/Cited/Basic.hs
@@ -85,7 +85,7 @@ instance
         (cite mempty)
         (\ mt ->
           do
-            frames :: Frames <- askLocal
+            frames <- askFrames
 
             -- Gather the current evaluation context at the time of thunk
             -- creation, and record it along with the thunk.

--- a/src/Nix/Context.hs
+++ b/src/Nix/Context.hs
@@ -9,24 +9,25 @@ import           Nix.Expr.Types.Annotated       ( SrcSpan
                                                 )
 
 --  2021-07-18: NOTE: It should be Options -> Scopes -> Frames -> Source(span)
-data Context m t = Context
-    { scopes  :: Scopes m t
-    , source  :: SrcSpan
-    , frames  :: Frames
-    , options :: Options
+data Context m t =
+  Context
+    { getOptions :: Options
+    , getScopes  :: Scopes m t
+    , getSource  :: SrcSpan
+    , getFrames  :: Frames
     }
 
 instance Has (Context m t) (Scopes m t) where
-  hasLens f a = (\x -> a { scopes = x }) <$> f (scopes a)
+  hasLens f a = (\x -> a { getScopes = x }) <$> f (getScopes a)
 
 instance Has (Context m t) SrcSpan where
-  hasLens f a = (\x -> a { source = x }) <$> f (source a)
+  hasLens f a = (\x -> a { getSource = x }) <$> f (getSource a)
 
 instance Has (Context m t) Frames where
-  hasLens f a = (\x -> a { frames = x }) <$> f (frames a)
+  hasLens f a = (\x -> a { getFrames = x }) <$> f (getFrames a)
 
 instance Has (Context m t) Options where
-  hasLens f a = (\x -> a { options = x }) <$> f (options a)
+  hasLens f a = (\x -> a { getOptions = x }) <$> f (getOptions a)
 
 newContext :: Options -> Context m t
-newContext = Context mempty nullSpan mempty
+newContext o = Context o mempty nullSpan mempty

--- a/src/Nix/Convert.hs
+++ b/src/Nix/Convert.hs
@@ -68,7 +68,7 @@ class FromValue a m v where
   fromValue    :: v -> m a
   fromValueMay :: v -> m (Maybe a)
 
-traverseFromM
+traverseFromValue
   :: ( Applicative m
      , Traversable t
      , FromValue b m a
@@ -77,7 +77,13 @@ traverseFromM
   -> m (Maybe (t b))
 traverseFromValue = traverse2 fromValueMay
 
-traverseToValue :: ((Traversable t, Applicative f, ToValue a f b) => t a -> f (t b))
+traverseToValue
+  :: ( Traversable t
+     , Applicative f
+     , ToValue a f b
+     )
+  => t a
+  -> f (t b)
 traverseToValue = traverse toValue
 
 -- Please, hide these helper function from export, to be sure they get optimized away.
@@ -281,7 +287,7 @@ instance ( Convertible e t f m
   => FromValue [a] m (Deeper (NValue' t f m (NValue t f m))) where
   fromValueMay =
     \case
-      Deeper (NVList' l) -> traverseFromM l
+      Deeper (NVList' l) -> traverseFromValue l
       _                  -> stub
 
 
@@ -305,7 +311,7 @@ instance ( Convertible e t f m
 
   fromValueMay =
     \case
-      Deeper (NVSet' _ s) -> traverseFromM s
+      Deeper (NVSet' _ s) -> traverseFromValue s
       _                   -> stub
 
   fromValue = fromMayToDeeperValue TSet
@@ -330,7 +336,7 @@ instance ( Convertible e t f m
 
   fromValueMay =
     \case
-      Deeper (NVSet' p s) -> (, p) <<$>> traverseFromM s
+      Deeper (NVSet' p s) -> (, p) <<$>> traverseFromValue s
       _                   -> stub
 
   fromValue = fromMayToDeeperValue TSet

--- a/src/Nix/Convert.hs
+++ b/src/Nix/Convert.hs
@@ -75,7 +75,7 @@ traverseFromM
      )
   => t a
   -> m (Maybe (t b))
-traverseFromM = traverseM fromValueMay
+traverseFromValue = traverse2 fromValueMay
 
 traverseToValue :: ((Traversable t, Applicative f, ToValue a f b) => t a -> f (t b))
 traverseToValue = traverse toValue

--- a/src/Nix/Convert.hs
+++ b/src/Nix/Convert.hs
@@ -363,39 +363,39 @@ instance ( Convertible e t f m
 
 instance Convertible e t f m
   => ToValue () m (NValue' t f m (NValue t f m)) where
-  toValue _ = pure . nvConstant' $ NNull
+  toValue _ = pure . mkNVConstant' $ NNull
 
 instance Convertible e t f m
   => ToValue Bool m (NValue' t f m (NValue t f m)) where
-  toValue = pure . nvConstant' . NBool
+  toValue = pure . mkNVConstant' . NBool
 
 instance Convertible e t f m
   => ToValue Int m (NValue' t f m (NValue t f m)) where
-  toValue = pure . nvConstant' . NInt . toInteger
+  toValue = pure . mkNVConstant' . NInt . toInteger
 
 instance Convertible e t f m
   => ToValue Integer m (NValue' t f m (NValue t f m)) where
-  toValue = pure . nvConstant' . NInt
+  toValue = pure . mkNVConstant' . NInt
 
 instance Convertible e t f m
   => ToValue Float m (NValue' t f m (NValue t f m)) where
-  toValue = pure . nvConstant' . NFloat
+  toValue = pure . mkNVConstant' . NFloat
 
 instance Convertible e t f m
   => ToValue NixString m (NValue' t f m (NValue t f m)) where
-  toValue = pure . nvStr'
+  toValue = pure . mkNVStr'
 
 instance Convertible e t f m
   => ToValue ByteString m (NValue' t f m (NValue t f m)) where
-  toValue = pure . nvStr' . mkNixStringWithoutContext . decodeUtf8
+  toValue = pure . mkNVStr' . mkNixStringWithoutContext . decodeUtf8
 
 instance Convertible e t f m
   => ToValue Text m (NValue' t f m (NValue t f m)) where
-  toValue = pure . nvStr' . mkNixStringWithoutContext
+  toValue = pure . mkNVStr' . mkNixStringWithoutContext
 
 instance Convertible e t f m
   => ToValue Path m (NValue' t f m (NValue t f m)) where
-  toValue = pure . nvPath' . coerce
+  toValue = pure . mkNVPath' . coerce
 
 instance Convertible e t f m
   => ToValue StorePath m (NValue' t f m (NValue t f m)) where
@@ -408,40 +408,40 @@ instance Convertible e t f m
     l' <- toValue $ unPos l
     c' <- toValue $ unPos c
     let pos = M.fromList [("file" :: VarName, f'), ("line", l'), ("column", c')]
-    pure $ nvSet' mempty pos
+    pure $ mkNVSet' mempty pos
 
 -- | With 'ToValue', we can always act recursively
 instance Convertible e t f m
   => ToValue [NValue t f m] m (NValue' t f m (NValue t f m)) where
-  toValue = pure . nvList'
+  toValue = pure . mkNVList'
 
 instance (Convertible e t f m
   , ToValue a m (NValue t f m)
   )
   => ToValue [a] m (Deeper (NValue' t f m (NValue t f m))) where
-  toValue l = Deeper . nvList' <$> traverseToValue l
+  toValue l = Deeper . mkNVList' <$> traverseToValue l
 
 instance Convertible e t f m
   => ToValue (AttrSet (NValue t f m)) m (NValue' t f m (NValue t f m)) where
-  toValue s = pure $ nvSet' mempty s
+  toValue s = pure $ mkNVSet' mempty s
 
 instance (Convertible e t f m, ToValue a m (NValue t f m))
   => ToValue (AttrSet a) m (Deeper (NValue' t f m (NValue t f m))) where
   toValue s =
-    liftA2 (\ v s -> Deeper $ nvSet' s v)
+    liftA2 (\ v s -> Deeper $ mkNVSet' s v)
       (traverseToValue s)
       stub
 
 instance Convertible e t f m
   => ToValue (AttrSet (NValue t f m), PositionSet) m
             (NValue' t f m (NValue t f m)) where
-  toValue (s, p) = pure $ nvSet' p s
+  toValue (s, p) = pure $ mkNVSet' p s
 
 instance (Convertible e t f m, ToValue a m (NValue t f m))
   => ToValue (AttrSet a, PositionSet) m
             (Deeper (NValue' t f m (NValue t f m))) where
   toValue (s, p) =
-    liftA2 (\ v s -> Deeper $ nvSet' s v)
+    liftA2 (\ v s -> Deeper $ mkNVSet' s v)
       (traverseToValue s)
       (pure p)
 
@@ -465,7 +465,7 @@ instance Convertible e t f m
         (pure Nothing)
         (fmap pure . toValue)
         ts
-    pure $ nvSet' mempty $ M.fromList $ catMaybes
+    pure $ mkNVSet' mempty $ M.fromList $ catMaybes
       [ ("path"      ,) <$> path
       , ("allOutputs",) <$> allOutputs
       , ("outputs"   ,) <$> outputs

--- a/src/Nix/Convert.hs
+++ b/src/Nix/Convert.hs
@@ -369,7 +369,7 @@ instance ( Convertible e t f m
 
 instance Convertible e t f m
   => ToValue () m (NValue' t f m (NValue t f m)) where
-  toValue _ = pure . mkNVConstant' $ NNull
+  toValue _ = pure $ nvNull'
 
 instance Convertible e t f m
   => ToValue Bool m (NValue' t f m (NValue t f m)) where

--- a/src/Nix/Convert.hs
+++ b/src/Nix/Convert.hs
@@ -218,7 +218,7 @@ instance ( Convertible e t f m
     \case
       NVStr' ns -> pure $ pure ns
       NVPath' p ->
-        (\path -> pure $ (`mkNixStringWithSingletonContext` (`StringContext` DirectPath) path) path ) . fromString . coerce <$>
+        (\path -> pure $ (`mkNixStringWithSingletonContext` StringContext DirectPath path) path ) . fromString . coerce <$>
           addPath p
       NVSet' _ s ->
         maybe

--- a/src/Nix/Convert.hs
+++ b/src/Nix/Convert.hs
@@ -218,7 +218,7 @@ instance ( Convertible e t f m
     \case
       NVStr' ns -> pure $ pure ns
       NVPath' p ->
-        (\path -> pure $ (`mkNixStringWithSingletonContext` StringContext DirectPath path) path ) . fromString . coerce <$>
+        (\path -> pure $ mkNixStringWithSingletonContext (StringContext DirectPath path) path) . fromString . coerce <$>
           addPath p
       NVSet' _ s ->
         maybe

--- a/src/Nix/Convert.hs
+++ b/src/Nix/Convert.hs
@@ -139,9 +139,10 @@ instance ( Convertible e t f m
          )
   => FromValue a m (Deeper (NValue t f m)) where
 
+  fromValueMay :: Deeper (NValue t f m) -> m (Maybe a)
   fromValueMay (Deeper v) =
     free
-      ((fromValueMay . Deeper) <=< force)
+      ((fromValueMay . Deeper) <=< force)  -- these places are complex in types
       (fromValueMay . Deeper)
       =<< demand v
 
@@ -217,7 +218,7 @@ instance ( Convertible e t f m
     \case
       NVStr' ns -> pure $ pure ns
       NVPath' p ->
-        (\path -> pure $ mkNixStringWithSingletonContext path (StringContext path DirectPath)) . fromString . coerce <$>
+        (\path -> pure $ (`mkNixStringWithSingletonContext` (`StringContext` DirectPath) path) path ) . fromString . coerce <$>
           addPath p
       NVSet' _ s ->
         maybe
@@ -369,7 +370,7 @@ instance ( Convertible e t f m
 
 instance Convertible e t f m
   => ToValue () m (NValue' t f m (NValue t f m)) where
-  toValue _ = pure $ nvNull'
+  toValue = const $ pure nvNull'
 
 instance Convertible e t f m
   => ToValue Bool m (NValue' t f m (NValue t f m)) where
@@ -478,7 +479,7 @@ instance Convertible e t f m
       ]
 
 instance Convertible e t f m => ToValue () m (NExprF (NValue t f m)) where
-  toValue _ = pure . NConstant $ NNull
+  toValue = const . pure . NConstant $ NNull
 
 instance Convertible e t f m => ToValue Bool m (NExprF (NValue t f m)) where
   toValue = pure . NConstant . NBool

--- a/src/Nix/Effects.hs
+++ b/src/Nix/Effects.hs
@@ -442,4 +442,4 @@ addPath p =
     =<< addToStore (fromString $ coerce takeFileName p) p True False
 
 toFile_ :: (Framed e m, MonadStore m) => Path -> Text -> m StorePath
-toFile_ p contents = addTextToStore (toText p) contents mempty False
+toFile_ p contents = addTextToStore (fromString $ coerce p) contents mempty False

--- a/src/Nix/Effects/Basic.hs
+++ b/src/Nix/Effects/Basic.hs
@@ -144,7 +144,7 @@ findPathBy finder ls name =
                 tryPath path $
                   whenJust
                     (\ nsPfx ->
-                      let pfx = stringIgnoreContext nsPfx in
+                      let pfx = ignoreContext nsPfx in
                       pure $ coerce $ toString pfx `whenFalse` Text.null pfx
                     )
                     mns
@@ -191,7 +191,7 @@ fetchTarball =
     -> m (NValue t f m)
   fetchFromString msha =
     \case
-      NVStr ns -> fetch (stringIgnoreContext ns) msha
+      NVStr ns -> fetch (ignoreContext ns) msha
       v -> throwError $ ErrorCall $ "builtins.fetchTarball: Expected URI or string, got " <> show v
 
 {- jww (2018-04-11): This should be written using pipes in another module
@@ -216,7 +216,7 @@ fetchTarball =
         do
           nsSha <- fromValue =<< demand v
 
-          let sha = stringIgnoreContext nsSha
+          let sha = ignoreContext nsSha
 
           nixInstantiateExpr $
             "builtins.fetchTarball { " <> "url    = \"" <> uri <> "\"; " <> "sha256 = \"" <> sha <> "\"; }"

--- a/src/Nix/Effects/Derivation.hs
+++ b/src/Nix/Effects/Derivation.hs
@@ -289,13 +289,13 @@ defaultDerivationStrict val = do
     let
       outputsWithContext =
         Map.mapWithKey
-          (\out (coerce -> path) -> mkNixStringWithSingletonContext path $ StringContext (DerivationOutput out) drvPath)
+          (\out (coerce -> path) -> mkNixStringWithSingletonContext (StringContext (DerivationOutput out) drvPath) path)
           (outputs drv')
-      drvPathWithContext = mkNixStringWithSingletonContext drvPath $ StringContext AllOutputs drvPath 
+      drvPathWithContext = mkNixStringWithSingletonContext (StringContext AllOutputs drvPath) drvPath
       attrSet = mkNVStr <$> M.fromList (("drvPath", drvPathWithContext) : Map.toList outputsWithContext)
     -- TODO: Add location information for all the entries.
     --              here --v
-    pure $ mkNVSet mempty (M.mapKeys coerce attrSet)
+    pure $ mkNVSet mempty $ M.mapKeys coerce attrSet
 
   where
 

--- a/src/Nix/Effects/Derivation.hs
+++ b/src/Nix/Effects/Derivation.hs
@@ -31,7 +31,7 @@ import           Nix.Exec                       ( MonadNix
                                                 , callFunc
                                                 )
 import           Nix.Frames
-import           Nix.Json                       ( nvalueToJSONNixString )
+import           Nix.Json                       ( toJSONNixString )
 import           Nix.Render
 import           Nix.String
 import           Nix.String.Coerce
@@ -367,7 +367,7 @@ buildDerivationWithContext drvAttrs = do
 
       env <- if useJson
         then do
-          jsonString :: NixString <- lift $ nvalueToJSONNixString $ mkNVSet mempty $ M.mapKeys coerce $
+          jsonString :: NixString <- lift $ toJSONNixString $ mkNVSet mempty $ M.mapKeys coerce $
             deleteKeys [ "args", "__ignoreNulls", "__structuredAttrs" ] attrs
           rawString :: Text <- extractNixString jsonString
           pure $ one ("__json", rawString)

--- a/src/Nix/Effects/Derivation.hs
+++ b/src/Nix/Effects/Derivation.hs
@@ -292,10 +292,10 @@ defaultDerivationStrict val = do
           (\out (coerce -> path) -> mkNixStringWithSingletonContext path $ StringContext drvPath $ DerivationOutput out)
           (outputs drv')
       drvPathWithContext = mkNixStringWithSingletonContext drvPath $ StringContext drvPath AllOutputs
-      attrSet = nvStr <$> M.fromList (("drvPath", drvPathWithContext) : Map.toList outputsWithContext)
+      attrSet = mkNVStr <$> M.fromList (("drvPath", drvPathWithContext) : Map.toList outputsWithContext)
     -- TODO: Add location information for all the entries.
     --              here --v
-    pure $ nvSet mempty (M.mapKeys coerce attrSet)
+    pure $ mkNVSet mempty (M.mapKeys coerce attrSet)
 
   where
 
@@ -367,7 +367,7 @@ buildDerivationWithContext drvAttrs = do
 
       env <- if useJson
         then do
-          jsonString :: NixString <- lift $ nvalueToJSONNixString $ nvSet mempty $ M.mapKeys coerce $
+          jsonString :: NixString <- lift $ nvalueToJSONNixString $ mkNVSet mempty $ M.mapKeys coerce $
             deleteKeys [ "args", "__ignoreNulls", "__structuredAttrs" ] attrs
           rawString :: Text <- extractNixString jsonString
           pure $ one ("__json", rawString)

--- a/src/Nix/Eval.hs
+++ b/src/Nix/Eval.hs
@@ -466,8 +466,7 @@ evalSetterKeyName =
   \case
     StaticKey k -> pure $ pure k
     DynamicKey k ->
-      (coerce . ignoreContext) <<$>>
-        runAntiquoted "\n" assembleString (fromValueMay =<<) k
+      coerce . ignoreContext <<$>> runAntiquoted "\n" assembleString (fromValueMay =<<) k
 
 assembleString
   :: forall v m

--- a/src/Nix/Eval.hs
+++ b/src/Nix/Eval.hs
@@ -466,7 +466,7 @@ evalSetterKeyName =
   \case
     StaticKey k -> pure $ pure k
     DynamicKey k ->
-      (coerce . stringIgnoreContext) <<$>>
+      (coerce . ignoreContext) <<$>>
         runAntiquoted "\n" assembleString (fromValueMay =<<) k
 
 assembleString

--- a/src/Nix/Eval.hs
+++ b/src/Nix/Eval.hs
@@ -259,9 +259,7 @@ attrSetAlter ks' pos m' p' val =
           , AttrSet (m v)
           )
     recurse p'' m'' =
-      fmap
-        (insertVal . (=<<) (toValue @(AttrSet v, PositionSet)) . fmap (,mempty) . sequenceA . snd)
-        (go p'' m'' ks)
+      insertVal . ((toValue @(AttrSet v, PositionSet)) <=< ((,mempty) <$>) . sequenceA . snd) <$> go p'' m'' ks
 
 desugarBinds :: forall r . ([Binding r] -> r) -> [Binding r] -> [Binding r]
 desugarBinds embed binds = evalState (traverse (findBinding <=< collect) binds) mempty

--- a/src/Nix/Eval.hs
+++ b/src/Nix/Eval.hs
@@ -84,7 +84,7 @@ type MonadNixEval v m
 data EvalFrame m v
   = EvaluatingExpr (Scopes m v) NExprLoc
   | ForcingExpr (Scopes m v) NExprLoc
-  | Calling Text SrcSpan
+  | Calling VarName SrcSpan
   | SynHole (SynHoleInfo m v)
   deriving (Show, Typeable)
 

--- a/src/Nix/Eval.hs
+++ b/src/Nix/Eval.hs
@@ -477,7 +477,7 @@ assembleString
 assembleString = fromParts . stringParts
  where
   fromParts :: [Antiquoted Text (m v)] -> m (Maybe NixString)
-  fromParts xs = fold <<$>> traverseM fun xs
+  fromParts xs = fold <<$>> traverse2 fun xs
 
   fun :: Antiquoted Text (m v) -> m (Maybe NixString)
   fun =

--- a/src/Nix/Eval.hs
+++ b/src/Nix/Eval.hs
@@ -557,12 +557,12 @@ addStackFrames f v =
  where
   withFrameInfo = withFrame Info
 
-framedEvalExprLoc
+evalWithMetaInfo
   :: forall e v m
   . (MonadNixEval v m, Framed e m, Has e SrcSpan, Typeable m, Typeable v)
   => NExprLoc
   -> m v
-framedEvalExprLoc =
+evalWithMetaInfo =
   adi addMetaInfo evalContent
 
 -- | Add source positions & frame context system.

--- a/src/Nix/Exec.hs
+++ b/src/Nix/Exec.hs
@@ -543,16 +543,18 @@ evalExprLoc expr =
       pTracedAdi =
         bool
           Eval.framedEvalExprLoc
-          (join . (`runReaderT` (0 :: Int)) .
-            adi
-              addMetaInfo
-              (addTracing Eval.evalContent)
-          )
+          (join . (`runReaderT` (0 :: Int)) . evalWithTracingAndMetaInfo)
           (isTrace opts)
     pTracedAdi expr
  where
-  addMetaInfo :: (NExprLoc -> ReaderT r m a) -> NExprLoc -> ReaderT r m a
-  addMetaInfo = (ReaderT .) . flip . (Eval.addMetaInfo .) . flip . (runReaderT .)
+  evalWithTracingAndMetaInfo :: NExprLoc -> ReaderT Int m (m (NValue t f m))
+  evalWithTracingAndMetaInfo =
+    adi
+      addMetaInfo
+      (addTracing Eval.evalContent)
+   where
+    addMetaInfo :: (NExprLoc -> ReaderT r m a) -> NExprLoc -> ReaderT r m a
+    addMetaInfo = (ReaderT .) . flip . (Eval.addMetaInfo .) . flip . (runReaderT .)
 
 exec :: (MonadNix e t f m, MonadInstantiate m) => [Text] -> m (NValue t f m)
 exec args = either throwError evalExprLoc =<< exec' args

--- a/src/Nix/Exec.hs
+++ b/src/Nix/Exec.hs
@@ -306,7 +306,7 @@ callFunc fun arg =
           span <- currentPos
           withFrame Info ((Calling @m @(NValue t f m)) name span) $ f arg -- Is this cool?
       (NVSet _ m) | Just f <- M.lookup "__functor" m ->
-        (`callFunc` arg) =<< (`callFunc` fun') =<< demand f
+        (`callFunc` arg) =<< (`callFunc` fun') f
       _x -> throwError $ ErrorCall $ "Attempt to call non-function: " <> show _x
 
 execUnaryOp

--- a/src/Nix/Exec.hs
+++ b/src/Nix/Exec.hs
@@ -542,7 +542,7 @@ evalExprLoc expr =
     let
       pTracedAdi =
         bool
-          Eval.framedEvalExprLoc
+          Eval.evalWithMetaInfo
           (join . (`runReaderT` (0 :: Int)) . evalWithTracingAndMetaInfo)
           (isTrace opts)
     pTracedAdi expr

--- a/src/Nix/Exec.hs
+++ b/src/Nix/Exec.hs
@@ -310,7 +310,7 @@ callFunc fun arg =
       NVBuiltin name f    ->
         do
           span <- currentPos
-          withFrame Info ((Calling @m @(NValue t f m)) (coerce name) span) $ f arg -- Is this cool?
+          withFrame Info ((Calling @m @(NValue t f m)) name span) $ f arg -- Is this cool?
       (NVSet _ m) | Just f <- M.lookup "__functor" m ->
         (`callFunc` arg) =<< (`callFunc` fun') =<< demand f
       _x -> throwError $ ErrorCall $ "Attempt to call non-function: " <> show _x

--- a/src/Nix/Exec.hs
+++ b/src/Nix/Exec.hs
@@ -276,11 +276,22 @@ instance MonadNix e t f m => MonadEval (NValue t f m) m where
       span  <- askSpan
       mkNVBinaryOpWithProvenance scope span NApp (pure f) Nothing <$> (callFunc f =<< defer x)
 
+  evalAbs
+    :: Params (m (NValue t f m))
+    -> ( forall a
+      . m (NValue t f m)
+      -> ( AttrSet (m (NValue t f m))
+        -> m (NValue t f m)
+        -> m (a, NValue t f m)
+        )
+      -> m (a, NValue t f m)
+      )
+    -> m (NValue t f m)
   evalAbs p k =
     do
       scope <- askScopes
       span  <- askSpan
-      pure $ mkNVClosureWithProvenance scope span (void p) (fmap snd . flip k (const (fmap (() ,))) . pure)
+      pure $ mkNVClosureWithProvenance scope span (void p) (fmap snd . flip (k @()) (const (fmap (mempty ,))) . pure)
 
   evalError = throwError
 

--- a/src/Nix/Exec.hs
+++ b/src/Nix/Exec.hs
@@ -545,14 +545,14 @@ evalExprLoc expr =
           Eval.framedEvalExprLoc
           (join . (`runReaderT` (0 :: Int)) .
             adi
-              raise
+              addMetaInfo
               (addTracing Eval.evalContent)
           )
           (isTrace opts)
     pTracedAdi expr
  where
-  raise :: (NExprLoc -> ReaderT r m a) -> NExprLoc -> ReaderT r m a
-  raise = (ReaderT .) . flip . (Eval.addMetaInfo .) . flip . (runReaderT .)
+  addMetaInfo :: (NExprLoc -> ReaderT r m a) -> NExprLoc -> ReaderT r m a
+  addMetaInfo = (ReaderT .) . flip . (Eval.addMetaInfo .) . flip . (runReaderT .)
 
 exec :: (MonadNix e t f m, MonadInstantiate m) => [Text] -> m (NValue t f m)
 exec args = either throwError evalExprLoc =<< exec' args

--- a/src/Nix/Exec.hs
+++ b/src/Nix/Exec.hs
@@ -242,21 +242,21 @@ instance MonadNix e t f m => MonadEval (NValue t f m) m where
       let f = join $ addProvenance . Provenance scope . NWithAnnF span Nothing . pure
       f <$> evalWithAttrSet c b
 
-  evalIf c tVal fVal = do
-    scope <- askScopes
-    span  <- askSpan
-    bl <- fromValue c
+  evalIf c tVal fVal =
+    do
+      scope <- askScopes
+      span  <- askSpan
+      bl <- fromValue c
 
-    let
-      fun x y = addProvenance (Provenance scope $ NIfAnnF span (pure c) x y)
-      -- Note: join acts as \ f x -> f x x
-      falseVal = join (fun Nothing . pure) <$> fVal
-      trueVal = join (flip fun Nothing . pure) <$> tVal
+      let
+        fun x y = addProvenance (Provenance scope $ NIfAnnF span (pure c) x y)
+        falseVal = (fun Nothing =<< pure) <$> fVal
+        trueVal = (flip fun Nothing =<< pure) <$> tVal
 
-    bool
-      falseVal
-      trueVal
-      bl
+      bool
+        falseVal
+        trueVal
+        bl
 
   evalAssert c body =
     do

--- a/src/Nix/Exec.hs
+++ b/src/Nix/Exec.hs
@@ -521,7 +521,7 @@ addTracing k v = do
   local succ $ do
     v'@(AnnF span x) <- sequenceA v
     pure $ do
-      opts :: Options <- askLocal
+      opts <- askOptions
       let
         rendered =
           bool
@@ -538,7 +538,7 @@ addTracing k v = do
 evalExprLoc :: forall e t f m . MonadNix e t f m => NExprLoc -> m (NValue t f m)
 evalExprLoc expr =
   do
-    opts :: Options <- askLocal
+    opts <- askOptions
     let
       pTracedAdi =
         bool

--- a/src/Nix/Exec.hs
+++ b/src/Nix/Exec.hs
@@ -280,7 +280,7 @@ instance MonadNix e t f m => MonadEval (NValue t f m) m where
     do
       scope <- askScopes
       span  <- askSpan
-      pure $ mkNVClosureWithProvenance scope span (void p) . (fmap snd .) . (. pure) $ flip k (const (fmap ((),)))
+      pure $ mkNVClosureWithProvenance scope span (void p) (fmap snd . flip k (const (fmap (() ,))) . pure)
 
   evalError = throwError
 

--- a/src/Nix/Exec.hs
+++ b/src/Nix/Exec.hs
@@ -59,28 +59,28 @@ nvConstantP
   => Provenance m (NValue t f m)
   -> NAtom
   -> NValue t f m
-nvConstantP p x = addProvenance p $ nvConstant x
+nvConstantP p x = addProvenance p $ mkNVConstant x
 
 nvStrP
   :: MonadCited t f m
   => Provenance m (NValue t f m)
   -> NixString
   -> NValue t f m
-nvStrP p ns = addProvenance p $ nvStr ns
+nvStrP p ns = addProvenance p $ mkNVStr ns
 
 nvPathP
   :: MonadCited t f m
   => Provenance m (NValue t f m)
   -> Path
   -> NValue t f m
-nvPathP p x = addProvenance p $ nvPath x
+nvPathP p x = addProvenance p $ mkNVPath x
 
 nvListP
   :: MonadCited t f m
   => Provenance m (NValue t f m)
   -> [NValue t f m]
   -> NValue t f m
-nvListP p l = addProvenance p $ nvList l
+nvListP p l = addProvenance p $ mkNVList l
 
 nvSetP
   :: MonadCited t f m
@@ -88,7 +88,7 @@ nvSetP
   -> PositionSet
   -> AttrSet (NValue t f m)
   -> NValue t f m
-nvSetP p x s = addProvenance p $ nvSet x s
+nvSetP p x s = addProvenance p $ mkNVSet x s
 
 nvClosureP
   :: MonadCited t f m
@@ -96,7 +96,7 @@ nvClosureP
   -> Params ()
   -> (NValue t f m -> m (NValue t f m))
   -> NValue t f m
-nvClosureP p x f = addProvenance p $ nvClosure x f
+nvClosureP p x f = addProvenance p $ mkNVClosure x f
 
 nvBuiltinP
   :: MonadCited t f m
@@ -104,7 +104,7 @@ nvBuiltinP
   -> VarName
   -> (NValue t f m -> m (NValue t f m))
   -> NValue t f m
-nvBuiltinP p name f = addProvenance p $ nvBuiltin name f
+nvBuiltinP p name f = addProvenance p $ mkNVBuiltin name f
 
 type MonadCitedThunks t f m =
   ( MonadThunk t m (NValue t f m)

--- a/src/Nix/Exec.hs
+++ b/src/Nix/Exec.hs
@@ -173,7 +173,7 @@ instance MonadNix e t f m => MonadEval (NValue t f m) m where
     scope                  <- currentScopes
     span@(SrcSpan delta _) <- currentPos
     addProvenance @_ @_ @(NValue t f m)
-      (Provenance scope $ NSymAnnF span (coerce @Text "__curPos")) <$>
+      (Provenance scope . NSymAnnF span $ coerce @Text "__curPos") <$>
         toValue delta
 
   evaledSym name val = do

--- a/src/Nix/Exec.hs
+++ b/src/Nix/Exec.hs
@@ -145,7 +145,7 @@ nverr :: forall e t f s m a . (MonadNix e t f m, Exception s) => s -> m a
 nverr = evalError @(NValue t f m)
 
 currentPos :: forall e m . (MonadReader e m, Has e SrcSpan) => m SrcSpan
-currentPos = asks $ view hasLens
+currentPos = askLocal
 
 wrapExprLoc :: SrcSpan -> NExprLocF r -> NExprLoc
 wrapExprLoc span x = Fix $ NSymAnn span "<?>" <$ x
@@ -295,7 +295,7 @@ callFunc
   -> m (NValue t f m)
 callFunc fun arg =
   do
-    frames :: Frames <- asks $ view hasLens
+    frames :: Frames <- askLocal
     when (length frames > 2000) $ throwError $ ErrorCall "Function call stack exhausted"
 
     fun' <- demand fun
@@ -521,7 +521,7 @@ addTracing k v = do
   local succ $ do
     v'@(AnnF span x) <- sequenceA v
     pure $ do
-      opts :: Options <- asks $ view hasLens
+      opts :: Options <- askLocal
       let
         rendered =
           bool
@@ -538,7 +538,7 @@ addTracing k v = do
 evalExprLoc :: forall e t f m . MonadNix e t f m => NExprLoc -> m (NValue t f m)
 evalExprLoc expr =
   do
-    opts :: Options <- asks $ view hasLens
+    opts :: Options <- askLocal
     let
       pTracedAdi =
         bool

--- a/src/Nix/Exec.hs
+++ b/src/Nix/Exec.hs
@@ -148,14 +148,15 @@ instance MonadNix e t f m => MonadEval (NValue t f m) m where
   freeVariable var =
     nverr @e @t @f $ ErrorCall $ toString @Text $ "Undefined variable '" <> coerce var <> "'"
 
-  synHole name = do
-    span  <- currentPos
-    scope <- currentScopes
-    evalError @(NValue t f m) $ SynHole $
-      SynHoleInfo
-        { _synHoleInfo_expr  = NSynHoleAnn span name
-        , _synHoleInfo_scope = scope
-        }
+  synHole name =
+    do
+      span  <- currentPos
+      scope <- currentScopes
+      evalError @(NValue t f m) $ SynHole $
+        SynHoleInfo
+          { _synHoleInfo_expr  = NSynHoleAnn span name
+          , _synHoleInfo_scope = scope
+          }
 
 
   attrMissing ks ms =
@@ -316,7 +317,8 @@ callFunc fun arg =
       _x -> throwError $ ErrorCall $ "Attempt to call non-function: " <> show _x
 
 execUnaryOp
-  :: (Framed e m, MonadCited t f m, Show t)
+  :: forall e t f m
+   . (Framed e m, MonadCited t f m, Show t)
   => Scopes m (NValue t f m)
   -> SrcSpan
   -> NUnaryOp

--- a/src/Nix/Exec.hs
+++ b/src/Nix/Exec.hs
@@ -201,7 +201,7 @@ instance MonadNix e t f m => MonadEval (NValue t f m) m where
               (nvStrP
                 . Provenance
                   scope
-                  . NStrAnnF span . DoubleQuoted . one . Plain . stringIgnoreContext
+                  . NStrAnnF span . DoubleQuoted . one . Plain . ignoreContext
               )
               ns
       )

--- a/src/Nix/Exec.hs
+++ b/src/Nix/Exec.hs
@@ -295,7 +295,7 @@ callFunc
   -> m (NValue t f m)
 callFunc fun arg =
   do
-    frames :: Frames <- askLocal
+    frames <- askFrames
     when (length frames > 2000) $ throwError $ ErrorCall "Function call stack exhausted"
 
     fun' <- demand fun

--- a/src/Nix/Expr/Shorthands.hs
+++ b/src/Nix/Expr/Shorthands.hs
@@ -1,5 +1,5 @@
 
--- | A bunch of shorthands for making nix expressions.
+-- | Shorthands for making Nix expressions.
 --
 -- Functions with an @F@ suffix return a more general type (base functor @F a@) without the outer
 -- 'Fix' wrapper that creates @a@.
@@ -424,13 +424,13 @@ infixr 1 ==>
 -- | __@Deprecated@__: Please, use `mkOp`
 -- Put an unary operator.
 mkOper :: NUnaryOp -> NExpr -> NExpr
-mkOper op = Fix . NUnary op
+mkOper = mkOp
 
 -- NOTE: Remove after 2023-07
 -- | __@Deprecated@__: Please, use `mkOp2`
 -- | Put a binary operator.
 mkOper2 :: NBinaryOp -> NExpr -> NExpr -> NExpr
-mkOper2 op a = Fix . NBinary op a
+mkOper2 = mkOp2
 
 -- NOTE: Remove after 2023-07
 -- | __@Deprecated@__: Please, use `mkOp2`

--- a/src/Nix/Expr/Types.hs
+++ b/src/Nix/Expr/Types.hs
@@ -318,9 +318,9 @@ data NKeyName r
     )
 
 instance NFData1 NKeyName where
-  liftRnf _ (StaticKey  !_            ) = ()
-  liftRnf _ (DynamicKey (Plain !_)    ) = ()
-  liftRnf _ (DynamicKey EscapedNewline) = ()
+  liftRnf _ (StaticKey  !_            ) = mempty
+  liftRnf _ (DynamicKey (Plain !_)    ) = mempty
+  liftRnf _ (DynamicKey EscapedNewline) = mempty
   liftRnf k (DynamicKey (Antiquoted r)) = k r
 
 -- | Most key names are just static text, so this instance is convenient.

--- a/src/Nix/Expr/Types.hs
+++ b/src/Nix/Expr/Types.hs
@@ -7,6 +7,7 @@
 {-# language TypeFamilies #-}
 
 {-# options_ghc -Wno-orphans #-}
+{-# options_ghc -Wno-name-shadowing #-}
 {-# options_ghc -Wno-missing-signatures #-}
 
 -- | The Nix expression type and supporting types.
@@ -26,10 +27,11 @@ import           Data.Aeson
 import qualified Data.Binary                   as Binary
 import           Data.Binary                    ( Binary )
 import           Data.Data
-import           Data.Fix                       ( Fix(Fix) )
+import           Data.Fix                       ( Fix(..) )
 import           Data.Functor.Classes
 import           Data.Hashable.Lifted
 import qualified Data.HashMap.Lazy             as MapL
+import qualified Data.Set                      as Set
 import qualified Data.List.NonEmpty            as NE
 import qualified Text.Show
 import           Data.Traversable               ( fmapDefault, foldMapDefault )
@@ -739,3 +741,74 @@ ekey keys pos f e@(Fix x)
           )
         <$> f Nothing
 ekey _ _ f e = fromMaybe e <$> f Nothing
+
+
+freeVars :: NExpr -> Set VarName
+freeVars e =
+  case unFix e of
+    (NConstant    _               ) -> mempty
+    (NStr         string          ) -> mapFreeVars string
+    (NSym         var             ) -> one var
+    (NList        list            ) -> mapFreeVars list
+    (NSet   NonRecursive  bindings) -> bindFreeVars bindings
+    (NSet   Recursive     bindings) -> diffBetween bindFreeVars bindDefs bindings
+    (NLiteralPath _               ) -> mempty
+    (NEnvPath     _               ) -> mempty
+    (NUnary       _    expr       ) -> freeVars expr
+    (NBinary      _    left right ) -> collectFreeVars left right
+    (NSelect      orExpr expr path) ->
+      Set.unions
+        [ freeVars expr
+        , pathFree path
+        , freeVars `whenJust` orExpr
+        ]
+    (NHasAttr expr            path) -> freeVars expr <> pathFree path
+    (NAbs     (Param varname) expr) -> Set.delete varname (freeVars expr)
+    (NAbs (ParamSet varname _ pset) expr) ->
+      -- Include all free variables from the expression and the default arguments
+      freeVars expr <>
+      -- But remove the argument name if existing, and all arguments in the parameter set
+      Set.difference
+        (Set.unions $ freeVars <$> mapMaybe snd pset)
+        (Set.difference
+          (one `whenJust` varname)
+          (Set.fromList $ fst <$> pset)
+        )
+    (NLet         bindings expr   ) ->
+      freeVars expr <>
+      diffBetween bindFreeVars bindDefs bindings
+    (NIf          cond th   el    ) -> Set.unions $ freeVars <$> [cond, th, el]
+    -- Evaluation is needed to find out whether x is a "real" free variable in `with y; x`, we just include it
+    -- This also makes sense because its value can be overridden by `x: with y; x`
+    (NWith        set  expr       ) -> collectFreeVars set expr
+    (NAssert      assertion expr  ) -> collectFreeVars assertion expr
+    (NSynHole     _               ) -> mempty
+ where
+  diffBetween :: (a -> Set VarName) -> (a -> Set VarName) -> a -> Set VarName
+  diffBetween g f b = Set.difference (g b) (f b)
+
+  collectFreeVars :: NExpr -> NExpr -> Set VarName
+  collectFreeVars = (<>) `on` freeVars
+
+  bindDefs :: Foldable t => t (Binding NExpr) -> Set VarName
+  bindDefs = foldMap bind1Def
+   where
+    bind1Def :: Binding r -> Set VarName
+    bind1Def (Inherit   Nothing                  _    _) = mempty
+    bind1Def (Inherit  (Just _                 ) keys _) = Set.fromList keys
+    bind1Def (NamedVar (StaticKey  varname :| _) _    _) = one varname
+    bind1Def (NamedVar (DynamicKey _       :| _) _    _) = mempty
+
+  bindFreeVars :: Foldable t => t (Binding NExpr) -> Set VarName
+  bindFreeVars = foldMap bind1Free
+   where
+    bind1Free :: Binding NExpr -> Set VarName
+    bind1Free (Inherit  Nothing     keys _) = Set.fromList keys
+    bind1Free (Inherit (Just scope) _    _) = freeVars scope
+    bind1Free (NamedVar path        expr _) = pathFree path <> freeVars expr
+
+  pathFree :: NAttrPath NExpr -> Set VarName
+  pathFree = foldMap mapFreeVars
+
+  mapFreeVars :: Foldable t => t NExpr -> Set VarName
+  mapFreeVars = foldMap freeVars

--- a/src/Nix/Expr/Types.hs
+++ b/src/Nix/Expr/Types.hs
@@ -59,13 +59,13 @@ import           Instances.TH.Lift              ()  -- importing Lift Text for G
 
 -- * utils
 
--- | Holds file positionng information for abstrations.
--- A type synonym for @HashMap VarName SourcePos@.
-type PositionSet = HashMap VarName SourcePos
-
 --  2021-07-16: NOTE: Should replace @ParamSet@ List
 -- | > Hashmap VarName -- type synonym
 type AttrSet = HashMap VarName
+
+-- | Holds file positionng information for abstrations.
+-- A type synonym for @HashMap VarName SourcePos@.
+type PositionSet = AttrSet SourcePos
 
 -- ** orphan instances
 

--- a/src/Nix/Frames.hs
+++ b/src/Nix/Frames.hs
@@ -5,6 +5,7 @@
 module Nix.Frames
   ( NixLevel(..)
   , Frames
+  , askFrames
   , Framed
   , NixFrame(..)
   , NixException(..)
@@ -21,16 +22,20 @@ import qualified Text.Show
 data NixLevel = Fatal | Error | Warning | Info | Debug
   deriving (Ord, Eq, Bounded, Enum, Show)
 
-data NixFrame = NixFrame
-  { frameLevel :: NixLevel
-  , frame      :: SomeException
-  }
+data NixFrame =
+  NixFrame
+    { frameLevel :: NixLevel
+    , frame      :: SomeException
+    }
 
 instance Show NixFrame where
   show (NixFrame level f) =
     "Nix frame at level " <> show level <> ": " <> show f
 
 type Frames = [NixFrame]
+
+askFrames :: forall e m . (MonadReader e m, Has e Frames) => m Frames
+askFrames = askLocal
 
 type Framed e m = (MonadReader e m, Has e Frames, MonadThrow m)
 

--- a/src/Nix/Frames.hs
+++ b/src/Nix/Frames.hs
@@ -45,7 +45,8 @@ withFrame level f = local $ over hasLens (NixFrame level (toException f) :)
 
 throwError
   :: forall s e m a . (Framed e m, Exception s, MonadThrow m) => s -> m a
-throwError err = do
-  context <- asks (view hasLens)
-  traceM "Throwing fail..."
-  throwM $ NixException $ NixFrame Error (toException err) : context
+throwError err =
+  do
+    context <- askLocal
+    traceM "Throwing fail..."
+    throwM $ NixException $ NixFrame Error (toException err) : context

--- a/src/Nix/Json.hs
+++ b/src/Nix/Json.hs
@@ -36,8 +36,8 @@ toEncodingSorted = \case
   A.Array l -> A.list toEncodingSorted $ V.toList l
   v         -> A.toEncoding v
 
-nvalueToJSONNixString :: MonadNix e t f m => NValue t f m -> m NixString
-nvalueToJSONNixString =
+toJSONNixString :: MonadNix e t f m => NValue t f m -> m NixString
+toJSONNixString =
   runWithStringContextT .
     fmap
       ( decodeUtf8

--- a/src/Nix/Json.hs
+++ b/src/Nix/Json.hs
@@ -72,7 +72,7 @@ toJSON = \case
   NVPath p ->
     do
       fp <- lift $ coerce <$> addPath p
-      addSingletonStringContext $ StringContext (fromString fp) DirectPath
+      addSingletonStringContext $ StringContext DirectPath $ fromString fp
       pure $ A.toJSON fp
   v -> lift $ throwError $ CoercionToJson v
 

--- a/src/Nix/Json.hs
+++ b/src/Nix/Json.hs
@@ -46,10 +46,10 @@ nvalueToJSONNixString =
       . toEncodingSorted
       )
 
-      . nvalueToJSON
+      . toJSON
 
-nvalueToJSON :: MonadNix e t f m => NValue t f m -> WithStringContextT m A.Value
-nvalueToJSON = \case
+toJSON :: MonadNix e t f m => NValue t f m -> WithStringContextT m A.Value
+toJSON = \case
   NVConstant (NInt   n) -> pure $ A.toJSON n
   NVConstant (NFloat n) -> pure $ A.toJSON n
   NVConstant (NBool  b) -> pure $ A.toJSON b
@@ -78,4 +78,4 @@ nvalueToJSON = \case
 
  where
   intoJson :: MonadNix e t f m => NValue t f m -> WithStringContextT m A.Value
-  intoJson nv = join $ lift $ nvalueToJSON <$> demand nv
+  intoJson nv = join $ lift $ toJSON <$> demand nv

--- a/src/Nix/Lint.hs
+++ b/src/Nix/Lint.hs
@@ -524,7 +524,7 @@ lint opts expr =
 
 instance
   Scoped (Symbolic (Lint s)) (Lint s) where
-  currentScopes = currentScopesReader
+  askScopes = askScopesReader
   clearScopes   = clearScopesReader @(Lint s) @(Symbolic (Lint s))
   pushScopes    = pushScopesReader
   lookupVar     = lookupVarReader

--- a/src/Nix/Lint.hs
+++ b/src/Nix/Lint.hs
@@ -387,7 +387,7 @@ instance MonadLint e m => MonadEval (Symbolic m) m where
       _ <- unify (void e) cond =<< mkSymbolic (one $ TConstant $ one TBool)
       pure body'
 
-  evalApp = (fmap snd .) . lintApp (NBinary NApp () ())
+  evalApp = (fmap snd .) . lintApp (join (NBinary NApp) mempty)
   evalAbs params _ = mkSymbolic (one $ TClosure $ void params)
 
   evalError = throwError

--- a/src/Nix/Normal.hs
+++ b/src/Nix/Normal.hs
@@ -139,7 +139,7 @@ normalForm_
 normalForm_ t = void $ normalizeValue t
 
 opaqueVal :: Applicative f => NValue t f m
-opaqueVal = nvStrWithoutContext "<cycle>"
+opaqueVal = mkNVStrWithoutContext "<cycle>"
 
 -- | Detect cycles & stub them.
 stubCycles
@@ -165,7 +165,7 @@ stubCycles =
   Free (NValue' cyc) = opaqueVal
 
 thunkStubVal :: Applicative f => NValue t f m
-thunkStubVal = nvStrWithoutContext thunkStubText
+thunkStubVal = mkNVStrWithoutContext thunkStubText
 
 -- | Check if thunk @t@ is computed,
 -- then bind it into first arg.

--- a/src/Nix/Options.hs
+++ b/src/Nix/Options.hs
@@ -84,3 +84,6 @@ data Verbosity
     | DebugInfo
     | Vomit
     deriving (Eq, Ord, Enum, Bounded, Show)
+
+askOptions :: forall e m . (MonadReader e m, Has e Options) => m Options
+askOptions = askLocal

--- a/src/Nix/Options.hs
+++ b/src/Nix/Options.hs
@@ -7,70 +7,74 @@ import           Data.Time
 
 --  2021-07-15: NOTE: What these are? They need to be documented.
 -- Also need better names. Foe example, Maybes & lists names need to show their type in the name.
-data Options = Options
-    { verbose      :: Verbosity
-    , tracing      :: Bool
-    , thunks       :: Bool
-    , values       :: Bool
-    , showScopes   :: Bool
-    , reduce       :: Maybe Path
-    , reduceSets   :: Bool
-    , reduceLists  :: Bool
-    , parse        :: Bool
-    , parseOnly    :: Bool
-    , finder       :: Bool
-    , findFile     :: Maybe Path
-    , strict       :: Bool
-    , evaluate     :: Bool
-    , json         :: Bool
-    , xml          :: Bool
-    , attr         :: Maybe Text
-    , include      :: [Path]
-    , check        :: Bool
-    , readFrom     :: Maybe Path
-    , cache        :: Bool
-    , repl         :: Bool
-    , ignoreErrors :: Bool
-    , expression   :: Maybe Text
-    , arg          :: [(Text, Text)]
-    , argstr       :: [(Text, Text)]
-    , fromFile     :: Maybe Path
-    , currentTime  :: UTCTime
-    , filePaths    :: [Path]
+data Options =
+  Options
+    { getVerbosity   :: Verbosity
+    , isTrace        :: Bool
+    , isThunks       :: Bool
+    , isValues       :: Bool
+    , isShowScopes   :: Bool
+    , getReduce      :: Maybe Path
+    , isReduceSets   :: Bool
+    , isReduceLists  :: Bool
+    , isParse        :: Bool
+    , isParseOnly    :: Bool
+    , isFinder       :: Bool
+    , getFindFile    :: Maybe Path
+    , isStrict       :: Bool
+    , isEvaluate     :: Bool
+    , isJson         :: Bool
+    , isXml          :: Bool
+    , getAttr        :: Maybe Text
+    , getInclude     :: [Path]
+    , isCheck        :: Bool
+    , getReadFrom    :: Maybe Path
+    , isCache        :: Bool
+    , isRepl         :: Bool
+    , isIgnoreErrors :: Bool
+    , getExpression  :: Maybe Text
+    , getArg         :: [(Text, Text)]
+    , getArgstr      :: [(Text, Text)]
+    , getFromFile    :: Maybe Path
+    , getTime        :: UTCTime
+    -- ^ The time can be set to reproduce time-dependent states.
+    , getFilePaths   :: [Path]
     }
     deriving Show
 
 defaultOptions :: UTCTime -> Options
-defaultOptions current = Options { verbose      = ErrorsOnly
-                                 , tracing      = False
-                                 , thunks       = False
-                                 , values       = False
-                                 , showScopes   = False
-                                 , reduce       = mempty
-                                 , reduceSets   = False
-                                 , reduceLists  = False
-                                 , parse        = False
-                                 , parseOnly    = False
-                                 , finder       = False
-                                 , findFile     = mempty
-                                 , strict       = False
-                                 , evaluate     = False
-                                 , json         = False
-                                 , xml          = False
-                                 , attr         = mempty
-                                 , include      = mempty
-                                 , check        = False
-                                 , readFrom     = mempty
-                                 , cache        = False
-                                 , repl         = False
-                                 , ignoreErrors = False
-                                 , expression   = mempty
-                                 , arg          = mempty
-                                 , argstr       = mempty
-                                 , fromFile     = mempty
-                                 , currentTime  = current
-                                 , filePaths    = mempty
-                                 }
+defaultOptions currentTime =
+  Options
+    { getVerbosity   = ErrorsOnly
+    , isTrace        = False
+    , isThunks       = False
+    , isValues       = False
+    , isShowScopes   = False
+    , getReduce      = mempty
+    , isReduceSets   = False
+    , isReduceLists  = False
+    , isParse        = False
+    , isParseOnly    = False
+    , isFinder       = False
+    , getFindFile    = mempty
+    , isStrict       = False
+    , isEvaluate     = False
+    , isJson         = False
+    , isXml          = False
+    , getAttr        = mempty
+    , getInclude     = mempty
+    , isCheck        = False
+    , getReadFrom    = mempty
+    , isCache        = False
+    , isRepl         = False
+    , isIgnoreErrors = False
+    , getExpression  = mempty
+    , getArg         = mempty
+    , getArgstr      = mempty
+    , getFromFile    = mempty
+    , getTime        = currentTime
+    , getFilePaths   = mempty
+    }
 
 data Verbosity
     = ErrorsOnly

--- a/src/Nix/Parser.hs
+++ b/src/Nix/Parser.hs
@@ -9,6 +9,7 @@ module Nix.Parser
   , parseNixFileLoc
   , parseNixText
   , parseNixTextLoc
+  , parseExpr
   , parseFromFileEx
   , Parser
   , parseFromText
@@ -918,3 +919,9 @@ parseNixTextLoc :: Text -> Result NExprLoc
 parseNixTextLoc =
   parseNixText' id
 
+parseExpr :: (MonadFail m) => Text -> m NExpr
+parseExpr =
+  either
+    (fail . show)
+    pure
+    . parseNixText

--- a/src/Nix/Pretty.hs
+++ b/src/Nix/Pretty.hs
@@ -325,7 +325,7 @@ valueToExpr = iterNValueByDiscardWith thk (Fix . phi)
 
   phi :: NValue' t f m NExpr -> NExprF NExpr
   phi (NVConstant' a     ) = NConstant a
-  phi (NVStr'      ns    ) = NStr $ DoubleQuoted $ one $ Plain $ stringIgnoreContext ns
+  phi (NVStr'      ns    ) = NStr $ DoubleQuoted $ one $ Plain $ ignoreContext ns
   phi (NVList'     l     ) = NList l
   phi (NVSet'      p    s) = NSet mempty
     [ NamedVar (one $ StaticKey k) v (fromMaybe nullPos $ (`M.lookup` p) k)
@@ -390,7 +390,7 @@ printNix = iterNValueByDiscardWith thk phi
 
   phi :: NValue' t f m Text -> Text
   phi (NVConstant' a ) = atomText a
-  phi (NVStr'      ns) = show $ stringIgnoreContext ns
+  phi (NVStr'      ns) = show $ ignoreContext ns
   phi (NVList'     l ) = "[ " <> unwords l <> " ]"
   phi (NVSet' _ s) =
     "{ " <>

--- a/src/Nix/Reduce.hs
+++ b/src/Nix/Reduce.hs
@@ -471,7 +471,7 @@ reducingEvalExpr eval mpath expr =
     expr'           <- flagExprLoc =<< liftIO (reduceExpr mpath expr)
     eres <- (`catch` pure . Left) $
       pure <$> foldFix (addEvalFlags eval) expr'
-    opts :: Options <- asks $ view hasLens
+    opts :: Options <- askLocal
     expr''          <- pruneTree opts expr'
     pure (fromMaybe annNNull expr'', eres)
  where

--- a/src/Nix/Reduce.hs
+++ b/src/Nix/Reduce.hs
@@ -44,8 +44,8 @@ import           Nix.Expr.Types
 import           Nix.Expr.Types.Annotated
 import           Nix.Frames
 import           Nix.Options                    ( Options
-                                                , reduceSets
-                                                , reduceLists
+                                                , isReduceSets
+                                                , isReduceLists
                                                 )
 import           Nix.Parser
 import           Nix.Scope
@@ -368,13 +368,13 @@ pruneTree opts =
       bool
         (fromMaybe annNNull <$>)
         catMaybes
-        (reduceLists opts)  -- Reduce list members that aren't used; breaks if elemAt is used
+        (isReduceLists opts)  -- Reduce list members that aren't used; breaks if elemAt is used
         l
     NSet recur binds -> pure $ NSet recur $
       bool
         (fromMaybe annNNull <<$>>)
         (mapMaybe sequenceA)
-        (reduceSets opts)  -- Reduce set members that aren't used; breaks if hasAttr is used
+        (isReduceSets opts)  -- Reduce set members that aren't used; breaks if hasAttr is used
         binds
 
     NLet binds (Just body@(Ann _ x)) ->
@@ -450,7 +450,7 @@ pruneTree opts =
         bool
           fmap
           ((pure .) . maybe annNNull)
-          (reduceSets opts)  -- Reduce set members that aren't used; breaks if hasAttr is used
+          (isReduceSets opts)  -- Reduce set members that aren't used; breaks if hasAttr is used
           (fromMaybe annNNull)
 
   pruneBinding :: Binding (Maybe NExprLoc) -> Maybe (Binding NExprLoc)

--- a/src/Nix/Reduce.hs
+++ b/src/Nix/Reduce.hs
@@ -46,6 +46,7 @@ import           Nix.Frames
 import           Nix.Options                    ( Options
                                                 , isReduceSets
                                                 , isReduceLists
+                                                , askOptions
                                                 )
 import           Nix.Parser
 import           Nix.Scope
@@ -471,7 +472,7 @@ reducingEvalExpr eval mpath expr =
     expr'           <- flagExprLoc =<< liftIO (reduceExpr mpath expr)
     eres <- (`catch` pure . Left) $
       pure <$> foldFix (addEvalFlags eval) expr'
-    opts :: Options <- askLocal
+    opts <- askOptions
     expr''          <- pruneTree opts expr'
     pure (fromMaybe annNNull expr'', eres)
  where

--- a/src/Nix/Render/Frame.hs
+++ b/src/Nix/Render/Frame.hs
@@ -41,7 +41,7 @@ renderFrames
 renderFrames []       = stub
 renderFrames xss@(x : xs) =
   do
-    opts :: Options <- asks $ view hasLens
+    opts :: Options <- askLocal
     let
       verbosity :: Verbosity
       verbosity = getVerbosity opts
@@ -104,7 +104,7 @@ renderEvalFrame
   -> m [Doc ann]
 renderEvalFrame level f =
   do
-    opts :: Options <- asks (view hasLens)
+    opts :: Options <- askLocal
     let
       addMetaInfo :: ([Doc ann] -> [Doc ann]) -> SrcSpan -> Doc ann -> m [Doc ann]
       addMetaInfo trans loc = fmap (trans . one) . renderLocation loc
@@ -152,7 +152,7 @@ renderExpr
   -> NExprLoc
   -> m (Doc ann)
 renderExpr _level longLabel shortLabel e@(Ann _ x) = do
-  opts :: Options <- asks (view hasLens)
+  opts :: Options <- askLocal
   let
     verbosity :: Verbosity
     verbosity = getVerbosity opts
@@ -215,7 +215,7 @@ renderValue
   -> NValue t f m
   -> m (Doc ann)
 renderValue _level _longLabel _shortLabel v = do
-  opts :: Options <- asks $ view hasLens
+  opts :: Options <- askLocal
   bool
     prettyNValue
     prettyNValueProv

--- a/src/Nix/Render/Frame.hs
+++ b/src/Nix/Render/Frame.hs
@@ -130,7 +130,7 @@ renderEvalFrame level f =
         addMetaInfo
           id
           loc
-          $ "While calling builtins." <> pretty name
+          $ "While calling `builtins." <> prettyVarName name <> "`"
 
       SynHole synfo ->
         sequenceA

--- a/src/Nix/Scope.hs
+++ b/src/Nix/Scope.hs
@@ -54,18 +54,18 @@ emptyScopes :: Scopes m a
 emptyScopes = Scopes mempty mempty
 
 class Scoped a m | m -> a where
-  currentScopes :: m (Scopes m a)
+  askScopes :: m (Scopes m a)
   clearScopes   :: m r -> m r
   pushScopes    :: Scopes m a -> m r -> m r
   lookupVar     :: VarName -> m (Maybe a)
 
-currentScopesReader
+askScopesReader
   :: forall m a e
   . ( MonadReader e m
     , Has e (Scopes m a)
     )
   => m (Scopes m a)
-currentScopesReader = askLocal
+askScopesReader = askLocal
 
 clearScopesReader
   :: forall m a e r

--- a/src/Nix/Scope.hs
+++ b/src/Nix/Scope.hs
@@ -26,13 +26,13 @@ instance Show (Scope a) where
   show (Scope m) = show $ M.keys m
 
 scopeLookup :: VarName -> [Scope a] -> Maybe a
-scopeLookup key = foldr go Nothing
+scopeLookup key = foldr fun Nothing
  where
-  go
+  fun
     :: Scope a
     -> Maybe a
     -> Maybe a
-  go (Scope m) rest = M.lookup key m <|> rest
+  fun (Scope m) rest = M.lookup key m <|> rest
 
 data Scopes m a =
   Scopes
@@ -65,7 +65,7 @@ currentScopesReader
     , Has e (Scopes m a)
     )
   => m (Scopes m a)
-currentScopesReader = asks $ view hasLens
+currentScopesReader = askLocal
 
 clearScopesReader
   :: forall m a e r

--- a/src/Nix/Scope.hs
+++ b/src/Nix/Scope.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE UndecidableInstances #-}
 {-# language AllowAmbiguousTypes #-}
 {-# language ConstraintKinds #-}
 {-# language FunctionalDependencies #-}
@@ -18,6 +19,7 @@ newtype Scope a = Scope (AttrSet a)
     , Read, Hashable
     , Semigroup, Monoid
     , Functor, Foldable, Traversable
+    , One
     )
 
 instance Show (Scope a) where

--- a/src/Nix/Standard.hs
+++ b/src/Nix/Standard.hs
@@ -83,10 +83,10 @@ instance HasCitations m (StdValue m) (StdThunk m) where
   addProvenance x (StdThunk c) = StdThunk $ addProvenance1 x c
 
 instance MonadReader (Context m (StdValue m)) m => Scoped (StdValue m) m where
-  currentScopes = currentScopesReader
-  clearScopes   = clearScopesReader @m @(StdValue m)
-  pushScopes    = pushScopesReader
-  lookupVar     = lookupVarReader
+  askScopes   = askScopesReader
+  clearScopes = clearScopesReader @m @(StdValue m)
+  pushScopes  = pushScopesReader
+  lookupVar   = lookupVarReader
 
 instance
   ( MonadFix m

--- a/src/Nix/String.hs
+++ b/src/Nix/String.hs
@@ -13,7 +13,7 @@ module Nix.String
   , stringHasContext
   , intercalateNixString
   , getStringNoContext
-  , stringIgnoreContext
+  , ignoreContext
   , mkNixStringWithoutContext
   , mkNixStringWithSingletonContext
   , modifyNixContents
@@ -162,8 +162,8 @@ getStringNoContext (NixString s c)
   | otherwise = mempty
 
 -- | Extract the string contents from a NixString even if the NixString has an associated context
-stringIgnoreContext :: NixString -> Text
-stringIgnoreContext (NixString s _) = s
+ignoreContext :: NixString -> Text
+ignoreContext (NixString s _) = s
 
 -- | Get the contents of a 'NixString' and write its context into the resulting set.
 extractNixString :: Monad m => NixString -> WithStringContextT m Text

--- a/src/Nix/String.hs
+++ b/src/Nix/String.hs
@@ -130,12 +130,13 @@ mkNixStringWithoutContext = NixString mempty
 
 -- | Create NixString using a singleton context
 mkNixStringWithSingletonContext
-  :: VarName -> StringContext -> NixString
-mkNixStringWithSingletonContext s c = NixString (one c) (coerce @VarName @Text s)
+  :: StringContext -> VarName -> NixString
+mkNixStringWithSingletonContext c s = NixString (one c) (coerce @VarName @Text s)
 
 -- | Create NixString from a Text and context
-mkNixString :: Text -> S.HashSet StringContext -> NixString
-mkNixString t = (`NixString` t)
+mkNixString
+  :: S.HashSet StringContext -> Text -> NixString
+mkNixString = NixString
 
 
 -- ** Checkers

--- a/src/Nix/String.hs
+++ b/src/Nix/String.hs
@@ -10,7 +10,7 @@ module Nix.String
   , NixLikeContextValue(..)
   , toNixLikeContext
   , fromNixLikeContext
-  , stringHasContext
+  , hasContext
   , intercalateNixString
   , getStringNoContext
   , ignoreContext
@@ -142,8 +142,8 @@ mkNixString = NixString
 -- ** Checkers
 
 -- | Returns True if the NixString has an associated context
-stringHasContext :: NixString -> Bool
-stringHasContext (NixString _ c) = not $ null c
+hasContext :: NixString -> Bool
+hasContext (NixString _ c) = not $ null c
 
 
 -- ** Getters

--- a/src/Nix/String/Coerce.hs
+++ b/src/Nix/String/Coerce.hs
@@ -133,5 +133,5 @@ coercePathToNixString =
     . (CopyToStore ==)
  where
   storePathToNixString :: StorePath -> NixString
-  storePathToNixString =
-    (mkNixStringWithSingletonContext <*> StringContext DirectPath) . fromString . coerce
+  storePathToNixString (fromString . coerce -> sp) =
+    (mkNixStringWithSingletonContext . StringContext DirectPath) sp sp

--- a/src/Nix/String/Coerce.hs
+++ b/src/Nix/String/Coerce.hs
@@ -134,4 +134,4 @@ coercePathToNixString =
  where
   storePathToNixString :: StorePath -> NixString
   storePathToNixString =
-    (mkNixStringWithSingletonContext <*> (`StringContext` DirectPath)) . fromString . coerce
+    (mkNixStringWithSingletonContext <*> StringContext DirectPath) . fromString . coerce

--- a/src/Nix/String/Coerce.hs
+++ b/src/Nix/String/Coerce.hs
@@ -126,12 +126,12 @@ coerceStringlikeToNixString ctsm =
 -- | Convert @Path@ into @NixString@.
 -- With an additional option to store the resolved path into Nix Store.
 coercePathToNixString :: (MonadStore m, Framed e m) => CopyToStoreMode -> Path -> m NixString
-coercePathToNixString ctsm =
+coercePathToNixString =
   bool
     (pure . mkNixStringWithoutContext . fromString . coerce)
-    (fmap storePathToNixString . addPath)
-    (ctsm == CopyToStore)
+    ((storePathToNixString <$>) . addPath)
+    . (CopyToStore ==)
  where
   storePathToNixString :: StorePath -> NixString
-  storePathToNixString (fromString . coerce -> sp) =
-    join (flip mkNixStringWithSingletonContext . (`StringContext` DirectPath)) sp
+  storePathToNixString =
+    (mkNixStringWithSingletonContext <*> (`StringContext` DirectPath)) . fromString . coerce

--- a/src/Nix/TH.hs
+++ b/src/Nix/TH.hs
@@ -2,11 +2,9 @@
 {-# language TemplateHaskell #-}
 
 {-# options_ghc -Wno-missing-fields #-}
-{-# options_ghc -Wno-name-shadowing #-}
 
 module Nix.TH where
 
-import           Data.Fix                       ( Fix(unFix) )
 import           Data.Generics.Aliases          ( extQ )
 import qualified Data.Set                      as Set
 import           Language.Haskell.TH
@@ -47,78 +45,6 @@ extQOnFreeVars
   -> b
   -> Maybe q
 extQOnFreeVars f = extQ (const Nothing) . f . freeVars
-
-freeVars :: NExpr -> Set VarName
-freeVars e = case unFix e of
-  (NConstant    _               ) -> mempty
-  (NStr         string          ) -> mapFreeVars string
-  (NSym         var             ) -> one var
-  (NList        list            ) -> mapFreeVars list
-  (NSet   NonRecursive  bindings) -> bindFreeVars bindings
-  (NSet   Recursive     bindings) -> diffBetween bindFreeVars bindDefs bindings
-  (NLiteralPath _               ) -> mempty
-  (NEnvPath     _               ) -> mempty
-  (NUnary       _    expr       ) -> freeVars expr
-  (NBinary      _    left right ) -> collectFreeVars left right
-  (NSelect      orExpr expr path) ->
-    Set.unions
-      [ freeVars expr
-      , pathFree path
-      , freeVars `whenJust` orExpr
-      ]
-  (NHasAttr expr            path) -> freeVars expr <> pathFree path
-  (NAbs     (Param varname) expr) -> Set.delete varname (freeVars expr)
-  (NAbs (ParamSet varname _ pset) expr) ->
-    -- Include all free variables from the expression and the default arguments
-    freeVars expr <>
-    -- But remove the argument name if existing, and all arguments in the parameter set
-    Set.difference
-      (Set.unions $ freeVars <$> mapMaybe snd pset)
-      (Set.difference
-        (one `whenJust` varname)
-        (Set.fromList $ fst <$> pset)
-      )
-  (NLet         bindings expr   ) ->
-    freeVars expr <>
-    diffBetween bindFreeVars bindDefs bindings
-  (NIf          cond th   el    ) -> Set.unions $ freeVars <$> [cond, th, el]
-  -- Evaluation is needed to find out whether x is a "real" free variable in `with y; x`, we just include it
-  -- This also makes sense because its value can be overridden by `x: with y; x`
-  (NWith        set  expr       ) -> collectFreeVars set expr
-  (NAssert      assertion expr  ) -> collectFreeVars assertion expr
-  (NSynHole     _               ) -> mempty
-
- where
-
-  diffBetween :: (a -> Set VarName) -> (a -> Set VarName) -> a -> Set VarName
-  diffBetween g f b = Set.difference (g b) (f b)
-
-  collectFreeVars :: NExpr -> NExpr -> Set VarName
-  collectFreeVars = (<>) `on` freeVars
-
-  bindDefs :: Foldable t => t (Binding NExpr) -> Set VarName
-  bindDefs = foldMap bind1Def
-   where
-    bind1Def :: Binding r -> Set VarName
-    bind1Def (Inherit   Nothing                  _    _) = mempty
-    bind1Def (Inherit  (Just _                 ) keys _) = Set.fromList keys
-    bind1Def (NamedVar (StaticKey  varname :| _) _    _) = one varname
-    bind1Def (NamedVar (DynamicKey _       :| _) _    _) = mempty
-
-  bindFreeVars :: Foldable t => t (Binding NExpr) -> Set VarName
-  bindFreeVars = foldMap bind1Free
-   where
-    bind1Free :: Binding NExpr -> Set VarName
-    bind1Free (Inherit  Nothing     keys _) = Set.fromList keys
-    bind1Free (Inherit (Just scope) _    _) = freeVars scope
-    bind1Free (NamedVar path        expr _) = pathFree path <> freeVars expr
-
-  pathFree :: NAttrPath NExpr -> Set VarName
-  pathFree = foldMap mapFreeVars
-
-  mapFreeVars :: Foldable t => t NExpr -> Set VarName
-  mapFreeVars = foldMap freeVars
-
 
 class ToExpr a where
   toExpr :: a -> NExprLoc

--- a/src/Nix/TH.hs
+++ b/src/Nix/TH.hs
@@ -27,7 +27,7 @@ quoteExprPat :: String -> PatQ
 quoteExprPat s =
   do
     expr <- parseExpr @Q $ fromString s
-    (dataToPatQ @NExpr)
+    dataToPatQ
       (extQOnFreeVars @_ @NExprLoc @PatQ metaPat expr)
       expr
 

--- a/src/Nix/TH.hs
+++ b/src/Nix/TH.hs
@@ -48,13 +48,6 @@ extQOnFreeVars
   -> Maybe q
 extQOnFreeVars f = extQ (const Nothing) . f . freeVars
 
-parseExpr :: (MonadFail m) => Text -> m NExpr
-parseExpr =
-  either
-    (fail . show)
-    pure
-    . parseNixText
-
 freeVars :: NExpr -> Set VarName
 freeVars e = case unFix e of
   (NConstant    _               ) -> mempty

--- a/src/Nix/TH.hs
+++ b/src/Nix/TH.hs
@@ -44,7 +44,7 @@ extQOnFreeVars
   -> NExpr
   -> b
   -> Maybe q
-extQOnFreeVars f = extQ (const Nothing) . f . freeVars
+extQOnFreeVars f = extQ (const Nothing) . f . getFreeVars
 
 class ToExpr a where
   toExpr :: a -> NExprLoc

--- a/src/Nix/Type/Infer.hs
+++ b/src/Nix/Type/Infer.hs
@@ -386,10 +386,10 @@ instance MonadInfer m => ToValue Bool (InferT s m) (Judgment s) where
 instance
   Monad m
   => Scoped (Judgment s) (InferT s m) where
-  currentScopes = currentScopesReader
-  clearScopes   = clearScopesReader @(InferT s m) @(Judgment s)
-  pushScopes    = pushScopesReader
-  lookupVar     = lookupVarReader
+  askScopes   = askScopesReader
+  clearScopes = clearScopesReader @(InferT s m) @(Judgment s)
+  pushScopes  = pushScopesReader
+  lookupVar   = lookupVarReader
 
 -- newtype JThunkT s m = JThunk (NThunkF (InferT s m) (Judgment s))
 

--- a/src/Nix/Type/Infer.hs
+++ b/src/Nix/Type/Infer.hs
@@ -493,13 +493,7 @@ instance MonadInfer m => MonadEval (Judgment s) (InferT s m) where
   evalEnvPath     = constInfer typePath
 
   evalUnary op (Judgment as1 cs1 t1) =
-    fmap
-      (join
-        $ Judgment
-            as1
-            . (cs1 <>) . (`unops` op) . (t1 :~>)
-      )
-      fresh
+    (Judgment as1 =<< (cs1 <>) . (`unops` op) . (t1 :~>)) <$> fresh
 
   evalBinary op (Judgment as1 cs1 t1) e2 = do
     Judgment as2 cs2 t2 <- e2

--- a/src/Nix/Type/Infer.hs
+++ b/src/Nix/Type/Infer.hs
@@ -534,15 +534,9 @@ instance MonadInfer m => MonadEval (Judgment s) (InferT s m) where
     ((), Judgment as cs t) <-
       extendMSet
         a
-        (k
-          (pure $
-             Judgment
-               (one (x, tv))
-               mempty
-               tv
-          )
-          (\_ b -> ((), ) <$> b)
-        )
+        $ k @()
+            ((pure . ((`Judgment` mempty) =<< curry one x)) tv)
+            $ const $ fmap (mempty,)
     pure $
       Judgment
         (as `Assumption.remove` x)

--- a/src/Nix/Type/Infer.hs
+++ b/src/Nix/Type/Infer.hs
@@ -553,7 +553,7 @@ instance MonadInfer m => MonadEval (Judgment s) (InferT s m) where
       call  = k arg $ \args b -> (args, ) <$> b
       names = fst <$> js
 
-    (args, Judgment as cs t) <- foldr (\(_, TVar a) -> extendMSet a) call js
+    (args, Judgment as cs t) <- foldr (extendMSet . (\ (TVar a) -> a) . snd) call js
 
     ty <- foldInitializedWith (TSet variadic) inferredType id args
 

--- a/src/Nix/Type/Infer.hs
+++ b/src/Nix/Type/Infer.hs
@@ -495,15 +495,10 @@ instance MonadInfer m => MonadEval (Judgment s) (InferT s m) where
   evalUnary op (Judgment as1 cs1 t1) =
     (Judgment as1 =<< (cs1 <>) . (`unops` op) . (t1 :~>)) <$> fresh
 
-  evalBinary op (Judgment as1 cs1 t1) e2 = do
-    Judgment as2 cs2 t2 <- e2
-    fmap
-      (join
-        $ Judgment
-          (as1 <> as2)
-          . (\ cs3 -> cs1 <> cs2 <> cs3) . (`binops` op) . (\ t3 -> t1 :~> t2 :~> t3)
-      )
-      fresh
+  evalBinary op (Judgment as1 cs1 t1) e2 =
+    do
+      Judgment as2 cs2 t2 <- e2
+      (Judgment (as1 <> as2) =<< ((cs1 <> cs2) <>) . (`binops` op) . ((t1 :~> t2) :~>)) <$> fresh
 
   evalWith = Eval.evalWithAttrSet
 

--- a/src/Nix/Type/Infer.hs
+++ b/src/Nix/Type/Infer.hs
@@ -452,9 +452,9 @@ instance MonadInfer m
 
 polymorphicVar :: MonadInfer m => VarName -> InferT s m (Judgment s)
 polymorphicVar var =
-    fmap
-      (join ((`Judgment` mempty) . curry one var))
-      fresh
+  fmap
+    (join $ (`Judgment` mempty) . curry one var)
+    fresh
 
 constInfer :: Applicative f => Type -> b -> f (Judgment s)
 constInfer x = const $ pure $ inferred x
@@ -534,9 +534,9 @@ instance MonadInfer m => MonadEval (Judgment s) (InferT s m) where
     ((), Judgment as cs t) <-
       extendMSet
         a
-        $ k @()
-            ((pure . ((`Judgment` mempty) =<< curry one x)) tv)
-            $ const $ fmap (mempty,)
+        $ k
+          (pure (join ((`Judgment` mempty) . curry one x ) tv))
+          $ const $ fmap (mempty,)
     pure $
       Judgment
         (as `Assumption.remove` x)

--- a/src/Nix/Utils.hs
+++ b/src/Nix/Utils.hs
@@ -242,54 +242,56 @@ instance IsString Path where
 
 -- | This set of @Path@ funcs is to control system filepath types & typesafety and to easily migrate from FilePath to anything suitable (like @path@ or so).
 
--- | @isAbsolute@ specialized to @Path@.
+-- | 'Path's 'FilePath.isAbsolute'.
 isAbsolute :: Path -> Bool
 isAbsolute = coerce FilePath.isAbsolute
 
--- | @(</>)@ specialized to @Path@
+-- | 'Path's 'FilePath.(</>)'.
 (</>) :: Path -> Path -> Path
 (</>) = coerce (FilePath.</>)
 infixr 5 </>
 
--- | @joinPath@ specialized to @Path@
+-- | 'Path's 'FilePath.joinPath'.
 joinPath :: [Path] -> Path
 joinPath = coerce FilePath.joinPath
 
--- | @splitDirectories@ specialized to @Path@
+-- | 'Path's 'FilePath.splitDirectories'.
 splitDirectories :: Path -> [Path]
 splitDirectories = coerce FilePath.splitDirectories
 
--- | @takeDirectory@ specialized to @Path@
+-- | 'Path's 'FilePath.takeDirectory'.
 takeDirectory :: Path -> Path
 takeDirectory = coerce FilePath.takeDirectory
 
--- | @takeFileName@ specialized to @Path@
+-- | 'Path's 'FilePath.takeFileName'.
 takeFileName :: Path -> Path
 takeFileName = coerce FilePath.takeFileName
 
--- | @takeBaseName@ specialized to @Path@
+-- | 'Path's 'FilePath.takeBaseName'.
 takeBaseName :: Path -> String
 takeBaseName = coerce FilePath.takeBaseName
 
--- | @takeExtension@ specialized to @Path@
+-- | 'Path's 'FilePath.takeExtension'.
 takeExtension :: Path -> String
 takeExtension = coerce FilePath.takeExtensions
 
--- | @takeExtensions@ specialized to @Path@
+-- | 'Path's 'FilePath.takeExtensions'.
 takeExtensions :: Path -> String
 takeExtensions = coerce FilePath.takeExtensions
 
+-- | 'Path's 'FilePath.addExtensions'.
 addExtension :: Path -> String -> Path
 addExtension = coerce FilePath.addExtension
 
--- | @dropExtensions@ specialized to @Path@
+-- | 'Path's 'FilePath.dropExtensions'.
 dropExtensions :: Path -> Path
 dropExtensions = coerce FilePath.dropExtensions
 
--- | @replaceExtension@ specialized to @Path@
+-- | 'Path's 'FilePath.replaceExtension'.
 replaceExtension :: Path -> String -> Path
 replaceExtension = coerce FilePath.replaceExtension
 
+-- | 'Path's 'FilePath.readFile'.
 readFile :: Path -> IO Text
 readFile = Text.readFile . coerce
 

--- a/src/Nix/Utils.hs
+++ b/src/Nix/Utils.hs
@@ -189,7 +189,6 @@ instance Has (a, b) b where
   hasLens = _2
 
 loebM :: (MonadFix m, Traversable t) => t (t a -> m a) -> m (t a)
--- Sectioning here insures optimization happening.
 loebM f = mfix $ \a -> (`traverse` f) ($ a)
 {-# inline loebM #-}
 
@@ -201,9 +200,7 @@ lifted
   -> (a -> u m b)
   -> u m b
 lifted f k =
-  do
-    lftd <- liftWith (\run -> f (run . k))
-    restoreT $ pure lftd
+  (restoreT . pure) =<< liftWith (\run -> f (run . k))
 
 -- | adi is Abstracting Definitional Interpreters:
 --

--- a/src/Nix/Utils.hs
+++ b/src/Nix/Utils.hs
@@ -150,7 +150,7 @@ nestM
   -> m a -- ^ & join layers of 'm'
 nestM 0 _ x = pure x
 nestM n f x =
-  foldM (\ xx () -> f xx) x $ replicate n () -- fuses. But also, can it be fix join?
+  foldM (const . f) x $ replicate @() n mempty -- fuses. But also, can it be fix join?
 {-# inline nestM #-}
 
 traverse2

--- a/src/Nix/Utils.hs
+++ b/src/Nix/Utils.hs
@@ -6,11 +6,22 @@
 -- It is for import for projects other then @HNix@.
 -- For @HNix@ - this module gets reexported by "Prelude", so for @HNix@ please fix-up pass-through there.
 module Nix.Utils
-  ( KeyMap
-  , Alg
-  , Transform
-  , TransformF
-  , Has(..)
+  ( stub
+  , pass
+  , dup
+  , both
+  , mapPair
+  , iterateN
+  , nestM
+  , traverseM
+  , lifted
+
+  , whenTrue
+  , whenFalse
+  , whenJust
+  , whenText
+  , list
+  , free
 
   , Path(..)
   , isAbsolute
@@ -27,25 +38,15 @@ module Nix.Utils
   , replaceExtension
   , readFile
 
-  , stub
-  , pass
-  , whenTrue
-  , whenFalse
-  , whenText
-  , whenJust
-  , list
-  , free
-
-  , dup
-  , mapPair
-  , both
-  , iterateN
-  , nestM
-  , traverseM
-  , lifted
-
+  , Alg
+  , Transform
+  , TransformF
   , loebM
   , adi
+
+  , Has(..)
+
+  , KeyMap
 
   , trace
   , traceM
@@ -95,6 +96,8 @@ traceM :: Monad m => String -> m ()
 traceM = const stub
 {-# inline traceM #-}
 #endif
+
+-- * Path
 
 -- | To have explicit type boundary between FilePath & String.
 newtype Path = Path FilePath
@@ -165,6 +168,8 @@ replaceExtension = coerce FilePath.replaceExtension
 -- | > Hashmap Text -- type synonym
 type KeyMap = HashMap Text
 
+-- * Recursion scheme
+
 -- | F-algebra defines how to reduce the fixed-point of a functor to a value.
 -- > type Alg f a = f a -> a
 type Alg f a = f a -> a
@@ -190,6 +195,7 @@ instance Has (a, b) a where
 
 instance Has (a, b) b where
   hasLens = _2
+
 
 loebM :: (MonadFix m, Traversable t) => t (t a -> m a) -> m (t a)
 loebM f = mfix $ \a -> (`traverse` f) ($ a)

--- a/src/Nix/Utils.hs
+++ b/src/Nix/Utils.hs
@@ -105,7 +105,7 @@ stub :: (Applicative f, Monoid a) => f a
 stub = pure mempty
 {-# inline stub #-}
 
--- | Alias for @stub@, since @Relude@ has more specialized @pure ()@.
+-- | Alias for 'stub', since "Relude" has more specialized @pure ()@.
 pass :: (Applicative f) => f ()
 pass = stub
 {-# inline pass #-}
@@ -124,7 +124,9 @@ both :: (a -> b) -> (a, a) -> (b, b)
 both f (x,y) = (f x, f y)
 {-# inline both #-}
 
--- | From @utility-ht@ for tuple laziness.
+-- | Gives tuple laziness.
+--
+-- Takem from @utility-ht@.
 mapPair :: (a -> c, b -> d) -> (a,b) -> (c,d)
 mapPair ~(f,g) ~(a,b) = (f a, g b)
 {-# inline mapPair #-}
@@ -135,24 +137,31 @@ iterateN
   -> (a -> a) -- ^ function apply
   -> a -- ^ on value
   -> a
-iterateN n f x = fix ((<*> (0 /=)) . ((bool x . f) .) . (. pred)) n -- It is hard to read - yes. It is a non-recursive momoized action - yes.
+iterateN n f x =
+  -- It is hard to read - yes. It is a non-recursive momoized action - yes.
+  fix ((<*> (0 /=)) . ((bool x . f) .) . (. pred)) n
 
--- | Apply Kleisli arrow N times, join 'm's.
-nestM :: Monad m => Int -> (a -> m a) -> a -> m a
+nestM
+  :: Monad m
+  => Int -- ^ Recursively apply 'Int' times
+  -> (a -> m a) -- ^ function (Kleisli arrow).
+  -> a -- ^ to value
+  -> m a -- ^ & join layers of 'm'
 nestM 0 _ x = pure x
-nestM n f x = foldM (\ xx () -> f xx) x $ replicate n () -- fuses. But also, can it be fix join?
+nestM n f x =
+  foldM (\ xx () -> f xx) x $ replicate n () -- fuses. But also, can it be fix join?
 {-# inline nestM #-}
 
 traverseM
   :: ( Applicative m
-     , Applicative f
+     , Applicative n
      , Traversable t
      )
   => ( a
-     -> m (f b)
+     -> m (n b)
      )
   -> t a
-  -> m (f (t b))
+  -> m (n (t b))
 traverseM f x = sequenceA <$> traverse f x
 
 --  2021-08-21: NOTE: Someone needs to put in normal words, what this does.
@@ -223,7 +232,7 @@ free fP fF fr =
 
 -- * Path
 
--- | To have explicit type boundary between FilePath & String.
+-- | Explicit type boundary between FilePath & String.
 newtype Path = Path FilePath
   deriving
     ( Eq, Ord, Generic

--- a/src/Nix/Utils.hs
+++ b/src/Nix/Utils.hs
@@ -133,9 +133,9 @@ mapPair ~(f,g) ~(a,b) = (f a, g b)
 
 iterateN
   :: forall a
-   . Int -- ^ times
-  -> (a -> a) -- ^ function apply
-  -> a -- ^ on value
+   . Int -- ^ Recursively apply 'Int' times
+  -> (a -> a) -- ^ the function
+  -> a -- ^ starting from argument
   -> a
 iterateN n f x =
   -- It is hard to read - yes. It is a non-recursive momoized action - yes.

--- a/src/Nix/Utils.hs
+++ b/src/Nix/Utils.hs
@@ -45,6 +45,7 @@ module Nix.Utils
   , adi
 
   , Has(..)
+  , askLocal
 
   , KeyMap
 
@@ -172,7 +173,7 @@ lifted
   -> (a -> u m b)
   -> u m b
 lifted f k =
-  (restoreT . pure) =<< liftWith (\run -> f (run . k))
+  restoreT . pure =<< liftWith (\run -> f (run . k))
 
 
 -- * Eliminators
@@ -357,6 +358,9 @@ instance Has (a, b) a where
 instance Has (a, b) b where
   hasLens = _2
 
+-- | Retrive monad state by 'Lens''.
+askLocal :: (MonadReader t m, Has t a) => m a
+askLocal = asks $ view hasLens
 
 -- * Other
 

--- a/src/Nix/Utils.hs
+++ b/src/Nix/Utils.hs
@@ -13,7 +13,7 @@ module Nix.Utils
   , mapPair
   , iterateN
   , nestM
-  , traverseM
+  , traverse2
   , lifted
 
   , whenTrue
@@ -152,7 +152,7 @@ nestM n f x =
   foldM (\ xx () -> f xx) x $ replicate n () -- fuses. But also, can it be fix join?
 {-# inline nestM #-}
 
-traverseM
+traverse2
   :: ( Applicative m
      , Applicative n
      , Traversable t
@@ -160,9 +160,9 @@ traverseM
   => ( a
      -> m (n b)
      ) -- ^ Run function that runs 2 'Applicative' actions
-  -> t a -- ^ on every element of a 'Traversable'
+  -> t a -- ^ on every element in 'Traversable'
   -> m (n (t b)) -- ^ collect the results.
-traverseM f x = sequenceA <$> traverse f x
+traverse2 f x = sequenceA <$> traverse f x
 
 --  2021-08-21: NOTE: Someone needs to put in normal words, what this does.
 -- This function is pretty spefic & used only once, in "Nix.Normal".

--- a/src/Nix/Utils.hs
+++ b/src/Nix/Utils.hs
@@ -7,9 +7,10 @@
 -- For @HNix@ - this module gets reexported by "Prelude", so for @HNix@ please fix-up pass-through there.
 module Nix.Utils
   ( KeyMap
-  , TransformF
-  , Transform
   , Alg
+  , Transform
+  , TransformF
+  , Has(..)
 
   , Path(..)
   , isAbsolute
@@ -26,17 +27,15 @@ module Nix.Utils
   , replaceExtension
   , readFile
 
-  , Has(..)
-  , trace
-  , traceM
   , stub
   , pass
   , whenTrue
   , whenFalse
-  , list
   , whenText
-  , free
   , whenJust
+  , list
+  , free
+
   , dup
   , mapPair
   , both
@@ -44,8 +43,12 @@ module Nix.Utils
   , nestM
   , traverseM
   , lifted
+
   , loebM
   , adi
+
+  , trace
+  , traceM
   , module X
   )
  where

--- a/src/Nix/Utils.hs
+++ b/src/Nix/Utils.hs
@@ -159,9 +159,9 @@ traverseM
      )
   => ( a
      -> m (n b)
-     )
-  -> t a
-  -> m (n (t b))
+     ) -- ^ Run function that runs 2 'Applicative' actions
+  -> t a -- ^ on every element of a 'Traversable'
+  -> m (n (t b)) -- ^ collect the results.
 traverseM f x = sequenceA <$> traverse f x
 
 --  2021-08-21: NOTE: Someone needs to put in normal words, what this does.

--- a/src/Nix/Utils.hs
+++ b/src/Nix/Utils.hs
@@ -174,8 +174,6 @@ type Transform f a = TransformF (Fix f) a
 -- | Do according transformation.
 --
 -- It is a transformation between functors.
--- ...
--- You got me, it is a natural transformation.
 type TransformF f a = (f -> a) -> f -> a
 
 class Has a b where

--- a/src/Nix/Value.hs
+++ b/src/Nix/Value.hs
@@ -153,18 +153,16 @@ instance Eq1 (NValueF p m) where
 -- ** Show
 
 instance Show r => Show (NValueF p m r) where
-  showsPrec d = go
-   where
-    go :: NValueF p m r -> String -> String
-    go = \case
+  showsPrec d =
+    \case
       (NVConstantF atom     ) -> showsCon1 "NVConstant" atom
-      (NVStrF      ns       ) -> showsCon1 "NVStr"      (stringIgnoreContext ns)
+      (NVStrF      ns       ) -> showsCon1 "NVStr"      $ stringIgnoreContext ns
       (NVListF     lst      ) -> showsCon1 "NVList"     lst
       (NVSetF      _   attrs) -> showsCon1 "NVSet"      attrs
       (NVClosureF  params _ ) -> showsCon1 "NVClosure"  params
       (NVPathF     path     ) -> showsCon1 "NVPath"     path
       (NVBuiltinF  name   _ ) -> showsCon1 "NVBuiltin"  name
-
+   where
     showsCon1 :: Show a => String -> a -> String -> String
     showsCon1 con a =
       showParen (d > 10) $ showString (con <> " ") . showsPrec 11 a

--- a/src/Nix/Value.hs
+++ b/src/Nix/Value.hs
@@ -664,7 +664,10 @@ builtin3
     -> m (NValue t f m)
     ) -- ^ ternary function
   -> m (NValue t f m)
-builtin3 = liftA3 (.) (.) ((.) . (.)) ((.) . (.)) . builtin
+builtin3 =
+  liftA2 (.) -- compose 2 together
+    builtin
+    ((.) . builtin2)
 
 -- *** @F: Evaluation -> NValue@
 

--- a/src/Nix/Value.hs
+++ b/src/Nix/Value.hs
@@ -404,6 +404,11 @@ mkNVConstant' :: Applicative f
   -> NValue' t f m r
 mkNVConstant' = NValue' . pure . NVConstantF
 
+-- | Using of Nulls is generally discouraged (in programming language design et al.), but, if you need it.
+nvNull' :: Applicative f
+  => NValue' t f m r
+nvNull' = mkNVConstant' NNull
+
 
 -- | Haskell text & context to the Nix text & context,
 mkNVStr' :: Applicative f

--- a/src/Nix/Value.hs
+++ b/src/Nix/Value.hs
@@ -402,58 +402,58 @@ unliftNValue' = hoistNValue' lift
 
 
 -- | Haskell constant to the Nix constant,
-nvConstant' :: Applicative f
+mkNVConstant' :: Applicative f
   => NAtom
   -> NValue' t f m r
-nvConstant' = NValue' . pure . NVConstantF
+mkNVConstant' = NValue' . pure . NVConstantF
 
 
 -- | Haskell text & context to the Nix text & context,
-nvStr' :: Applicative f
+mkNVStr' :: Applicative f
   => NixString
   -> NValue' t f m r
-nvStr' = NValue' . pure . NVStrF
+mkNVStr' = NValue' . pure . NVStrF
 
 
 -- | Haskell @Path@ to the Nix path,
-nvPath' :: Applicative f
+mkNVPath' :: Applicative f
   => Path
   -> NValue' t f m r
-nvPath' = NValue' . pure . NVPathF . coerce
+mkNVPath' = NValue' . pure . NVPathF . coerce
 
 
 -- | Haskell @[]@ to the Nix @[]@,
-nvList' :: Applicative f
+mkNVList' :: Applicative f
   => [r]
   -> NValue' t f m r
-nvList' = NValue' . pure . NVListF
+mkNVList' = NValue' . pure . NVListF
 
 
 -- | Haskell key-value to the Nix key-value,
-nvSet' :: Applicative f
+mkNVSet' :: Applicative f
   => PositionSet
   -> AttrSet r
   -> NValue' t f m r
 --  2021-07-16: NOTE: that the arguments are flipped.
-nvSet' p s = NValue' $ pure $ NVSetF p s
+mkNVSet' p s = NValue' $ pure $ NVSetF p s
 
 
 -- | Haskell closure to the Nix closure,
-nvClosure' :: (Applicative f, Functor m)
+mkNVClosure' :: (Applicative f, Functor m)
   => Params ()
   -> (NValue t f m
       -> m r
     )
   -> NValue' t f m r
-nvClosure' x f = NValue' $ pure $ NVClosureF x f
+mkNVClosure' x f = NValue' $ pure $ NVClosureF x f
 
 
 -- | Haskell functions to the Nix functions!
-nvBuiltin' :: (Applicative f, Functor m)
+mkNVBuiltin' :: (Applicative f, Functor m)
   => VarName
   -> (NValue t f m -> m r)
   -> NValue' t f m r
-nvBuiltin' name f = NValue' $ pure $ NVBuiltinF name f
+mkNVBuiltin' name f = NValue' $ pure $ NVBuiltinF name f
 
 
 -- So above we have maps of Hask subcategory objects to Nix objects,
@@ -574,66 +574,66 @@ unliftNValue = hoistNValue lift
 
 
 -- | Life of a Haskell thunk to the life of a Nix thunk,
-nvThunk :: Applicative f
+mkNVThunk :: Applicative f
   => t
   -> NValue t f m
-nvThunk = Pure
+mkNVThunk = Pure
 
 
 -- | Life of a Haskell constant to the life of a Nix constant,
-nvConstant :: Applicative f
+mkNVConstant :: Applicative f
   => NAtom
   -> NValue t f m
-nvConstant = Free . nvConstant'
+mkNVConstant = Free . mkNVConstant'
 
 
 -- | Life of a Haskell sting & context to the life of a Nix string & context,
-nvStr :: Applicative f
+mkNVStr :: Applicative f
   => NixString
   -> NValue t f m
-nvStr = Free . nvStr'
+mkNVStr = Free . mkNVStr'
 
-nvStrWithoutContext :: Applicative f
+mkNVStrWithoutContext :: Applicative f
   => Text
   -> NValue t f m
-nvStrWithoutContext = nvStr . mkNixStringWithoutContext
+mkNVStrWithoutContext = mkNVStr . mkNixStringWithoutContext
 
 
 -- | Life of a Haskell FilePath to the life of a Nix path
-nvPath :: Applicative f
+mkNVPath :: Applicative f
   => Path
   -> NValue t f m
-nvPath = Free . nvPath'
+mkNVPath = Free . mkNVPath'
 
 
-nvList :: Applicative f
+mkNVList :: Applicative f
   => [NValue t f m]
   -> NValue t f m
-nvList = Free . nvList'
+mkNVList = Free . mkNVList'
 
 
-nvSet :: Applicative f
+mkNVSet :: Applicative f
   => PositionSet
   -> AttrSet (NValue t f m)
   -> NValue t f m
-nvSet p s = Free $ nvSet' p s
+mkNVSet p s = Free $ mkNVSet' p s
 
-nvClosure :: (Applicative f, Functor m)
+mkNVClosure :: (Applicative f, Functor m)
   => Params ()
   -> (NValue t f m
       -> m (NValue t f m)
     )
   -> NValue t f m
-nvClosure x f = Free $ nvClosure' x f
+mkNVClosure x f = Free $ mkNVClosure' x f
 
 
-nvBuiltin :: (Applicative f, Functor m)
+mkNVBuiltin :: (Applicative f, Functor m)
   => VarName
   -> (NValue t f m
     -> m (NValue t f m)
     )
   -> NValue t f m
-nvBuiltin name f = Free $ nvBuiltin' name f
+mkNVBuiltin name f = Free $ mkNVBuiltin' name f
 
 
 builtin
@@ -644,7 +644,7 @@ builtin
     -> m (NValue t f m)
     ) -- ^ unary function
   -> m (NValue t f m)
-builtin = (pure .) . nvBuiltin
+builtin = (pure .) . mkNVBuiltin
 
 
 builtin2

--- a/src/Nix/Value.hs
+++ b/src/Nix/Value.hs
@@ -340,7 +340,7 @@ hoistNValue'
   -> NValue' t f m a
   -> NValue' t f n a
 hoistNValue' run lft (NValue' v) =
-    NValue' $ lmapNValueF (hoistNValue lft run) . hoistNValueF lft <$> v
+  NValue' $ lmapNValueF (hoistNValue lft run) . hoistNValueF lft <$> v
 {-# inline hoistNValue' #-}
 
 -- ** Monad
@@ -763,17 +763,17 @@ showValueType (Free (NValue' (extract -> v))) =
 -- * @ValueFrame@
 
 data ValueFrame t f m
-    = ForcingThunk t
-    | ConcerningValue (NValue t f m)
-    | Comparison (NValue t f m) (NValue t f m)
-    | Addition (NValue t f m) (NValue t f m)
-    | Multiplication (NValue t f m) (NValue t f m)
-    | Division (NValue t f m) (NValue t f m)
-    | Coercion ValueType ValueType
-    | CoercionToJson (NValue t f m)
-    | CoercionFromJson Aeson.Value
-    | Expectation ValueType (NValue t f m)
-    deriving Typeable
+  = ForcingThunk t
+  | ConcerningValue (NValue t f m)
+  | Comparison (NValue t f m) (NValue t f m)
+  | Addition (NValue t f m) (NValue t f m)
+  | Multiplication (NValue t f m) (NValue t f m)
+  | Division (NValue t f m) (NValue t f m)
+  | Coercion ValueType ValueType
+  | CoercionToJson (NValue t f m)
+  | CoercionFromJson Aeson.Value
+  | Expectation ValueType (NValue t f m)
+ deriving Typeable
 
 deriving instance (Comonad f, Show t) => Show (ValueFrame t f m)
 
@@ -796,7 +796,7 @@ instance MonadDataErrorContext t f m => Exception (ValueFrame t f m)
 $(deriveEq1 ''NValue')
 
 
--- * @NValue'@ traversals, getter & setters
+-- * @NValueF@ traversals, getter & setters
 
 -- | Make traversals for Nix traversable structures.
 $(makeTraversals ''NValueF)

--- a/src/Nix/Value.hs
+++ b/src/Nix/Value.hs
@@ -588,6 +588,10 @@ mkNVConstant :: Applicative f
   -> NValue t f m
 mkNVConstant = Free . mkNVConstant'
 
+-- | Using of Nulls is generally discouraged (in programming language design et al.), but, if you need it.
+nvNull :: Applicative f
+  => NValue t f m
+nvNull = mkNVConstant NNull
 
 -- | Life of a Haskell sting & context to the life of a Nix string & context,
 mkNVStr :: Applicative f

--- a/src/Nix/Value.hs
+++ b/src/Nix/Value.hs
@@ -144,9 +144,9 @@ data NValueF p m r
 instance Eq1 (NValueF p m) where
   liftEq _  (NVConstantF x) (NVConstantF y) = x == y
   liftEq _  (NVStrF      x) (NVStrF      y) = x == y
+  liftEq _  (NVPathF     x) (NVPathF     y) = x == y
   liftEq eq (NVListF     x) (NVListF     y) = liftEq eq x y
   liftEq eq (NVSetF  _   x) (NVSetF _    y) = liftEq eq x y
-  liftEq _  (NVPathF     x) (NVPathF     y) = x == y
   liftEq _  _               _               = False
 
 
@@ -176,10 +176,10 @@ instance Foldable (NValueF p m) where
     NVConstantF _  -> mempty
     NVStrF      _  -> mempty
     NVPathF     _  -> mempty
-    NVListF     l  -> foldMap f l
-    NVSetF     _ s -> foldMap f s
     NVClosureF _ _ -> mempty
     NVBuiltinF _ _ -> mempty
+    NVListF     l  -> foldMap f l
+    NVSetF     _ s -> foldMap f s
 
 
 -- ** Traversable
@@ -283,13 +283,13 @@ instance (Comonad f, Show a) => Show (NValue' t f m a) where
 
 instance Comonad f => Show1 (NValue' t f m) where
   liftShowsPrec sp sl p = \case
-    NVConstant' atom  -> showsUnaryWith showsPrec "NVConstantF" p atom
-    NVStr' ns         -> showsUnaryWith showsPrec "NVStrF" p $ ignoreContext ns
-    NVList' lst       -> showsUnaryWith (liftShowsPrec sp sl) "NVListF" p lst
-    NVSet'  _   attrs -> showsUnaryWith (liftShowsPrec sp sl) "NVSetF" p attrs
-    NVPath' path      -> showsUnaryWith showsPrec "NVPathF" p path
-    NVClosure' c    _ -> showsUnaryWith showsPrec "NVClosureF" p c
-    NVBuiltin' name _ -> showsUnaryWith showsPrec "NVBuiltinF" p name
+    NVConstant' atom  -> showsUnaryWith showsPrec             "NVConstantF" p atom
+    NVStr' ns         -> showsUnaryWith showsPrec             "NVStrF"      p $ ignoreContext ns
+    NVList' lst       -> showsUnaryWith (liftShowsPrec sp sl) "NVListF"     p lst
+    NVSet'  _   attrs -> showsUnaryWith (liftShowsPrec sp sl) "NVSetF"      p attrs
+    NVPath' path      -> showsUnaryWith showsPrec             "NVPathF"     p path
+    NVClosure' c    _ -> showsUnaryWith showsPrec             "NVClosureF"  p c
+    NVBuiltin' name _ -> showsUnaryWith showsPrec             "NVBuiltinF"  p name
 
 
 -- ** Traversable
@@ -436,7 +436,6 @@ mkNVSet' :: Applicative f
   => PositionSet
   -> AttrSet r
   -> NValue' t f m r
---  2021-07-16: NOTE: that the arguments are flipped.
 mkNVSet' p s = NValue' $ pure $ NVSetF p s
 
 
@@ -554,7 +553,7 @@ liftNValue
   => (forall x . u m x -> m x)
   -> NValue t f m
   -> NValue t f (u m)
-liftNValue run = hoistNValue run lift
+liftNValue = (`hoistNValue` lift)
 
 
 -- *** MonadTransUnlift

--- a/src/Nix/Value.hs
+++ b/src/Nix/Value.hs
@@ -724,7 +724,7 @@ valueType =
         NNull    -> TNull
     NVStrF ns  ->
       TString $
-        HasContext `whenTrue` stringHasContext ns
+        HasContext `whenTrue` hasContext ns
     NVListF{}    -> TList
     NVSetF{}     -> TSet
     NVClosureF{} -> TClosure

--- a/src/Nix/Value.hs
+++ b/src/Nix/Value.hs
@@ -156,7 +156,7 @@ instance Show r => Show (NValueF p m r) where
   showsPrec d =
     \case
       (NVConstantF atom     ) -> showsCon1 "NVConstant" atom
-      (NVStrF      ns       ) -> showsCon1 "NVStr"      $ stringIgnoreContext ns
+      (NVStrF      ns       ) -> showsCon1 "NVStr"      $ ignoreContext ns
       (NVListF     lst      ) -> showsCon1 "NVList"     lst
       (NVSetF      _   attrs) -> showsCon1 "NVSet"      attrs
       (NVClosureF  params _ ) -> showsCon1 "NVClosure"  params
@@ -284,8 +284,7 @@ instance (Comonad f, Show a) => Show (NValue' t f m a) where
 instance Comonad f => Show1 (NValue' t f m) where
   liftShowsPrec sp sl p = \case
     NVConstant' atom  -> showsUnaryWith showsPrec "NVConstantF" p atom
-    NVStr' ns ->
-      showsUnaryWith showsPrec "NVStrF" p (stringIgnoreContext ns)
+    NVStr' ns         -> showsUnaryWith showsPrec "NVStrF" p $ ignoreContext ns
     NVList' lst       -> showsUnaryWith (liftShowsPrec sp sl) "NVListF" p lst
     NVSet'  _   attrs -> showsUnaryWith (liftShowsPrec sp sl) "NVSetF" p attrs
     NVPath' path      -> showsUnaryWith showsPrec "NVPathF" p path

--- a/src/Nix/Value/Equal.hs
+++ b/src/Nix/Value/Equal.hs
@@ -62,7 +62,7 @@ alignEqM eq fa fb =
             (Data.Semialign.align fa fb)
 
 alignEq :: (Align f, Traversable f) => (a -> b -> Bool) -> f a -> f b -> Bool
-alignEq eq fa fb = runIdentity $ alignEqM (\x y -> Identity (eq x y)) fa fb
+alignEq eq fa fb = runIdentity $ alignEqM ((Identity .) . eq) fa fb
 
 isDerivationM
   :: Monad m
@@ -128,8 +128,8 @@ valueFEq
 valueFEq attrsEq eq x y =
   runIdentity $
     valueFEqM
-      (\x' y' -> Identity $ attrsEq x' y')
-      (\x' y' -> Identity $ eq x' y')
+      ((Identity .) . attrsEq)
+      ((Identity .) . eq)
       x
       y
 
@@ -164,7 +164,7 @@ compareAttrSets
   -> AttrSet t
   -> Bool
 compareAttrSets f eq lm rm = runIdentity
-  $ compareAttrSetsM (Identity . f) (\x y -> Identity $ eq x y) lm rm
+  $ compareAttrSetsM (Identity . f) ((Identity .) . eq) lm rm
 
 valueEqM
   :: (MonadThunk t m (NValue t f m), Comonad f)

--- a/src/Nix/Value/Equal.hs
+++ b/src/Nix/Value/Equal.hs
@@ -50,17 +50,16 @@ alignEqM
   -> m Bool
 alignEqM eq fa fb =
   fmap
-    isRight
+    (isRight @() @())
     $ runExceptT $
-      do
-        pairs <-
-          traverse
+      traverse_
+        (guard <=< lift . uncurry eq)
+        =<< traverse
             (\case
               These a b -> pure (a, b)
-              _         -> throwE ()
+              _         -> throwE mempty
             )
             (Data.Semialign.align fa fb)
-        traverse_ (\ (a, b) -> guard =<< lift (eq a b)) pairs
 
 alignEq :: (Align f, Traversable f) => (a -> b -> Bool) -> f a -> f b -> Bool
 alignEq eq fa fb = runIdentity $ alignEqM (\x y -> Identity (eq x y)) fa fb

--- a/src/Nix/Value/Equal.hs
+++ b/src/Nix/Value/Equal.hs
@@ -83,7 +83,7 @@ isDerivationM f m =
       -- We should probably really make sure the context is empty here
       -- but the C++ implementation ignores it.
       False
-      ((==) "derivation" . stringIgnoreContext)
+      ((==) "derivation" . ignoreContext)
       <$> f t
 
 isDerivation
@@ -114,7 +114,7 @@ valueFEqM attrsEq eq =
       (NVConstantF (NFloat x), NVConstantF (NInt   y)) -> pure $             x == fromInteger y
       (NVConstantF (NInt   x), NVConstantF (NFloat y)) -> pure $ fromInteger x == y
       (NVConstantF lc        , NVConstantF rc        ) -> pure $            lc == rc
-      (NVStrF      ls        , NVStrF      rs        ) -> pure $  (\ i -> i ls == i rs) stringIgnoreContext
+      (NVStrF      ls        , NVStrF      rs        ) -> pure $  (\ i -> i ls == i rs) ignoreContext
       (NVListF     ls        , NVListF     rs        ) ->          alignEqM eq ls rs
       (NVSetF      _      lm , NVSetF      _      rm ) ->          attrsEq lm rm
       (NVPathF     lp        , NVPathF     rp        ) ->             pure $ lp == rp

--- a/tests/EvalTests.hs
+++ b/tests/EvalTests.hs
@@ -13,7 +13,6 @@ import           Data.Time
 import           NeatInterpolation (text)
 import           Nix
 import           Nix.Standard
-import           Nix.TH
 import           Nix.Value.Equal
 import qualified System.Directory as D
 import           Test.Tasty

--- a/tests/EvalTests.hs
+++ b/tests/EvalTests.hs
@@ -443,7 +443,7 @@ case_mapattrs_builtin =
 -- Regression test for #373
 case_regression_373 :: Assertion
 case_regression_373 =
-  traverse_ (uncurry freeVarsEqual)
+  traverse_ (uncurry sameFreeVars)
     [ ( "{ inherit a; }"
       , one "a"
       )
@@ -563,9 +563,10 @@ case_concat_thunk_rigth =
 tests :: TestTree
 tests = $testGroupGenerator
 
+genEvalCompareTests :: IO TestTree
 genEvalCompareTests =
   do
-    (coerce -> files :: [Path]) <- D.listDirectory $ coerce testDir
+    files <- coerce D.listDirectory testDir
 
     let
       unmaskedFiles :: [Path]
@@ -631,13 +632,13 @@ assertNixEvalThrows a =
         (\(_ :: NixException) -> pure True)
     unless errored $ assertFailure "Did not catch nix exception"
 
-freeVarsEqual :: Text -> [VarName] -> Assertion
-freeVarsEqual a xs =
+sameFreeVars :: Text -> [VarName] -> Assertion
+sameFreeVars a xs =
   do
     let
       Right a' = parseNixText a
       xs' = S.fromList xs
-      free' = freeVars a'
+      free' = getFreeVars a'
     assertEqual mempty xs' free'
 
 maskedFiles :: [Path]

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -55,7 +55,7 @@ ensureNixpkgsCanParse =
           time <- getCurrentTime
           runWithBasicEffectsIO (defaultOptions time) $
             Nix.nixEvalExprLoc mempty expr
-        let dir = stringIgnoreContext ns
+        let dir = ignoreContext ns
         exists <- fileExist $ toString dir
         unless exists $
           errorWithoutStackTrace $

--- a/tests/NixLanguageTests.hs
+++ b/tests/NixLanguageTests.hs
@@ -163,7 +163,7 @@ assertLangOk opts fileBaseName =
 assertLangOkXml :: Options -> Path -> Assertion
 assertLangOkXml opts fileBaseName =
   do
-    actual <- stringIgnoreContext . toXML <$> hnixEvalFile opts (addNixExt fileBaseName)
+    actual <- ignoreContext . toXML <$> hnixEvalFile opts (addNixExt fileBaseName)
     expected <- read fileBaseName ".exp.xml"
     assertEqual mempty expected actual
 

--- a/tests/NixLanguageTests.hs
+++ b/tests/NixLanguageTests.hs
@@ -173,7 +173,7 @@ assertEval _opts files =
     time <- liftIO getCurrentTime
     let opts = defaultOptions time
     case delete ".nix" $ sort $ fromString @Text . takeExtensions <$> files of
-      []                  -> void $ hnixEvalFile opts (addNixExt name)
+      []                  -> void $ hnixEvalFile opts $ addNixExt name
       [".exp"          ]  -> assertLangOk    opts name
       [".exp.xml"      ]  -> assertLangOkXml opts name
       [".exp.disabled" ]  -> stub

--- a/tests/ParserTests.hs
+++ b/tests/ParserTests.hs
@@ -540,34 +540,46 @@ case_select_keyword =
     )
 
 case_select_or_precedence =
-    assertParsePrint [text|let
-  matchDef = def:   matcher:
-                      v:   let
-                             case = builtins.head (builtins.attrNames v);
-                           in (matcher.case or def case) (v.case);
-in null|] [text|let
-  matchDef = def:
-    matcher:
-      v:
+    assertParsePrint
+      [text|
         let
-          case = builtins.head (builtins.attrNames v);
-        in (matcher.case or def) case (v.case);
-in null|]
+          matchDef = def:   matcher:
+                              v:   let
+                                    case = builtins.head (builtins.attrNames v);
+                                  in (matcher.case or def case) (v.case);
+        in null
+      |]
+      [text|
+         let
+          matchDef = def:
+            matcher:
+              v:
+                let
+                  case = builtins.head (builtins.attrNames v);
+                in (matcher.case or def) case (v.case);
+        in null
+      |]
 
 case_select_or_precedence2 =
-    assertParsePrint [text|let
-  matchDef = def:   matcher:
-                      v:   let
-                             case = builtins.head (builtins.attrNames v);
-                           in (matcher.case or null.foo) (v.case);
-in null|] [text|let
-  matchDef = def:
-    matcher:
-      v:
+    assertParsePrint
+      [text|
         let
-          case = builtins.head (builtins.attrNames v);
-        in (matcher.case or null).foo (v.case);
-in null|]
+          matchDef = def:   matcher:
+                              v:   let
+                                    case = builtins.head (builtins.attrNames v);
+                                  in (matcher.case or null.foo) (v.case);
+        in null
+      |]
+      [text|
+        let
+          matchDef = def:
+            matcher:
+              v:
+                let
+                  case = builtins.head (builtins.attrNames v);
+                in (matcher.case or null).foo (v.case);
+        in null
+      |]
 
 -- ** Function application
 

--- a/tests/ParserTests.hs
+++ b/tests/ParserTests.hs
@@ -794,7 +794,7 @@ instance (VariadicAssertions a) => VariadicAssertions ((ExpectedHask, NixLang) -
   checkListPairs' f acc x = checkListPairs' f (acc <> one x)
 
 checks :: (VariadicAssertions a) => a
-checks = checkListPairs' (uncurry assertParseText) []
+checks = checkListPairs' (uncurry assertParseText) mempty
 
 
 class VariadicArgs t where
@@ -810,7 +810,7 @@ instance (VariadicArgs a) => VariadicArgs (NixLang -> a) where
   checkList' f acc x = checkList' f (acc <> one x)
 
 knownAs :: (VariadicArgs a) => (NixLang -> Assertion) -> a
-knownAs f = checkList' f []
+knownAs f = checkList' f mempty
 
 mistakes :: (VariadicArgs a) => a
 mistakes = knownAs assertParseFail

--- a/tests/ParserTests.hs
+++ b/tests/ParserTests.hs
@@ -730,7 +730,7 @@ assertParseFile file expected =
   do
     res <- parseNixFile $ "data/" <> file
     either
-      (throwParseError "data file" $ toText file)
+      (throwParseError "data file" $ coerce fromString file)
       (assertEqual
         ("Parsing data file " <> coerce file)
         (stripPositionInfo expected)

--- a/tests/TestCommon.hs
+++ b/tests/TestCommon.hs
@@ -39,9 +39,7 @@ hnixEvalText :: Options -> Text -> IO StdVal
 hnixEvalText opts src =
   either
     (\ err -> fail $ toString $ "Parsing failed for expression `" <> src <> "`.\n" <> show err)
-    (\ expr ->
-      runWithBasicEffects opts $ normalForm =<< nixEvalExpr mempty expr
-    )
+    (runWithBasicEffects opts . (normalForm <=< nixEvalExpr mempty))
     $ parseNixText src
 
 nixEvalString :: Text -> IO Text
@@ -51,7 +49,7 @@ nixEvalString expr =
     Text.hPutStr h expr
     hClose h
     res <- nixEvalFile $ coerce fp
-    removeLink $ fp
+    removeLink fp
     pure res
 
 nixEvalFile :: Path -> IO Text


### PR DESCRIPTION
https://github.com/haskell-nix/hnix/wiki/Naming-style-guidelines

Closes a lot of #949

Option getter names are not ideal (I can not name them properly currently because every one of them requires in-depth lookup of what was the semantic meanings implied but not expressed, as it was not documented, to name them a superset of them must be considered. And strangely, at least a couple of them, based on the code, - are redundant, a synonym of one another. But current naming is than before & push thoughts into the right direction.
