### PR TITLE
Expr.Types: add & use NPos & NSourcePos

### DIFF
--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -1986,7 +1986,7 @@ builtinsList =
     , add  Normal   "tail"             tailNix
     , add2 Normal   "toFile"           toFileNix
     , add  Normal   "toJSON"           toJSONNix
-    , add  Normal   "toPath"           toPathNix
+    , add  Normal   "toPath"           toPathNix -- Deprecated in Nix: https://github.com/NixOS/nix/pull/2524
     , add  Normal   "toXML"            toXMLNix
     , add0 Normal   "true"             (pure $ mkNVBool True)
     , add  Normal   "tryEval"          tryEvalNix

--- a/src/Nix/Convert.hs
+++ b/src/Nix/Convert.hs
@@ -21,7 +21,6 @@ import qualified Data.HashMap.Lazy             as M
 import           Nix.Atoms
 import           Nix.Effects
 import           Nix.Expr.Types
-import           Nix.Expr.Types.Annotated
 import           Nix.Frames
 import           Nix.String
 import           Nix.Value
@@ -410,11 +409,11 @@ instance Convertible e t f m
   toValue = toValue @Path . coerce
 
 instance Convertible e t f m
-  => ToValue SourcePos m (NValue' t f m (NValue t f m)) where
-  toValue (SourcePos f l c) = do
-    f' <- toValue $ mkNixStringWithoutContext $ fromString f
-    l' <- toValue $ unPos l
-    c' <- toValue $ unPos c
+  => ToValue NSourcePos m (NValue' t f m (NValue t f m)) where
+  toValue (NSourcePos f l c) = do
+    f' <- toValue $ mkNixStringWithoutContext $ fromString $ coerce f
+    l' <- toValue $ unPos $ coerce l
+    c' <- toValue $ unPos $ coerce c
     let pos = M.fromList [("file" :: VarName, f'), ("line", l'), ("column", c')]
     pure $ mkNVSet' mempty pos
 

--- a/src/Nix/Expr/Types.hs
+++ b/src/Nix/Expr/Types.hs
@@ -60,6 +60,38 @@ import           Instances.TH.Lift              ()  -- importing Lift Text for G
 
 -- * utils
 
+newtype NPos = NPos Pos
+ deriving
+   ( Eq, Ord
+   , Read, Show
+   , Data, NFData
+   , Generic
+   )
+
+instance Semigroup NPos where
+  (NPos x) <> (NPos y) = NPos (x <> y)
+
+-- | Represents source positions.
+-- Source line & column positions change intensively during parsing,
+-- so they are declared strict to avoid memory leaks.
+--
+-- The data type is a reimplementation of 'Text.Megaparsec.Pos' 'SourcePos'.
+data NSourcePos =
+  NSourcePos
+  { -- | Name of source file
+    getSourceName :: Path,
+    -- | Line number
+    getSourceLine :: !NPos,
+    -- | Column number
+    getSourceColumn :: !NPos
+  }
+ deriving
+   ( Eq, Ord
+   , Read, Show
+   , Data, NFData
+   , Generic
+   )
+
 --  2021-07-16: NOTE: Should replace @ParamSet@ List
 -- | > Hashmap VarName -- type synonym
 type AttrSet = HashMap VarName

--- a/src/Nix/Expr/Types.hs
+++ b/src/Nix/Expr/Types.hs
@@ -92,6 +92,16 @@ data NSourcePos =
    , Generic
    )
 
+-- | Helper for 'SourcePos' -> 'NSourcePos' coersion.
+toNSourcePos :: SourcePos -> NSourcePos
+toNSourcePos (SourcePos f l c) =
+  NSourcePos (coerce f) (coerce l) (coerce c)
+
+-- | Helper for 'NSourcePos' -> 'SourcePos' coersion.
+toSourcePos :: NSourcePos -> SourcePos
+toSourcePos (NSourcePos f l c) =
+  SourcePos (coerce f) (coerce l) (coerce c)
+
 --  2021-07-16: NOTE: Should replace @ParamSet@ List
 -- | > Hashmap VarName -- type synonym
 type AttrSet = HashMap VarName

--- a/src/Nix/Expr/Types/Annotated.hs
+++ b/src/Nix/Expr/Types/Annotated.hs
@@ -10,9 +10,6 @@
 module Nix.Expr.Types.Annotated
   ( module Nix.Expr.Types.Annotated
   , module Data.Functor.Compose
-  , SourcePos(..)
-  , unPos
-  , mkPos
   )
 where
 
@@ -35,10 +32,6 @@ import           Data.Ord.Deriving
 import           GHC.Generics
 import           Nix.Atoms
 import           Nix.Expr.Types
-import           Text.Megaparsec                ( unPos
-                                                , mkPos
-                                                )
-import           Text.Megaparsec.Pos            ( SourcePos(..) )
 import           Text.Read.Deriving
 import           Text.Show.Deriving
 
@@ -46,8 +39,8 @@ import           Text.Show.Deriving
 
 -- | Demarcation of a chunk in a source file.
 data SrcSpan = SrcSpan
-  { spanBegin :: SourcePos
-  , spanEnd   :: SourcePos
+  { getSpanBegin :: NSourcePos
+  , getSpanEnd   :: NSourcePos
   }
  deriving (Ord, Eq, Generic, Typeable, Data, Show, NFData, Hashable)
 
@@ -56,8 +49,8 @@ data SrcSpan = SrcSpan
 instance Semigroup SrcSpan where
   s1 <> s2 =
     SrcSpan
-      (on min spanBegin s1 s2)
-      (on max spanEnd   s1 s2)
+      (on min getSpanBegin s1 s2)
+      (on max getSpanEnd   s1 s2)
 
 instance Binary SrcSpan
 instance ToJSON SrcSpan
@@ -183,8 +176,8 @@ annNAbs (AnnUnit s1 ps) e1@(Ann s2 _) = NAbsAnn (s1 <> s2) ps e1
 annNStr :: AnnUnit SrcSpan (NString NExprLoc) -> NExprLoc
 annNStr (AnnUnit s1 s) = NStrAnn s1 s
 
-deltaInfo :: SourcePos -> (Text, Int, Int)
-deltaInfo (SourcePos fp l c) = (fromString fp, unPos l, unPos c)
+deltaInfo :: NSourcePos -> (Text, Int, Int)
+deltaInfo (NSourcePos fp l c) = (fromString $ coerce fp, unPos $ coerce l, unPos $ coerce c)
 
 annNNull :: NExprLoc
 annNNull = NConstantAnn nullSpan NNull

--- a/src/Nix/Parser.hs
+++ b/src/Nix/Parser.hs
@@ -108,10 +108,10 @@ annotateLocation1 :: Parser a -> Parser (AnnUnit SrcSpan a)
 annotateLocation1 p =
   do
     begin <- getSourcePos
-    res <- p
+    res   <- p
     end   <- get -- The state set before the last whitespace
 
-    pure $ AnnUnit (SrcSpan begin end) res
+    pure $ AnnUnit (SrcSpan (toNSourcePos begin) (toNSourcePos end)) res
 
 annotateLocation :: Parser (NExprF NExprLoc) -> Parser NExprLoc
 annotateLocation = (annUnitToAnn <$>) . annotateLocation1
@@ -401,7 +401,7 @@ nixBinders = (inherit <|> namedVar) `endBy` symbol ';' where
       label "inherited binding" $
         liftA2 (Inherit x)
           (many identifier)
-          (pure p)
+          (pure (toNSourcePos p))
   namedVar =
     do
       p <- getSourcePos
@@ -409,7 +409,7 @@ nixBinders = (inherit <|> namedVar) `endBy` symbol ';' where
         liftA3 NamedVar
           (annotated <$> nixSelector)
           (exprAfterSymbol '=')
-          (pure p)
+          (pure (toNSourcePos p))
   scope = label "inherit scope" nixParens
 
 nixSet :: Parser NExprLoc

--- a/src/Nix/Reduce.hs
+++ b/src/Nix/Reduce.hs
@@ -102,7 +102,7 @@ staticImport pann path =
           (\ err -> fail $ "Parse failed: " <> show err)
           (\ x -> do
             let
-              pos  = join (SourcePos "Reduce.hs") $ mkPos 1
+              pos  = join (NSourcePos "Reduce.hs") $ (coerce . mkPos) 1
               span = join SrcSpan pos
               cur  =
                 NamedVar

--- a/src/Nix/Render.hs
+++ b/src/Nix/Render.hs
@@ -14,6 +14,9 @@ import qualified Data.Set                      as Set
 import           Nix.Utils.Fix1                 ( Fix1T
                                                 , MonadFix1T
                                                 )
+import           Nix.Expr.Types                 ( NPos(..)
+                                                , NSourcePos(..)
+                                                )
 import           Nix.Expr.Types.Annotated
 import           Prettyprinter
 import qualified System.Directory              as S
@@ -65,14 +68,14 @@ instance MonadFile IO where
 
 instance (MonadFix1T t m, MonadIO (Fix1T t m), MonadFail (Fix1T t m), MonadFile m) => MonadFile (Fix1T t m)
 
-posAndMsg :: SourcePos -> Doc a -> ParseError s Void
-posAndMsg (SourcePos _ lineNo _) msg =
+posAndMsg :: NSourcePos -> Doc a -> ParseError s Void
+posAndMsg (NSourcePos _ (coerce -> lineNo) _) msg =
   FancyError
     (unPos lineNo)
     (Set.fromList $ one (ErrorFail (show msg) :: ErrorFancy Void))
 
 renderLocation :: MonadFile m => SrcSpan -> Doc a -> m (Doc a)
-renderLocation (SrcSpan (SourcePos (coerce -> file) begLine begCol) (SourcePos (coerce -> file') endLine endCol)) msg
+renderLocation (SrcSpan (NSourcePos file (coerce -> begLine) (coerce -> begCol)) (NSourcePos file' (coerce -> endLine) (coerce -> endCol))) msg
   | file == file' && file == "<string>" && begLine == endLine =
     pure $ "In raw input string at position " <> pretty (unPos begCol)
 

--- a/src/Nix/Render/Frame.hs
+++ b/src/Nix/Render/Frame.hs
@@ -58,14 +58,14 @@ renderFrames xss@(x : xs) =
   renderPosition :: NixFrame -> [Doc ann]
   renderPosition =
     whenJust
-      (\ pos -> one ("While evaluating at " <> pretty (sourcePosPretty pos) <> colon))
+      (\ pos -> one ("While evaluating at " <> pretty (sourcePosPretty $ toSourcePos pos) <> colon))
       . framePos @v @m
 
 framePos
   :: forall v (m :: Type -> Type)
    . (Typeable m, Typeable v)
   => NixFrame
-  -> Maybe SourcePos
+  -> Maybe NSourcePos
 framePos (NixFrame _ f) =
   (\case
     EvaluatingExpr _ (Ann (SrcSpan beg _) _) -> pure beg

--- a/tests/ParserTests.hs
+++ b/tests/ParserTests.hs
@@ -649,7 +649,7 @@ case_comments =
 
 case_simpleLoc =
   let
-    mkSPos = on (SourcePos "<string>") mkPos
+    mkSPos = on (NSourcePos "<string>") (coerce . mkPos)
     mkSpan = on SrcSpan (uncurry mkSPos)
   in
     assertParseTextLoc [text|let

--- a/tests/PrettyParseTests.hs
+++ b/tests/PrettyParseTests.hs
@@ -22,7 +22,6 @@ import           Nix.Pretty
 import           Prettyprinter
 import           Test.Tasty
 import           Test.Tasty.Hedgehog
-import           Text.Megaparsec                ( Pos )
 import qualified Text.Show.Pretty              as PS
 
 asciiString :: MonadGen m => m String
@@ -35,16 +34,16 @@ asciiVarName :: Gen VarName
 asciiVarName = coerce <$> asciiText
 
 -- Might want to replace this instance with a constant value
-genPos :: Gen Pos
-genPos = mkPos <$> Gen.int (Range.linear 1 256)
+genNPos :: Gen NPos
+genNPos = fmap coerce $ mkPos <$> Gen.int (Range.linear 1 256)
 
-genSourcePos :: Gen SourcePos
-genSourcePos =
+genNSourcePos :: Gen NSourcePos
+genNSourcePos =
   join (liftA3
-      SourcePos
-      asciiString
+      NSourcePos
+      (fmap coerce asciiString)
     )
-    genPos
+    genNPos
 
 genKeyName :: Gen (NKeyName NExpr)
 genKeyName =
@@ -59,11 +58,11 @@ genBinding = Gen.choice
   [ liftA3 NamedVar
       genAttrPath
       genExpr
-      genSourcePos
+      genNSourcePos
   , liftA3 Inherit
       (Gen.maybe genExpr)
       (Gen.list (Range.linear 0 5) asciiVarName)
-      genSourcePos
+      genNSourcePos
   ]
 
 genString :: Gen (NString NExpr)


### PR DESCRIPTION
This is a type & type boundary lifting groundwork to do #1026 & #746 design in this release.

The `NPos` & `NSourcePos` next can be freely shaped into what comes out of the #1026 & #746.
