### PR TITLE
Fix pretty printer closing brace alignment

### DIFF
--- a/src/Nix/Pretty.hs
+++ b/src/Nix/Pretty.hs
@@ -343,7 +343,7 @@ exprFNixDoc = \case
   prettyContainer h f t c =
     handlePresence
       (simpleExpr (h <> t))
-      (const $ simpleExpr $ group $ nest 2 $ vsep $ one h <> (f <$> c) <> one t)
+      (const $ simpleExpr $ group $ nest 2 (h <> line <> vsep (f <$> c)) <> line <> t)
       c
 
   prettyAddScope h c b =


### PR DESCRIPTION
Before this PR, `prettyNix` generates docs like this:

```
{
  foo = {
    bar = [
      a
      b
      c
      ]
    }
  }
```

With this PR, the closing braces are more correctly aligned with the opening ones:
```
{
  foo = {
    bar = [
      a
      b
      c
    ]
  }
}
```