### PR TITLE
(#1029) upd nix submodule

### DIFF
--- a/hnix.cabal
+++ b/hnix.cabal
@@ -12,21 +12,10 @@ license:        BSD-3-Clause
 license-file:   License
 build-type:     Simple
 data-dir:       data/
-data-files:
-  nix/corepkgs/buildenv.nix
-  nix/corepkgs/unpack-channel.nix
-  nix/corepkgs/derivation.nix
-  nix/corepkgs/fetchurl.nix
-  nix/corepkgs/imported-drv-to-derivation.nix
 extra-source-files:
   ChangeLog.md
   ReadMe.md
   License
-  data/nix/corepkgs/buildenv.nix
-  data/nix/corepkgs/unpack-channel.nix
-  data/nix/corepkgs/derivation.nix
-  data/nix/corepkgs/fetchurl.nix
-  data/nix/corepkgs/imported-drv-to-derivation.nix
   data/nix/tests/lang/binary-data
   data/nix/tests/lang/data
   data/nix/tests/lang/dir1/a.nix
@@ -38,7 +27,6 @@ extra-source-files:
   data/nix/tests/lang/dir4/a.nix
   data/nix/tests/lang/dir4/c.nix
   data/nix/tests/lang/eval-fail-abort.nix
-  data/nix/tests/lang/eval-fail-antiquoted-path.nix
   data/nix/tests/lang/eval-fail-assert.nix
   data/nix/tests/lang/eval-fail-bad-antiquote-1.nix
   data/nix/tests/lang/eval-fail-bad-antiquote-2.nix

--- a/tests/NixLanguageTests.hs
+++ b/tests/NixLanguageTests.hs
@@ -56,20 +56,28 @@ groupBy key = Map.fromListWith (<>) . fmap (key &&& pure)
 -- previously passed.
 newFailingTests :: Set String
 newFailingTests = Set.fromList
-  [ 
-    "eval-okay-hash"
-  , "eval-okay-path"  -- #128
+  [ "eval-okay-path"  -- #128
   , "eval-okay-fromTOML"
-  , "eval-okay-ind-string" -- #1000 #610 
+  , "eval-okay-zipAttrsWith"
+  , "eval-okay-tojson"
+  , "eval-okay-search-path"
+  , "eval-okay-sort"
+  , "eval-okay-path-antiquotation"
+  , "eval-okay-groupBy"
+  , "eval-okay-getattrpos-functionargs"
+  , "eval-okay-floor-ceil"
+  , "eval-okay-attrs6"
   ]
 
 -- | Upstream tests that test cases that HNix disaded as a misfeature that is used so rarely
 -- that it more effective to fix it & lint it out of existance.
 deprecatedRareNixQuirkTests :: Set String
-deprecatedRareNixQuirkTests = Set.fromList $
-  one
-    -- A rare quirk of Nix that is proper to fix&enforce then to support (see git commit history)
+deprecatedRareNixQuirkTests = Set.fromList
+  [ -- A rare quirk of Nix that is proper to fix&enforce then to support (see git commit history)
     "eval-okay-strings-as-attrs-names"
+    -- Nix upstream removed this test alltogather
+  , "eval-okay-hash"
+  ]
 
 genTests :: IO TestTree
 genTests =


### PR DESCRIPTION
Solves #610.

Adds a bunch of new tests that do not pass.

Puts `eval-okay-hash` into proper deprecation.