### PR TITLE
(#1053) Fix compilation with ghc 8.6.5

### DIFF
--- a/src/Nix/Reduce.hs
+++ b/src/Nix/Reduce.hs
@@ -22,7 +22,7 @@ module Nix.Reduce
 
 import           Nix.Prelude
 import           Control.Monad.Catch            ( MonadCatch(catch) )
-#if !MIN_VERSION_base(4,13,0)
+#if !MIN_VERSION_base(4,12,0)
 import           Prelude                 hiding ( fail )
 import           Control.Monad.Fail
 #endif


### PR DESCRIPTION
This change fixes the following errors when building with GHC 8.6.5
```
[51 of 52] Compiling Nix.Reduce       ( src/Nix/Reduce.hs, /Users/hamish/iohk/hnix/dist-newstyle/build/x86_64-osx/ghc-8.6.5/hnix-0.16.0/build/Nix/Reduce.o )

src/Nix/Reduce.hs:98:18: error:
    Ambiguous occurrence ‘putStrLn’
    It could refer to either ‘Nix.Prelude.putStrLn’,
                             imported from ‘Nix.Prelude’ at src/Nix/Reduce.hs:23:1-28
                             (and originally defined in ‘Relude.Lifted.Terminal’)
                          or ‘Prelude.putStrLn’,
                             imported from ‘Prelude’ at src/Nix/Reduce.hs:26:1-56
                             (and originally defined in ‘System.IO’)
   |
98 |         liftIO $ putStrLn $ "Importing file " <> coerce path''
   |                  ^^^^^^^^

src/Nix/Reduce.hs:102:48: error:
    Ambiguous occurrence ‘show’
    It could refer to either ‘Nix.Prelude.show’,
                             imported from ‘Nix.Prelude’ at src/Nix/Reduce.hs:23:1-28
                             (and originally defined in ‘Relude.String.Conversion’)
                          or ‘Text.Show.show’,
                             imported from ‘Prelude’ at src/Nix/Reduce.hs:26:1-56
                             (and originally defined in ‘GHC.Show’)
    |
102 |           (\ err -> fail $ "Parse failed: " <> show err)
    |                                                ^^^^

src/Nix/Reduce.hs:343:28: error:
    Ambiguous occurrence ‘show’
    It could refer to either ‘Nix.Prelude.show’,
                             imported from ‘Nix.Prelude’ at src/Nix/Reduce.hs:23:1-28
                             (and originally defined in ‘Relude.String.Conversion’)
                          or ‘Text.Show.show’,
                             imported from ‘Prelude’ at src/Nix/Reduce.hs:26:1-56
                             (and originally defined in ‘GHC.Show’)
```

One way to reproduce this issue is with the haskell.nix [hix tool](https://github.com/input-output-hk/haskell.nix/blob/master/docs/tutorials/getting-started-hix.md):

You can install hix with:
```
nix-env -iA hix -f https://github.com/input-output-hk/haskell.nix/tarball/master
```

Then run this to run cabal build in a nix-shell:
```
hix-shell --argstr compiler-nix-name ghc865 --argstr configureArgs '--disable-benchmarks' --run 'cabal build lib:hnix'
```

If you are on an M1 Mac you will need to pass `--system x86_64-darwin ` as well (ghc 8.6.5 does not work on `aarch64-darwin`).