### PR TITLE
Resolve indentifiers scope upfront

### DIFF
--- a/src/Nix/Effects/Basic.hs
+++ b/src/Nix/Effects/Basic.hs
@@ -51,7 +51,7 @@ defaultToAbsolutePath origPath =
                       val -> throwError $ ErrorCall $ "when resolving relative path, __cur_file is in scope, but is not a path; it is: " <> show val
                     ) <=< demand
                   )
-                  =<< lookupVar "__cur_file"
+                  =<< lookupVar Unknown "__cur_file"
             )
             (pure origPathExpanded)
             (isAbsolute origPathExpanded)
@@ -94,7 +94,7 @@ findEnvPathM name =
         l <- fromValue @[NValue t f m] =<< demand v
         findPathBy nixFilePath l name
     )
-    =<< lookupVar "__nixPath"
+    =<< lookupVar Unknown "__nixPath"
 
  where
   nixFilePath :: MonadEffects t f m => Path -> m (Maybe Path)

--- a/src/Nix/Eval.hs
+++ b/src/Nix/Eval.hs
@@ -103,11 +103,11 @@ instance (Typeable m, Typeable v) => Exception (SynHoleInfo m v)
 -- eval :: forall v m . MonadNixEval v m => NExprF v -> m v
 eval :: forall v m . MonadNixEval v m => NExprF (m v) -> m v
 
-eval (NSym "__curPos") = evalCurPos
+eval (NSym _ "__curPos") = evalCurPos
 
-eval (NSym var       ) =
+eval (NSym offset var  ) =
   do
-    mVal <- lookupVar var
+    mVal <- lookupVar offset var
     maybe
       (freeVariable var)
       (evaledSym var <=< demand)
@@ -396,12 +396,12 @@ evalBinds isRecursive binds =
           (attrMissing (one var) Nothing)
           demand
           =<< maybe
-              (withScopes scopes $ lookupVar var)
+              (withScopes scopes $ lookupVar Unknown var)
               (\ s ->
                 do
                   (coerce -> scope, _) <- fromValue @(AttrSet v, PositionSet) =<< s
 
-                  clearScopes $ pushScope @v scope $ lookupVar var
+                  clearScopes $ pushScope @v scope $ lookupVar Unknown var
               )
               ms
       )

--- a/src/Nix/Exec.hs
+++ b/src/Nix/Exec.hs
@@ -159,7 +159,7 @@ askSpan :: forall e m . (MonadReader e m, Has e SrcSpan) => m SrcSpan
 askSpan = askLocal
 
 wrapExprLoc :: SrcSpan -> NExprLocF r -> NExprLoc
