### PR TITLE
cryptonite -> crypton

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,6 +1,11 @@
 
 # ChangeLog
 
+## [(diff)](https://github.com/haskell-nix/hnix/compare/0.17.0...master#files_bucket) next
+
+* Additional
+  * Switch from `cryptonite` to `crypton`
+
 ## [(diff)](https://github.com/haskell-nix/hnix/compare/0.16.0...0.17.0#files_bucket) 0.17.0
 
 * Additional
@@ -29,7 +34,7 @@
       * `wrapPath`
     * In `Nix.Parser`:
       * rm `get{App,Unary,Binary,Special}Operator`, currely `NOp` class instances are used instead.
-    
+
   * `Nix.Pretty`:
     * [(link)](https://github.com/haskell-nix/hnix/pull/1047/files) rm `appOp`, instead use `appOpDef`.
     * [(link)](https://github.com/haskell-nix/hnix/pull/1047/files) `precedenceWrap` behaviour is changed (to be literal to the name), the old behaviour is now a `wrap` function.

--- a/hnix.cabal
+++ b/hnix.cabal
@@ -440,7 +440,7 @@ library
     , base16-bytestring >= 0.1.1 && < 1.1
     , binary >= 0.8.5 && < 0.9
     , bytestring >= 0.10.8 && < 0.12
-    , cryptonite
+    , crypton >= 0.34
     , comonad >= 5.0.4 && < 5.1
     , containers >= 0.5.11.0 && < 0.7
     , deepseq >= 1.4.3 && <1.6

--- a/src/Nix/Effects.hs
+++ b/src/Nix/Effects.hs
@@ -5,7 +5,7 @@
 {-# language DataKinds #-}
 {-# language GeneralizedNewtypeDeriving #-}
 {-# language UndecidableInstances #-}
-{-# language PackageImports #-} -- 2021-07-05: Due to hashing Haskell IT system situation, in HNix we currently ended-up with 2 hash package dependencies @{hashing, cryptonite}@
+{-# language PackageImports #-} -- 2021-07-05: Due to hashing Haskell IT system situation, in HNix we currently ended-up with 2 hash package dependencies @{hashing, crypton}@
 {-# language TypeOperators #-}
 
 {-# options_ghc -Wno-orphans #-}
@@ -23,7 +23,7 @@ import qualified Data.Text                     as Text
 import           Network.HTTP.Client     hiding ( path, Proxy )
 import           Network.HTTP.Client.TLS
 import           Network.HTTP.Types
-import qualified "cryptonite" Crypto.Hash      as Hash
+import qualified "crypton" Crypto.Hash      as Hash
 import           Nix.Utils.Fix1
 import           Nix.Expr.Types.Annotated
 import           Nix.Frames              hiding ( Proxy )

--- a/src/Nix/Effects/Derivation.hs
+++ b/src/Nix/Effects/Derivation.hs
@@ -1,7 +1,7 @@
 {-# language DataKinds #-}
 {-# language NamedFieldPuns #-}
 {-# language RecordWildCards #-}
-{-# language PackageImports #-} -- 2021-07-05: Due to hashing Haskell IT system situation, in HNix we currently ended-up with 2 hash package dependencies @{hashing, cryptonite}@
+{-# language PackageImports #-} -- 2021-07-05: Due to hashing Haskell IT system situation, in HNix we currently ended-up with 2 hash package dependencies @{hashing, crypton}@
 
 module Nix.Effects.Derivation ( defaultDerivationStrict ) where
 
@@ -21,7 +21,7 @@ import qualified Data.Text                     as Text
 import           Text.Megaparsec
 import           Text.Megaparsec.Char
 
-import qualified "cryptonite" Crypto.Hash      as Hash -- 2021-07-05: Attrocity of Haskell hashing situation, in HNix we ended-up with 2 hash package dependencies @{hashing, cryptonite}@
+import qualified "crypton" Crypto.Hash      as Hash -- 2021-07-05: Attrocity of Haskell hashing situation, in HNix we ended-up with 2 hash package dependencies @{hashing, crypton}@
 
 import           Nix.Atoms
 import           Nix.Expr.Types          hiding ( Recursive )


### PR DESCRIPTION
`cryptonite` is unmaintaned, switch to `crypton` fork.

Similar to https://github.com/haskell-nix/hnix-store/pull/256