### PR TITLE
Unify `mkNV*` and `NV*` patterns by bidirectional synonyms in value modules

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -9,6 +9,8 @@
     * [(link)](https://github.com/haskell-nix/hnix/pull/1038/files) project was using `megaparsec` `{,Source}Pos` and to use it shipped a lot of orphan instances. To improve the situation & performance (reports [#1026](https://github.com/haskell-nix/hnix/issues/1026), [#746](https://github.com/haskell-nix/hnix/issues/746)) project uses `N{,Source}Pos` types, related type signatures were changed accordingly.
   * `Nix.Value`
     * Unify builder `mkNV*` and `NV*` patterns by bidirectional synonyms, a lot of builders `mkNV*` are removed, and merged to `NV*`. e.g. instead of builder `mkNVList`, `NVList` should be used.
+    * Constraint `NVConstraint f = (Comonad f, Applicative f)` was introduced, in order to unify builder `mkNV*` and `NV*` patterns.
+  
 
 ## [(diff)](https://github.com/haskell-nix/hnix/compare/0.15.0...0.16.0#files_bucket) 0.16.0
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -8,7 +8,7 @@
     * [(link)](https://github.com/haskell-nix/hnix/pull/1042/files) The central HNix type `NExprF` changed, the `NApp` was moved out of `NBinary` & now a `NExprF` constructor of its own, the type signatures were changed accordingly.
     * [(link)](https://github.com/haskell-nix/hnix/pull/1038/files) project was using `megaparsec` `{,Source}Pos` and to use it shipped a lot of orphan instances. To improve the situation & performance (reports [#1026](https://github.com/haskell-nix/hnix/issues/1026), [#746](https://github.com/haskell-nix/hnix/issues/746)) project uses `N{,Source}Pos` types, related type signatures were changed accordingly.
   * `Nix.Value`
-    * Unify `mkNV*` and `NV*` patterns by bidirectional synonyms, a lot of `mkNV*` are removed, and merged to `NV*`. e.g. instead of `mkNVList`, `NVList` should be used, same goes for .
+    * Unify builder `mkNV*` and `NV*` patterns by bidirectional synonyms, a lot of builders `mkNV*` are removed, and merged to `NV*`. e.g. instead of builder `mkNVList`, `NVList` should be used.
 
 ## [(diff)](https://github.com/haskell-nix/hnix/compare/0.15.0...0.16.0#files_bucket) 0.16.0
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -8,8 +8,8 @@
     * [(link)](https://github.com/haskell-nix/hnix/pull/1042/files) The central HNix type `NExprF` changed, the `NApp` was moved out of `NBinary` & now a `NExprF` constructor of its own, the type signatures were changed accordingly.
     * [(link)](https://github.com/haskell-nix/hnix/pull/1038/files) project was using `megaparsec` `{,Source}Pos` and to use it shipped a lot of orphan instances. To improve the situation & performance (reports [#1026](https://github.com/haskell-nix/hnix/issues/1026), [#746](https://github.com/haskell-nix/hnix/issues/746)) project uses `N{,Source}Pos` types, related type signatures were changed accordingly.
   * `Nix.Value`
-    * Unify builder `mkNV*` and `NV*` patterns by bidirectional synonyms, a lot of builders `mkNV*` are removed, and merged to `NV*`. e.g. instead of builder `mkNVList`, `NVList` should be used.
-    * Constraint `NVConstraint f = (Comonad f, Applicative f)` was introduced, in order to unify builder `mkNV*` and `NV*` patterns.
+    * [(link)](https://github.com/haskell-nix/hnix/pull/1046/files) Unify builder `mkNV*` and `NV*` patterns by bidirectional synonyms, a lot of builders `mkNV*` are removed, and merged to `NV*`. e.g. instead of builder `mkNVList`, `NVList` should be used.
+    * [(link)](https://github.com/haskell-nix/hnix/pull/1046/files) Constraint `NVConstraint f = (Comonad f, Applicative f)` was introduced, in order to unify builder `mkNV*` and `NV*` patterns.
   
 
 ## [(diff)](https://github.com/haskell-nix/hnix/compare/0.15.0...0.16.0#files_bucket) 0.16.0

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,13 +3,16 @@
 
 ## [(diff)](https://github.com/haskell-nix/hnix/compare/0.16.0...0.17.0#files_bucket) 0.17.0
 
+* Introduction:
+  * `Nix.Value`
+    * [(link)](https://github.com/haskell-nix/hnix/pull/1046/files) Constraint `NVConstraint f = (Comonad f, Applicative f)` was introduced, in order to unify builder `mkNV*` and `NV*` patterns.
+
 * Breaking:
   * `Nix.Expr.Types`
     * [(link)](https://github.com/haskell-nix/hnix/pull/1042/files) The central HNix type `NExprF` changed, the `NApp` was moved out of `NBinary` & now a `NExprF` constructor of its own, the type signatures were changed accordingly.
     * [(link)](https://github.com/haskell-nix/hnix/pull/1038/files) project was using `megaparsec` `{,Source}Pos` and to use it shipped a lot of orphan instances. To improve the situation & performance (reports [#1026](https://github.com/haskell-nix/hnix/issues/1026), [#746](https://github.com/haskell-nix/hnix/issues/746)) project uses `N{,Source}Pos` types, related type signatures were changed accordingly.
   * `Nix.Value`
     * [(link)](https://github.com/haskell-nix/hnix/pull/1046/files) Unify builder `mkNV*` and `NV*` patterns by bidirectional synonyms, a lot of builders `mkNV*` are removed, and merged to `NV*`. e.g. instead of builder `mkNVList`, `NVList` should be used.
-    * [(link)](https://github.com/haskell-nix/hnix/pull/1046/files) Constraint `NVConstraint f = (Comonad f, Applicative f)` was introduced, in order to unify builder `mkNV*` and `NV*` patterns.
   
 
 ## [(diff)](https://github.com/haskell-nix/hnix/compare/0.15.0...0.16.0#files_bucket) 0.16.0

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -7,6 +7,8 @@
   * `Nix.Expr.Types`
     * [(link)](https://github.com/haskell-nix/hnix/pull/1042/files) The central HNix type `NExprF` changed, the `NApp` was moved out of `NBinary` & now a `NExprF` constructor of its own, the type signatures were changed accordingly.
     * [(link)](https://github.com/haskell-nix/hnix/pull/1038/files) project was using `megaparsec` `{,Source}Pos` and to use it shipped a lot of orphan instances. To improve the situation & performance (reports [#1026](https://github.com/haskell-nix/hnix/issues/1026), [#746](https://github.com/haskell-nix/hnix/issues/746)) project uses `N{,Source}Pos` types, related type signatures were changed accordingly.
+  * `Nix.Value`
+    * Unify `mkNV*` and `NV*` patterns by bidirectional synonyms, a lot of `mkNV*` are removed, and merged to `NV*`. e.g. instead of `mkNVList`, `NVList` should be used, same goes for .
 
 ## [(diff)](https://github.com/haskell-nix/hnix/compare/0.15.0...0.16.0#files_bucket) 0.16.0
 

--- a/src/Nix.hs
+++ b/src/Nix.hs
@@ -114,7 +114,7 @@ evaluateExpression mpath evaluator handler expr =
     f' <- demand f
     val <-
       case f' of
-        NVClosure _ g -> g $ mkNVSet mempty $ M.fromList args
+        NVClosure _ g -> g $ NVSet mempty $ M.fromList args
         _             -> pure f
     processResult handler val
  where

--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -1530,14 +1530,14 @@ placeHolderNix p =
       $ Base32.encode
       -- Please, stop Text -> Bytestring here after migration to Text
       $ case Base16.decode (bytes h) of -- The result coming out of hashString is base16 encoded
-
+#if MIN_VERSION_base16_bytestring(1,0,0)
         -- Please, stop Text -> String here after migration to Text
         Left e -> error $ "Couldn't Base16 decode the text: '" <> body h <> "'.\nThe Left fail content: '" <> show e <> "'."
         Right d -> d
-
-
-
-
+#else
+        (d, "") -> d
+        (_, e) -> error $ "Couldn't Base16 decode the text: '" <> body h <> "'.\nUndecodable remainder: '" <> show e <> "'."
+#endif
     where
       bytes :: NixString -> ByteString
       bytes = encodeUtf8 . body

--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -33,10 +33,10 @@ import qualified "hashing" Crypto.Hash.SHA1    as SHA1
 import qualified "hashing" Crypto.Hash.SHA256  as SHA256
 import qualified "hashing" Crypto.Hash.SHA512  as SHA512
 import qualified Data.Aeson                    as A
-
-
-
-
+#if MIN_VERSION_aeson(2,0,0)
+import qualified Data.Aeson.Key                as AKM
+import qualified Data.Aeson.KeyMap             as AKM
+#endif
 import           Data.Align                     ( alignWith )
 import           Data.Array
 import           Data.Bits
@@ -1619,11 +1619,11 @@ fromJSONNix nvjson =
       A.Object m ->
         traverseToNValue
           (NVSet mempty)
-
-
-
+#if MIN_VERSION_aeson(2,0,0)
+          (M.mapKeys (coerce . AKM.toText)  $ AKM.toHashMap m)
+#else
           (M.mapKeys coerce m)
-
+#endif
       A.Array  l -> traverseToNValue NVList (V.toList l)
       A.String s -> pure $ mkNVStrWithoutContext s
       A.Number n ->

--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -915,7 +915,7 @@ pathNix arg =
 
     Right (coerce . toText . coerce @StorePath @String -> s) <- addToStore name path recursive False
     -- TODO: Ensure that s matches sha256 when not empty
-    pure $ mkNVStr $ mkNixStringWithSingletonContext (StringContext DirectPath s) s
+    pure $ NVStr $ mkNixStringWithSingletonContext (StringContext DirectPath s) s
  where
   coerceToPath = coerceToString callFunc DontCopyToStore CoerceAny
 

--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -132,7 +132,7 @@ instance
 
 -- We wrap values solely to provide an Ord instance for genericClosure
 data WValue t f m where
-  WValue :: NvConstraint f => NValue t f m -> WValue t f m
+  WValue :: NVConstraint f => NValue t f m -> WValue t f m
 
 instance Eq (WValue t f m) where
   WValue (NVConstant (NFloat x)) == WValue (NVConstant (NInt y)) =
@@ -337,7 +337,7 @@ splitMatches numDropped (((_, (start, len)) : captures) : mts) haystack =
       (thunkStr a)
       (s >= 0)
 
-thunkStr :: NvConstraint f => ByteString -> NValue t f m
+thunkStr :: NVConstraint f => ByteString -> NValue t f m
 thunkStr s = mkNVStrWithoutContext $ decodeUtf8 s
 
 hasKind
@@ -1785,7 +1785,7 @@ currentTimeNix =
 derivationStrictNix :: MonadNix e t f m => NValue t f m -> m (NValue t f m)
 derivationStrictNix = derivationStrict
 
-getRecursiveSizeNix :: (MonadIntrospect m, NvConstraint f) => a -> m (NValue t f m)
+getRecursiveSizeNix :: (MonadIntrospect m, NVConstraint f) => a -> m (NValue t f m)
 getRecursiveSizeNix = fmap (NVConstant . NInt . fromIntegral) . recursiveSize
 
 getContextNix

--- a/src/Nix/Builtins.hs
+++ b/src/Nix/Builtins.hs
@@ -1,9 +1,9 @@
-{-# LANGUAGE GADTs #-}
 {-# language CPP #-}
 {-# language AllowAmbiguousTypes #-}
 {-# language ConstraintKinds #-}
 {-# language FunctionalDependencies #-}
 {-# language KindSignatures #-}
+{-# language MonoLocalBinds #-}
 {-# language MultiWayIf #-}
 {-# language PartialTypeSignatures #-}
 {-# language QuasiQuotes #-}
@@ -131,10 +131,9 @@ instance
 -- *** @WValue@ closure wrapper to have @Ord@
 
 -- We wrap values solely to provide an Ord instance for genericClosure
-data WValue t f m where
-  WValue :: NVConstraint f => NValue t f m -> WValue t f m
+newtype WValue t f m = WValue (NValue t f m)
 
-instance Eq (WValue t f m) where
+instance NVConstraint f => Eq (WValue t f m) where
   WValue (NVConstant (NFloat x)) == WValue (NVConstant (NInt y)) =
     x == fromInteger y
   WValue (NVConstant (NInt   x)) == WValue (NVConstant (NFloat y)) =
@@ -146,7 +145,7 @@ instance Eq (WValue t f m) where
     ignoreContext x == ignoreContext y
   _ == _ = False
 
-instance Ord (WValue t f m) where
+instance NVConstraint f => Ord (WValue t f m) where
   WValue (NVConstant (NFloat x)) <= WValue (NVConstant (NInt y)) =
     x <= fromInteger y
   WValue (NVConstant (NInt   x)) <= WValue (NVConstant (NFloat y)) =

--- a/src/Nix/Convert.hs
+++ b/src/Nix/Convert.hs
@@ -370,39 +370,39 @@ instance ( Convertible e t f m
 
 instance Convertible e t f m
   => ToValue () m (NValue' t f m (NValue t f m)) where
-  toValue = const $ pure nvNull'
+  toValue = const $ pure NVNull'
 
 instance Convertible e t f m
   => ToValue Bool m (NValue' t f m (NValue t f m)) where
-  toValue = pure . mkNVConstant' . NBool
+  toValue = pure . NVConstant' . NBool
 
 instance Convertible e t f m
   => ToValue Int m (NValue' t f m (NValue t f m)) where
-  toValue = pure . mkNVConstant' . NInt . toInteger
+  toValue = pure . NVConstant' . NInt . toInteger
 
 instance Convertible e t f m
   => ToValue Integer m (NValue' t f m (NValue t f m)) where
-  toValue = pure . mkNVConstant' . NInt
+  toValue = pure . NVConstant' . NInt
 
 instance Convertible e t f m
   => ToValue Float m (NValue' t f m (NValue t f m)) where
-  toValue = pure . mkNVConstant' . NFloat
+  toValue = pure . NVConstant' . NFloat
 
 instance Convertible e t f m
   => ToValue NixString m (NValue' t f m (NValue t f m)) where
-  toValue = pure . mkNVStr'
+  toValue = pure . NVStr'
 
 instance Convertible e t f m
   => ToValue ByteString m (NValue' t f m (NValue t f m)) where
-  toValue = pure . mkNVStr' . mkNixStringWithoutContext . decodeUtf8
+  toValue = pure . NVStr' . mkNixStringWithoutContext . decodeUtf8
 
 instance Convertible e t f m
   => ToValue Text m (NValue' t f m (NValue t f m)) where
-  toValue = pure . mkNVStr' . mkNixStringWithoutContext
+  toValue = pure . NVStr' . mkNixStringWithoutContext
 
 instance Convertible e t f m
   => ToValue Path m (NValue' t f m (NValue t f m)) where
-  toValue = pure . mkNVPath' . coerce
+  toValue = pure . NVPath' . coerce
 
 instance Convertible e t f m
   => ToValue StorePath m (NValue' t f m (NValue t f m)) where
@@ -415,40 +415,40 @@ instance Convertible e t f m
     l' <- toValue $ unPos $ coerce l
     c' <- toValue $ unPos $ coerce c
     let pos = M.fromList [("file" :: VarName, f'), ("line", l'), ("column", c')]
-    pure $ mkNVSet' mempty pos
+    pure $ NVSet' mempty pos
 
 -- | With 'ToValue', we can always act recursively
 instance Convertible e t f m
   => ToValue [NValue t f m] m (NValue' t f m (NValue t f m)) where
-  toValue = pure . mkNVList'
+  toValue = pure . NVList'
 
 instance (Convertible e t f m
   , ToValue a m (NValue t f m)
   )
   => ToValue [a] m (Deeper (NValue' t f m (NValue t f m))) where
-  toValue l = Deeper . mkNVList' <$> traverseToValue l
+  toValue l = Deeper . NVList' <$> traverseToValue l
 
 instance Convertible e t f m
   => ToValue (AttrSet (NValue t f m)) m (NValue' t f m (NValue t f m)) where
-  toValue s = pure $ mkNVSet' mempty s
+  toValue s = pure $ NVSet' mempty s
 
 instance (Convertible e t f m, ToValue a m (NValue t f m))
   => ToValue (AttrSet a) m (Deeper (NValue' t f m (NValue t f m))) where
   toValue s =
-    liftA2 (\ v s -> Deeper $ mkNVSet' s v)
+    liftA2 (\ v s -> Deeper $ NVSet' s v)
       (traverseToValue s)
       stub
 
 instance Convertible e t f m
   => ToValue (AttrSet (NValue t f m), PositionSet) m
             (NValue' t f m (NValue t f m)) where
-  toValue (s, p) = pure $ mkNVSet' p s
+  toValue (s, p) = pure $ NVSet' p s
 
 instance (Convertible e t f m, ToValue a m (NValue t f m))
   => ToValue (AttrSet a, PositionSet) m
             (Deeper (NValue' t f m (NValue t f m))) where
   toValue (s, p) =
-    liftA2 (\ v s -> Deeper $ mkNVSet' s v)
+    liftA2 (\ v s -> Deeper $ NVSet' s v)
       (traverseToValue s)
       (pure p)
 
@@ -472,7 +472,7 @@ instance Convertible e t f m
         (pure Nothing)
         (fmap pure . toValue)
         ts
-    pure $ mkNVSet' mempty $ M.fromList $ catMaybes
+    pure $ NVSet' mempty $ M.fromList $ catMaybes
       [ ("path"      ,) <$> path
       , ("allOutputs",) <$> allOutputs
       , ("outputs"   ,) <$> outputs

--- a/src/Nix/Effects/Derivation.hs
+++ b/src/Nix/Effects/Derivation.hs
@@ -292,10 +292,10 @@ defaultDerivationStrict val = do
           (\out (coerce -> path) -> mkNixStringWithSingletonContext (StringContext (DerivationOutput out) drvPath) path)
           (outputs drv')
       drvPathWithContext = mkNixStringWithSingletonContext (StringContext AllOutputs drvPath) drvPath
-      attrSet = mkNVStr <$> M.fromList (("drvPath", drvPathWithContext) : Map.toList outputsWithContext)
+      attrSet = NVStr <$> M.fromList (("drvPath", drvPathWithContext) : Map.toList outputsWithContext)
     -- TODO: Add location information for all the entries.
     --              here --v
-    pure $ mkNVSet mempty $ M.mapKeys coerce attrSet
+    pure $ NVSet mempty $ M.mapKeys coerce attrSet
 
   where
 
@@ -368,7 +368,7 @@ buildDerivationWithContext drvAttrs = do
 
       env <- if useJson
         then do
-          jsonString :: NixString <- lift $ toJSONNixString $ mkNVSet mempty $ M.mapKeys coerce $
+          jsonString :: NixString <- lift $ toJSONNixString $ NVSet mempty $ M.mapKeys coerce $
             deleteKeys [ "args", "__ignoreNulls", "__structuredAttrs" ] attrs
           rawString :: Text <- extractNixString jsonString
           pure $ one ("__json", rawString)

--- a/src/Nix/Exec.hs
+++ b/src/Nix/Exec.hs
@@ -61,7 +61,7 @@ mkNVConstantWithProvenance
   -> NAtom
   -> NValue t f m
 mkNVConstantWithProvenance scopes span x =
-  addProvenance (Provenance scopes . NConstantAnnF span $ x) $ mkNVConstant x
+  addProvenance (Provenance scopes . NConstantAnnF span $ x) $ NVConstant x
 
 mkNVStrWithProvenance
   :: MonadCited t f m
@@ -70,7 +70,7 @@ mkNVStrWithProvenance
   -> NixString
   -> NValue t f m
 mkNVStrWithProvenance scopes span x =
-  addProvenance (Provenance scopes . NStrAnnF span . DoubleQuoted . one . Plain . ignoreContext $ x) $ mkNVStr x
+  addProvenance (Provenance scopes . NStrAnnF span . DoubleQuoted . one . Plain . ignoreContext $ x) $ NVStr x
 
 mkNVPathWithProvenance
   :: MonadCited t f m
@@ -80,7 +80,7 @@ mkNVPathWithProvenance
   -> Path
   -> NValue t f m
 mkNVPathWithProvenance scope span lit real =
-  addProvenance (Provenance scope . NLiteralPathAnnF span $ lit) $ mkNVPath real
+  addProvenance (Provenance scope . NLiteralPathAnnF span $ lit) $ NVPath real
 
 mkNVClosureWithProvenance
   :: MonadCited t f m
@@ -90,7 +90,7 @@ mkNVClosureWithProvenance
   -> (NValue t f m -> m (NValue t f m))
   -> NValue t f m
 mkNVClosureWithProvenance scopes span x f =
-  addProvenance (Provenance scopes $ NAbsAnnF span (Nothing <$ x) Nothing) $ mkNVClosure x f
+  addProvenance (Provenance scopes $ NAbsAnnF span (Nothing <$ x) Nothing) $ NVClosure x f
 
 mkNVUnaryOpWithProvenance
   :: MonadCited t f m
@@ -339,7 +339,7 @@ execUnaryOp scope span op arg =
       throwError $ ErrorCall $ "argument to unary operator must evaluate to an atomic type: " <> show _x
  where
   mkUnaryOp :: (a -> NAtom) -> (a -> a) -> a -> m (NValue t f m)
-  mkUnaryOp c b a = pure . mkNVUnaryOpWithProvenance scope span op (pure arg) . mkNVConstant $ c (b a)
+  mkUnaryOp c b a = pure . mkNVUnaryOpWithProvenance scope span op (pure arg) . NVConstant $ c (b a)
 
 execBinaryOp
   :: forall e t f m
@@ -390,7 +390,7 @@ execBinaryOp scope span op lval rarg =
 
   toBoolOp :: Maybe (NValue t f m) -> Bool -> m (NValue t f m)
   toBoolOp r b =
-    pure $ mkNVBinaryOpWithProvenance scope span op (pure lval) r $ mkNVConstant $ NBool b
+    pure $ mkNVBinaryOpWithProvenance scope span op (pure lval) r $ NVConstant $ NBool b
 
 execBinaryOpForced
   :: forall e t f m
@@ -454,25 +454,25 @@ execBinaryOpForced scope span op lval rval =
     mkNVBinaryOpWithProvenance scope span op (pure lval) (pure rval)
 
   mkBoolP :: Bool -> m (NValue t f m)
-  mkBoolP = pure . addProv . mkNVConstant . NBool
+  mkBoolP = pure . addProv . NVConstant . NBool
 
   mkIntP :: Integer -> m (NValue t f m)
-  mkIntP = pure . addProv . mkNVConstant . NInt
+  mkIntP = pure . addProv . NVConstant . NInt
 
   mkFloatP :: Float -> m (NValue t f m)
-  mkFloatP = pure . addProv . mkNVConstant . NFloat
+  mkFloatP = pure . addProv . NVConstant . NFloat
 
   mkListP :: [NValue t f m] -> NValue t f m
-  mkListP = addProv . mkNVList
+  mkListP = addProv . NVList
 
   mkStrP :: NixString -> NValue t f m
-  mkStrP = addProv . mkNVStr
+  mkStrP = addProv . NVStr
 
   mkPathP :: Path -> NValue t f m
-  mkPathP = addProv . mkNVPath
+  mkPathP = addProv . NVPath
 
   mkSetP :: (PositionSet -> AttrSet (NValue t f m) -> NValue t f m)
-  mkSetP x s = addProv $ mkNVSet x s
+  mkSetP x s = addProv $ NVSet x s
 
   mkCmpOp :: (forall a. Ord a => a -> a -> Bool) -> m (NValue t f m)
   mkCmpOp op = case (lval, rval) of

--- a/src/Nix/Lint.hs
+++ b/src/Nix/Lint.hs
@@ -1,7 +1,6 @@
 {-# language ConstraintKinds #-}
 {-# language CPP #-}
 {-# language DataKinds #-}
-{-# language GADTs #-}
 {-# language GeneralizedNewtypeDeriving #-}
 {-# language TypeFamilies #-}
 {-# language UndecidableInstances #-}

--- a/src/Nix/Normal.hs
+++ b/src/Nix/Normal.hs
@@ -1,7 +1,6 @@
 {-# language AllowAmbiguousTypes #-}
 {-# language ConstraintKinds #-}
 {-# language DataKinds #-}
-{-# language GADTs #-}
 {-# language TypeFamilies #-}
 {-# language RankNTypes #-}
 

--- a/src/Nix/Normal.hs
+++ b/src/Nix/Normal.hs
@@ -141,7 +141,7 @@ normalForm_
   -> m ()
 normalForm_ t = void $ normalizeValue t
 
-opaqueVal :: NvConstraint f => NValue t f m
+opaqueVal :: NVConstraint f => NValue t f m
 opaqueVal = mkNVStrWithoutContext "<cycle>"
 
 -- | Detect cycles & stub them.
@@ -167,14 +167,14 @@ stubCycles =
  where
   Free (NValue' cyc) = opaqueVal
 
-thunkStubVal :: NvConstraint f => NValue t f m
+thunkStubVal :: NVConstraint f => NValue t f m
 thunkStubVal = mkNVStrWithoutContext thunkStubText
 
 -- | Check if thunk @t@ is computed,
 -- then bind it into first arg.
 -- else bind the thunk stub val.
 bindComputedThunkOrStub
-  :: ( NvConstraint f
+  :: ( NVConstraint f
     , MonadThunk t m (NValue t f m)
     )
   => (NValue t f m -> m a)

--- a/src/Nix/Normal.hs
+++ b/src/Nix/Normal.hs
@@ -141,7 +141,7 @@ normalForm_
   -> m ()
 normalForm_ t = void $ normalizeValue t
 
-opaqueVal :: Applicative f => NValue t f m
+opaqueVal :: NvConstraint f => NValue t f m
 opaqueVal = mkNVStrWithoutContext "<cycle>"
 
 -- | Detect cycles & stub them.
@@ -167,14 +167,14 @@ stubCycles =
  where
   Free (NValue' cyc) = opaqueVal
 
-thunkStubVal :: Applicative f => NValue t f m
+thunkStubVal :: NvConstraint f => NValue t f m
 thunkStubVal = mkNVStrWithoutContext thunkStubText
 
 -- | Check if thunk @t@ is computed,
 -- then bind it into first arg.
 -- else bind the thunk stub val.
 bindComputedThunkOrStub
-  :: ( Applicative f
+  :: ( NvConstraint f
     , MonadThunk t m (NValue t f m)
     )
   => (NValue t f m -> m a)

--- a/src/Nix/Render.hs
+++ b/src/Nix/Render.hs
@@ -2,7 +2,6 @@
 {-# language CPP #-}
 {-# language ConstraintKinds #-}
 {-# language DefaultSignatures #-}
-{-# language GADTs #-}
 {-# language TypeFamilies #-}
 {-# language TypeOperators #-}
 {-# language MultiWayIf #-}

--- a/src/Nix/Render/Frame.hs
+++ b/src/Nix/Render/Frame.hs
@@ -2,7 +2,6 @@
 {-# language AllowAmbiguousTypes #-}
 {-# language ConstraintKinds #-}
 {-# language MultiWayIf #-}
-{-# language GADTs #-}
 {-# language TypeFamilies #-}
 
 

--- a/src/Nix/Value/Equal.hs
+++ b/src/Nix/Value/Equal.hs
@@ -167,7 +167,7 @@ compareAttrSets f eq lm rm = runIdentity
   $ compareAttrSetsM (Identity . f) ((Identity .) . eq) lm rm
 
 valueEqM
-  :: (MonadThunk t m (NValue t f m), NvConstraint f)
+  :: (MonadThunk t m (NValue t f m), NVConstraint f)
   => NValue t f m
   -> NValue t f m
   -> m Bool
@@ -195,7 +195,7 @@ valueEqM (Free (NValue' (extract -> x))) (Free (NValue' (extract -> y))) =
           _        -> mempty
       )
 
-thunkEqM :: (MonadThunk t m (NValue t f m), NvConstraint f) => t -> t -> m Bool
+thunkEqM :: (MonadThunk t m (NValue t f m), NVConstraint f) => t -> t -> m Bool
 thunkEqM lt rt =
   do
     lv <- force lt

--- a/src/Nix/Value/Equal.hs
+++ b/src/Nix/Value/Equal.hs
@@ -167,7 +167,7 @@ compareAttrSets f eq lm rm = runIdentity
   $ compareAttrSetsM (Identity . f) ((Identity .) . eq) lm rm
 
 valueEqM
-  :: (MonadThunk t m (NValue t f m), Comonad f)
+  :: (MonadThunk t m (NValue t f m), NvConstraint f)
   => NValue t f m
   -> NValue t f m
   -> m Bool
@@ -195,7 +195,7 @@ valueEqM (Free (NValue' (extract -> x))) (Free (NValue' (extract -> y))) =
           _        -> mempty
       )
 
-thunkEqM :: (MonadThunk t m (NValue t f m), Comonad f) => t -> t -> m Bool
+thunkEqM :: (MonadThunk t m (NValue t f m), NvConstraint f) => t -> t -> m Bool
 thunkEqM lt rt =
   do
     lv <- force lt


### PR DESCRIPTION
changes draft related to #1045