### PR TITLE
Fix nix-shell invocation

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -109,6 +109,7 @@
       else abort "Requires Nix >= 2.0"
 
 , mkDerivation   ? null
+, inNixShell ? false
 }:
 
 let


### PR DESCRIPTION
nix-shell passes the parameter `inNixShell` now