### PR TITLE
update nixpkgs version in build system, fix bug, build shell properly 

### DIFF
--- a/.github/workflows/Optional-Nix-dev-env-main.yml
+++ b/.github/workflows/Optional-Nix-dev-env-main.yml
@@ -22,7 +22,7 @@ env:
   ### and the other part of keys explained in `build.sh`, since those address external procedures aound the builds.
   ### Additional documentation is in Nixpkgs Haskell.lib: https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/haskell-modules/lib.nix
   ###
-  rev: "b165ce0c4efbb74246714b5c66b6bcdce8cde175"
+  rev: "ce6aa13369b667ac2542593170993504932eb836"
   cachixAccount: "hnix"
   CACHIX_SIGNING_KEY: ${{ secrets.CACHIX_SIGNING_KEY }}
   allowInconsistentDependencies: "false"

--- a/default.nix
+++ b/default.nix
@@ -156,7 +156,8 @@ let
       else overlay;
   };
 
-  haskellPackages = pkgs.haskell.packages.${compilerPackage};
+   haskellPackages = pkgs.haskell.packages.${compilerPackage}.override
+    overrideHaskellPackages;
 
   # Application of functions from this list to the package in code here happens in the reverse order (from the tail). Some options depend on & override others, so if enabling options caused Nix error or not expected result - change the order, and please do not change this order without proper testing.
   listSwitchFunc =
@@ -189,10 +190,6 @@ let
     root = packageRoot;
 
     overrides = self: super: {
-
-      # semialign = super.semialign_1_2;
-      # relude = super.relude_1_0_0_1;
-
     };
 
     modifier = drv: hlib.overrideCabal drv (attrs: {

--- a/default.nix
+++ b/default.nix
@@ -131,33 +131,17 @@ let
       then getDefaultGHC
       else compiler;
 
-  # Overlay source
-  # hnix-store-src = pkgs.fetchFromGitHub {
-  #   owner = "haskell-nix";
-  #   repo = "hnix-store";
-  #   rev = "fd09d29b8bef4904058f033d693e7d928a4a92dc";
-  #   sha256 = "0fxig1ckzknm5g19jzg7rrcpz7ssn4iiv9bs9hff9gfy3ciq4zrs";
-  # };
-
-  overlay = lib.foldr lib.composeExtensions (_: _: {}) [
-    # (import "${hnix-store-src}/overlay.nix" pkgs hlib)
-    (self: super:
-      lib.optionalAttrs withHoogle {
-      ghc = super.ghc // { withPackages = super.ghc.withHoogle; };
-      ghcWithPackages = self.ghc.withPackages;
-    })
-  ];
-
-  overrideHaskellPackages = orig: {
-    buildHaskellPackages =
-      orig.buildHaskellPackages.override overrideHaskellPackages;
-    overrides = if orig ? overrides
-      then lib.composeExtensions orig.overrides overlay
-      else overlay;
-  };
-
-   haskellPackages = pkgs.haskell.packages.${compilerPackage}.override
-    overrideHaskellPackages;
+  haskellPackages = (
+      pkgs.haskell.packages.${compilerPackage}.override {  
+              overrides = (self: super:
+                {
+                  ghcWithPackages = super.ghcWithPackages.override {
+                      withHoogle = withHoogle;
+                  };
+                }
+              );
+            }
+  );
 
   # Application of functions from this list to the package in code here happens in the reverse order (from the tail). Some options depend on & override others, so if enabling options caused Nix error or not expected result - change the order, and please do not change this order without proper testing.
   listSwitchFunc =

--- a/default.nix
+++ b/default.nix
@@ -93,7 +93,7 @@
 #   , nixos-20.03  # Last stable release, gets almost no updates to recipes, gets only required backports
 #   ...
 #   }
-, rev ? "b165ce0c4efbb74246714b5c66b6bcdce8cde175"
+, rev ? "ce6aa13369b667ac2542593170993504932eb836"
 
 , pkgs ?
     if builtins.compareVersions builtins.nixVersion "2.0" > 0
@@ -104,7 +104,7 @@
           else import (builtins.fetchTarball "https://github.com/NixOS/nixpkgs/archive/${rev}.tar.gz") {}
         // {
           # Try to build dependencies even if they are marked broken.
-          config.allowBroken = true;
+          # config.allowBroken = true;
         }
       else abort "Requires Nix >= 2.0"
 
@@ -156,8 +156,7 @@ let
       else overlay;
   };
 
-  haskellPackages = pkgs.haskell.packages.${compilerPackage}.override
-    overrideHaskellPackages;
+  haskellPackages = pkgs.haskell.packages.${compilerPackage};
 
   # Application of functions from this list to the package in code here happens in the reverse order (from the tail). Some options depend on & override others, so if enabling options caused Nix error or not expected result - change the order, and please do not change this order without proper testing.
   listSwitchFunc =
@@ -191,8 +190,8 @@ let
 
     overrides = self: super: {
 
-      semialign = super.semialign_1_2;
-      relude = super.relude_1_0_0_1;
+      # semialign = super.semialign_1_2;
+      # relude = super.relude_1_0_0_1;
 
     };
 

--- a/shell.nix
+++ b/shell.nix
@@ -2,6 +2,7 @@ attrs@{...}:
 let defaultAttrs = {
   # Defaults are put in this form deliberately. Details: #748
   withHoogle = true;
+  returnShellEnv = true;
   compiler = "ghc8107";
 };
-in (import ./. (defaultAttrs // attrs)).env
+in (import ./. (defaultAttrs // attrs))


### PR DESCRIPTION
This fix #1068  #1070
* It update the nixpkgs version
* It fix the bug for if returnShellEnv
* It build the shell properly using returnShellEnv