### PR TITLE
tests: NixLanguageTests: enable test 'eval-okay-hashfile'

### DIFF
--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -1420,6 +1420,18 @@ hashStringNix nsAlgo ns =
         mkHash s = hash $ encodeUtf8 s
 
 
+-- | hashFileNix
+-- use hashStringNix to hash file content
+hashFileNix
+  :: forall e t f m . MonadNix e t f m => NixString -> Path -> Prim m NixString
+hashFileNix nsAlgo nvfilepath = Prim $ hash =<< fileContent
+ where
+  hash = outPrim . hashStringNix nsAlgo
+  outPrim (Prim x) = x
+  fileContent :: m NixString
+  fileContent = mkNixStringWithoutContext <$> Nix.Render.readFile nvfilepath
+
+
 placeHolderNix :: forall t f m e . MonadNix e t f m => NValue t f m -> m (NValue t f m)
 placeHolderNix p =
   do
@@ -1849,6 +1861,7 @@ builtinsList =
     , add2 Normal   "hasAttr"          hasAttrNix
     , add  Normal   "hasContext"       hasContextNix
     , add' Normal   "hashString"       (hashStringNix @e @t @f @m)
+    , add' Normal   "hashFile"         hashFileNix
     , add  Normal   "head"             headNix
     , add2 Normal   "intersectAttrs"   intersectAttrsNix
     , add  Normal   "isAttrs"          isAttrsNix

--- a/tests/NixLanguageTests.hs
+++ b/tests/NixLanguageTests.hs
@@ -56,8 +56,8 @@ groupBy key = Map.fromListWith (<>) . fmap (key &&& pure)
 -- previously passed.
 newFailingTests :: Set String
 newFailingTests = Set.fromList
-  [ "eval-okay-hash"
-  , "eval-okay-hashfile"
+  [ 
+    "eval-okay-hash"
   , "eval-okay-path"  -- #128
   , "eval-okay-types"
   , "eval-okay-fromTOML"


### PR DESCRIPTION
add builtins.hashfile should suffice to pass eval-okay-hashfile
The main agenda & details are in the #966. This PR covers a part of it.