-wrapExprLoc span x = Fix $ NSymAnn span "<?>" <$ x
+wrapExprLoc span x = Fix $ NSymAnn span Unknown "<?>" <$ x
 {-# inline wrapExprLoc #-}
 
 --  2021-01-07: NOTE: This instance belongs to be beside MonadEval type class.
@@ -193,7 +193,7 @@ instance MonadNix e t f m => MonadEval (NValue t f m) m where
       scope                  <- askScopes
       span@(SrcSpan delta _) <- askSpan
       addProvenance @_ @_ @(NValue t f m)
-        (Provenance scope . NSymAnnF span $ coerce @Text "__curPos") <$>
+        (Provenance scope . NSymAnnF span Unknown $ coerce @Text "__curPos") <$>
           toValue delta
 
   evaledSym name val =
@@ -202,7 +202,7 @@ instance MonadNix e t f m => MonadEval (NValue t f m) m where
       span  <- askSpan
       pure $
         addProvenance @_ @_ @(NValue t f m)
-          (Provenance scope $ NSymAnnF span name)
+          (Provenance scope $ NSymAnnF span Unknown name)
           val
 
   evalConstant c =
@@ -543,7 +543,7 @@ addTracing k v = do
       let
         rendered =
           bool
-            (prettyNix $ Fix $ Fix (NSym "?") <$ x)
+            (prettyNix $ Fix $ Fix (NSym Unknown "?") <$ x)
             (pretty $ PS.ppShow $ void x)
             (getVerbosity opts >= Chatty)
         msg x = pretty ("eval: " <> replicate depth ' ') <> x

--- a/src/Nix/Expr/Shorthands.hs
+++ b/src/Nix/Expr/Shorthands.hs
@@ -58,8 +58,8 @@ mkRelPath :: FilePath -> NExpr
 mkRelPath = Fix . mkRelPathF
 
 -- | Put a variable (symbol).
-mkSym :: Text -> NExpr
-mkSym = Fix . mkSymF
+mkSym :: VarOffset -> Text -> NExpr
+mkSym offset = Fix . mkSymF offset
 
 -- | Put syntactic hole.
 mkSynHole :: Text -> NExpr
@@ -252,8 +252,8 @@ mkRelPathF :: FilePath -> NExprF a
 mkRelPathF = mkPathF False
 
 -- | Unfixed @mkSym@.
-mkSymF :: Text -> NExprF a
-mkSymF = NSym . coerce
+mkSymF :: VarOffset -> Text -> NExprF a
+mkSymF offset = NSym offset . coerce
 
 -- | Unfixed @mkSynHole@.
 mkSynHoleF :: Text -> NExprF a

--- a/src/Nix/Expr/Types/Annotated.hs
+++ b/src/Nix/Expr/Types/Annotated.hs
@@ -197,8 +197,8 @@ pattern NConstantAnnF    ann x      = AnnF ann (NConstant x)
 pattern NStrAnnF         :: SrcSpan -> NString r -> NExprLocF r
 pattern NStrAnnF         ann x      = AnnF ann (NStr x)
 
-pattern NSymAnnF         :: SrcSpan -> VarName -> NExprLocF r
-pattern NSymAnnF         ann x      = AnnF ann (NSym x)
+pattern NSymAnnF         :: SrcSpan -> VarOffset -> VarName -> NExprLocF r
+pattern NSymAnnF         ann x y    = AnnF ann (NSym x y)
 
 pattern NListAnnF        :: SrcSpan -> [r] -> NExprLocF r
 pattern NListAnnF        ann x      = AnnF ann (NList x)
@@ -255,8 +255,8 @@ pattern NConstantAnn    ann x      = Ann ann (NConstant x)
 pattern NStrAnn         :: SrcSpan -> NString NExprLoc -> NExprLoc
 pattern NStrAnn         ann x      = Ann ann (NStr x)
 
-pattern NSymAnn         :: SrcSpan -> VarName -> NExprLoc
-pattern NSymAnn         ann x      = Ann ann (NSym x)
+pattern NSymAnn         :: SrcSpan -> VarOffset -> VarName -> NExprLoc
+pattern NSymAnn         ann x y    = Ann ann (NSym x y)
 
 pattern NListAnn        :: SrcSpan -> [NExprLoc] -> NExprLoc
 pattern NListAnn        ann x      = Ann ann (NList x)

--- a/src/Nix/Pretty.hs
+++ b/src/Nix/Pretty.hs
@@ -313,7 +313,7 @@ exprFNixDoc = \case
               ("./" <> path)
               path
               (any (`isPrefixOf` coerce path) ["/", "~/", "./", "../"])
-  NSym name -> simpleExpr $ prettyVarName name
+  NSym _ name -> simpleExpr $ prettyVarName name
   NLet binds body ->
     leastPrecedence $
       group $
@@ -355,7 +355,7 @@ exprFNixDoc = \case
 valueToExpr :: forall t f m . MonadDataContext f m => NValue t f m -> NExpr
 valueToExpr = iterNValueByDiscardWith thk (Fix . phi)
  where
-  thk = Fix . NSym $ "<expr>"
+  thk = Fix . NSym Unknown $ "<expr>"
 
   phi :: NValue' t f m NExpr -> NExprF NExpr
   phi (NVConstant' a     ) = NConstant a
@@ -365,9 +365,9 @@ valueToExpr = iterNValueByDiscardWith thk (Fix . phi)
     [ NamedVar (one $ StaticKey k) v (fromMaybe nullPos $ (`M.lookup` p) k)
     | (k, v) <- toList s
     ]
-  phi (NVClosure'  _    _) = NSym "<closure>"
+  phi (NVClosure'  _    _) = NSym Unknown "<closure>"
   phi (NVPath'     p     ) = NLiteralPath p
-  phi (NVBuiltin'  name _) = NSym $ coerce ((mappend @Text) "builtins.") name
+  phi (NVBuiltin'  name _) = NSym Unknown $ coerce ((mappend @Text) "builtins.") name
 
 prettyNValue
   :: forall t f m ann . MonadDataContext f m => NValue t f m -> Doc ann

--- a/src/Nix/Reduce.hs
+++ b/src/Nix/Reduce.hs
@@ -152,8 +152,8 @@ reduce
 
 -- | Reduce the variable to its value if defined.
 --   Leave it as it is otherwise.
-reduce (NSymAnnF ann var) =
-  fromMaybe (NSymAnn ann var) <$> lookupVar var
+reduce (NSymAnnF ann offset var) =
+  fromMaybe (NSymAnn ann offset var) <$> lookupVar offset var
 
 -- | Reduce binary and integer negation.
 reduce (NUnaryAnnF uann op arg) =
@@ -173,7 +173,7 @@ reduce (NUnaryAnnF uann op arg) =
 --       scope and recursively reducing its body.
 reduce (NAppAnnF bann fun arg) =
   (\case
-    f@(NSymAnn _ "import") ->
+    f@(NSymAnn _ _ "import") ->
       (\case
           -- NEnvPathAnn     pann origPath -> staticImport pann origPath
         NLiteralPathAnn pann origPath -> staticImport pann origPath
@@ -325,9 +325,9 @@ reduce (NAbsAnnF ann params body) = do
   let
     scope = coerce $
       case params' of
-        Param    name     -> one (name, NSymAnn ann name)
+        Param    name     -> one (name, NSymAnn ann Unknown name)
         ParamSet _ _ pset ->
-          HM.fromList $ (\(k, _) -> (k, NSymAnn ann k)) <$> pset
+          HM.fromList $ (\(k, _) -> (k, NSymAnn ann Unknown k)) <$> pset
   NAbsAnn ann params' <$> pushScope scope body
 
 reduce v = reduceLayer v

--- a/src/Nix/Render/Frame.hs
+++ b/src/Nix/Render/Frame.hs
@@ -97,7 +97,7 @@ renderFrame (NixFrame level f)
   | otherwise = fail $ "Unrecognized frame: " <> show f
 
 wrapExpr :: NExprF r -> NExpr
-wrapExpr x = Fix (Fix (NSym "<?>") <$ x)
+wrapExpr x = Fix (Fix (NSym Unknown "<?>") <$ x)
 
 renderEvalFrame
   :: forall e m v ann
@@ -164,7 +164,7 @@ renderExpr _level longLabel shortLabel e@(Ann _ x) =
       expr :: NExpr
       expr = stripAnnotation e
 
-      concise = prettyNix $ Fix $ Fix (NSym "<?>") <$ x
+      concise = prettyNix $ Fix $ Fix (NSym Unknown "<?>") <$ x
 
       chatty =
         bool

--- a/src/Nix/TH.hs
+++ b/src/Nix/TH.hs
@@ -54,7 +54,7 @@ instance ToExpr NExprLoc where
   toExpr = id
 
 instance ToExpr VarName where
-  toExpr = NSymAnn nullSpan
+  toExpr = NSymAnn nullSpan Unknown
 
 instance ToExpr Int where
   toExpr = NConstantAnn nullSpan . NInt . fromIntegral
@@ -66,12 +66,12 @@ instance ToExpr Float where
   toExpr = NConstantAnn nullSpan . NFloat
 
 metaExp :: Set VarName -> NExprLoc -> Maybe ExpQ
-metaExp fvs (NSymAnn _ x) | x `Set.member` fvs =
+metaExp fvs (NSymAnn _ _ x) | x `Set.member` fvs =
   pure [| toExpr $(varE (mkName $ toString x)) |]
 metaExp _ _ = Nothing
 
 metaPat :: Set VarName -> NExprLoc -> Maybe PatQ
-metaPat fvs (NSymAnn _ x) | x `Set.member` fvs =
+metaPat fvs (NSymAnn _ _ x) | x `Set.member` fvs =
   pure $ varP $ mkName $ toString x
 metaPat _ _ = Nothing
 


### PR DESCRIPTION
This is a POC that shows how we can resilve identifiers statically, on the expression tree.

A simple test shows that hnix execution speed increases from 14s to 10.5s when computing `pow2 18` with the naive algorithm below.

```nix
pow2 = n:
  if n == 0 then 1
  else pow2 (n - 1) + pow2 (n - 1)
```

There are however some unresolved issues. As-is, this phase does not work because it would require accessing the builtins list (the base environment) during parsing. To alleviate that, the base environment has been turned into a weak scope (as if defined by a `with`). This is invalid from the point of view of nix semantics. There also appers to be a lot of places where we use environments in a way that makes this optimisation difficult. Ideally there should always be one base env, and then environments from the nix expression. We cannot change arbitrarily the level (offset) of the base environment or the trick does not work.

There exists ways to ensure, at type level, that offsets and scopes are consistent, but they involve tricky type machinery which dit not even attempt to setup.

Any thoughts ? 
