### PR TITLE
cabal.project: drop no longer needed allow-newer

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,7 +1,2 @@
 packages:
   ./hnix.cabal
-
-allow-newer:
-  lens-family-th:template-haskell,
-  relude:base,
-  relude:ghc-prim,

--- a/default.nix
+++ b/default.nix
@@ -168,9 +168,6 @@ let
     root = packageRoot;
 
     overrides = self: super: {
-      # 2023-11-21 too strict bound on template-haskell
-      # https://github.com/DanBurton/lens-family-th/pull/20
-      lens-family-th = hlib.doJailbreak (super.lens-family-th);
       hnix-store-core = super.hnix-store-core_0_6_1_0;
       hnix-store-remote = super.hnix-store-remote_0_6_0_0;
     };


### PR DESCRIPTION
\+ lens-family-th override removal