### PR TITLE
deps: unordered-containers >= 0.2.14

### DIFF
--- a/hnix.cabal
+++ b/hnix.cabal
@@ -488,7 +488,7 @@ library
     , transformers >= 0.5.5 && < 0.6
     , transformers-base >= 0.4.5 && < 0.5
     , unix-compat >= 0.4.3 && < 0.6
-    , unordered-containers >= 0.2.9 && < 0.3
+    , unordered-containers >= 0.2.14 && < 0.3
     , vector >= 0.12.0 && < 0.13
     , xml >= 1.3.14 && < 1.4
 


### PR DESCRIPTION
Set lower bounds for unordered-containers to match actual need.