### PR TITLE
fix if epression parser

### DIFF
--- a/src/Nix/Parser.hs
+++ b/src/Nix/Parser.hs
@@ -789,7 +789,7 @@ nixIf :: Parser NExprLoc
 nixIf =
   annotateNamedLocation "if" $
     liftA3 NIf
-      (reserved "if"   *> nixExprAlgebra)
+      (reserved "if"   *> nixExpr)
       (exprAfterReservedWord "then")
       (exprAfterReservedWord "else")
 

--- a/tests/EvalTests.hs
+++ b/tests/EvalTests.hs
@@ -534,6 +534,11 @@ case_attrset_function_nested_bottom_equal =
     "true"
     "let nested = { y = _: (let x = x; in x); }; in nested == nested"
 
+case_if_follow_by_with = 
+  constantEqualText
+    "1"
+    "let x = { a = true; b = 2; }; in if with x; a then 1 else 2"
+
 -- Regression test for #527
 
 case_add_string_thunk_left =

--- a/tests/ParserTests.hs
+++ b/tests/ParserTests.hs
@@ -383,6 +383,14 @@ case_if_syntax_mistakes =
     "if true then false else false else"
     "1 + 2 then"
 
+-- ** If follow by with
+
+case_if_follow_by_with = checks 
+  (
+    mkLets (one $ "x" $= mkNonRecSet ["a" $= mkBool True, "b" $= mkInt 2 ]) 
+      $ mkIf (mkWith (mkSym "x") (mkSym "a")) (mkInt 1) (mkInt 2)
+    , "let x = { a = true; b = 2; }; in if with x; a then 1 else 2"
+  )
 
 -- ** Literal expressions in vals
 


### PR DESCRIPTION
This fix #1067
1. Allow `nixExpr` following keyword 'if'
instead of `nixExprAlgebra`
2. add if follow by with test cases in parser test and eval test
