### PR TITLE
fix getFreeVars and add test

### DIFF
--- a/tests/EvalTests.hs
+++ b/tests/EvalTests.hs
@@ -455,6 +455,18 @@ case_regression_373 =
       )
     ]
 
+case_bound_vars :: Assertion
+case_bound_vars =
+  traverse_ noFreeVars
+    [ "a: a"
+    , "{b}: b"
+    , "let c = 5; d = c; in d"
+    , "rec { e = 5; f = e; }"
+    ]
+  where
+    noFreeVars = flip sameFreeVars mempty
+
+
 case_expression_split =
   constantEqualText
     "[ \"\" [ \"a\" ] \"c\" ]"


### PR DESCRIPTION
the treatment of variable bindings was of so e.g. `{x}: x` was said to have `x` as a free variable. This seemed to just be a mistake to me, so I fixed it and added a test for that and similar cases.