### PR TITLE
Escape ${ in strings when printing Nix expressions

### DIFF
--- a/src/Nix/Pretty.hs
+++ b/src/Nix/Pretty.hs
@@ -1,5 +1,7 @@
 {-# language CPP #-}
 {-# language AllowAmbiguousTypes #-}
+{-# language ViewPatterns, PatternSynonyms, OverloadedStrings #-}
+
 
 {-# options_ghc -fno-warn-name-shadowing #-}
 
@@ -99,21 +101,27 @@ wrapPath op sub =
     ("\"${" <> withoutParens sub <> "}\"")
     (wasPath sub)
 
+
+infixr 5 :<
+pattern (:<) :: Char -> Text -> Text
+pattern t :< ts <- (Text.uncons -> Just (t, ts))
+  where (:<) = Text.cons
+
+escapeDoubleQuoteString :: Text -> Text
+escapeDoubleQuoteString ('"':<xs) = "\\\"" <> escapeDoubleQuoteString xs
+escapeDoubleQuoteString ('$':<'{':<xs) = "\\${" <> escapeDoubleQuoteString xs
+escapeDoubleQuoteString ('$':<xs) = '$' :< escapeDoubleQuoteString xs
+escapeDoubleQuoteString (x:<xs) = maybe (one x) (('\\' :<) . one) (toEscapeCode x)
+  <> escapeDoubleQuoteString xs
+escapeDoubleQuoteString a = a
+
+
 prettyString :: NString (NixDoc ann) -> Doc ann
 prettyString (DoubleQuoted parts) = "\"" <> foldMap prettyPart parts <> "\""
  where
-  -- It serializes Text -> String, because the helper code is done for String,
-  -- please, can someone break that code.
-  prettyPart (Plain t)      = pretty . dollarEscape . toText . foldMap escape . toString $ t
+  prettyPart (Plain t)      = pretty $ escapeDoubleQuoteString t
   prettyPart EscapedNewline = "''\\n"
   prettyPart (Antiquoted r) = "${" <> withoutParens r <> "}"
-  escape '"' = "\\\""
-  escape '$' = "$" -- do not print $ as \$ if no { is following 
-  escape x   =
-    maybe
-      (one x)
-      (('\\' :) . one)
-      (toEscapeCode x)
 prettyString (Indented _ parts) = group $ nest 2 $ vcat
   ["''", content, "''"]
  where
@@ -383,9 +391,6 @@ prettyNThunk t =
           "(" <> fold (one "thunk from: " <> (prettyOriginExpr . _originExpr <$> ps)) <> ")"
         ]
 
--- | dollarEscape for double quoted string 
-dollarEscape :: Text -> Text
-dollarEscape = replace "${" "\\${"
 
 -- | This function is used only by the testing code.
 printNix :: forall t f m . MonadDataContext f m => NValue t f m -> Text
@@ -395,7 +400,7 @@ printNix = iterNValueByDiscardWith thk phi
 
   phi :: NValue' t f m Text -> Text
   phi (NVConstant' a ) = atomText a
-  phi (NVStr'      ns) = dollarEscape $ show $ ignoreContext ns
+  phi (NVStr'      ns) = "\"" <> escapeDoubleQuoteString (ignoreContext ns) <> "\""
   phi (NVList'     l ) = "[ " <> unwords l <> " ]"
   phi (NVSet' _ s) =
     "{ " <>

--- a/src/Nix/Pretty.hs
+++ b/src/Nix/Pretty.hs
@@ -108,12 +108,12 @@ pattern t :< ts <- (Text.uncons -> Just (t, ts))
   where (:<) = Text.cons
 
 escapeDoubleQuoteString :: Text -> Text
-escapeDoubleQuoteString ('"':<xs) = "\\\"" <> escapeDoubleQuoteString xs
+escapeDoubleQuoteString ('"':<xs)      = "\\\"" <> escapeDoubleQuoteString xs
 escapeDoubleQuoteString ('$':<'{':<xs) = "\\${" <> escapeDoubleQuoteString xs
-escapeDoubleQuoteString ('$':<xs) = '$' :< escapeDoubleQuoteString xs
-escapeDoubleQuoteString (x:<xs) = maybe (one x) (('\\' :<) . one) (toEscapeCode x)
-  <> escapeDoubleQuoteString xs
-escapeDoubleQuoteString a = a
+escapeDoubleQuoteString ('$':<xs)      = '$' :< escapeDoubleQuoteString xs
+escapeDoubleQuoteString (x:<xs)        = maybe (one x) (('\\' :<) . one) (toEscapeCode x) 
+                                         <> escapeDoubleQuoteString xs
+escapeDoubleQuoteString a              = a
 
 
 prettyString :: NString (NixDoc ann) -> Doc ann

--- a/tests/NixLanguageTests.hs
+++ b/tests/NixLanguageTests.hs
@@ -61,6 +61,7 @@ newFailingTests = Set.fromList
   , "eval-okay-path"  -- #128
   , "eval-okay-types"
   , "eval-okay-fromTOML"
+  , "eval-okay-ind-string" -- #1000 #610 
   ]
 
 -- | Upstream tests that test cases that HNix disaded as a misfeature that is used so rarely

--- a/tests/PrettyTests.hs
+++ b/tests/PrettyTests.hs
@@ -23,7 +23,7 @@ case_string_antiquotation =
   do
     assertPretty
       (mkStr "echo $foo")
-      "\"echo \\$foo\""
+      "\"echo $foo\""
     assertPretty
       (mkStr "echo ${foo}")
       "\"echo \\${foo}\""

--- a/tests/eval-compare/ind-string-18.nix
+++ b/tests/eval-compare/ind-string-18.nix
@@ -1,0 +1,2 @@
+# to observe the upstream nix behavior for dollar sign excape in doublequote string
+"\${foo $foo"

--- a/tests/eval-compare/ind-string-18.nix
+++ b/tests/eval-compare/ind-string-18.nix
@@ -1,2 +1,2 @@
 # to observe the upstream nix behavior for dollar sign excape in doublequote string
-"\${foo $foo"
+"\${foo \$ $foo"

--- a/tests/eval-compare/ind-string-19.nix
+++ b/tests/eval-compare/ind-string-19.nix
@@ -1,0 +1,4 @@
+# to observe the upstream nix behavior for dollar excape in Indented string
+''
+''$ ''${
+''

--- a/tests/eval-compare/ind-string-19.nix
+++ b/tests/eval-compare/ind-string-19.nix
@@ -1,4 +1,4 @@
 # to observe the upstream nix behavior for dollar excape in Indented string
 ''
-''$ ''${
+''$ $ ''${
 ''


### PR DESCRIPTION
Fix for #1000 
Following the fix in [NixOS/nix 4012](https://github.com/NixOS/nix/pull/4012)
* What is done: 
  * stop escaping a single `$` sign in double quoted string if not following by `{` when printing.
  * escape `${` to `\${` in double quoted string when printing.
  * update the tests for this behavior.
  * refactor to drop the usage of `show` in `printNix`, and unify some double string escape behavior for `prettyString` and `printNix`

* What is not working:
  * test eval-okay-ind-string is malformed since the nix submodule is outdated(the test violate  [NixOS/nix 4012](https://github.com/NixOS/nix/pull/4012)), however the test does work for [Nix 2.4 version of eval-okay-ind-string.exp](https://raw.githubusercontent.com/NixOS/nix/2.4/tests/lang/eval-okay-ind-string.exp), this test should be banned until modern Nix submodule is pulled #610
