### PR TITLE
Adapt to new `hnix-store`

### DIFF
--- a/hnix.cabal
+++ b/hnix.cabal
@@ -440,19 +440,25 @@ library
     , base16-bytestring >= 0.1.1 && < 1.1
     , binary >= 0.8.5 && < 0.9
     , bytestring >= 0.10.8 && < 0.13
-    , cryptonite
+    , crypton
     , comonad >= 5.0.4 && < 5.1
     , containers >= 0.5.11.0 && < 0.8
+    , constraints-extras
+    , data-default-class
     , deepseq >= 1.4.3 && <1.6
+    , dependent-sum > 0.7
     , deriving-compat >= 0.3 && < 0.7
     , directory >= 1.3.1 && < 1.4
+    , dlist
     , extra >= 1.7 && < 1.8
     , free >= 5.1 && < 5.3
     , gitrev >= 1.1.0 && < 1.4
     , hashable >= 1.2.5 && < 1.6
     , hashing >= 0.1.0 && < 0.2
-    , hnix-store-core >= 0.6.0 && < 0.7
-    , hnix-store-remote >= 0.6.0 && < 0.7
+    , hnix-store-core >= 0.8.0 && < 0.9
+    , hnix-store-nar >= 0.1.0 && < 0.2
+    , hnix-store-readonly >= 0.1.0 && < 0.2
+    , hnix-store-remote >= 0.7.0 && < 0.8
     , http-client >= 0.5.14 && < 0.6 || >= 0.6.4 && < 0.8
     , http-client-tls >= 0.3.5 && < 0.4
     , http-types >= 0.12.2 && < 0.13

--- a/hnix.cabal
+++ b/hnix.cabal
@@ -353,12 +353,12 @@ common shared
       base >= 4.12 && < 5
     , data-fix >= 0.3.0 && < 0.4
     , exceptions >= 0.10.0 && < 0.11
-    , filepath >= 1.4.2 && < 1.5
+    , filepath >= 1.4.2 && < 1.6
     , optparse-applicative >= 0.14.3 && < 0.19
     , relude >= 1.0.0 && < 1.3
     , serialise >= 0.2.1 && < 0.3
-    , template-haskell >= 2.13 && < 2.22
-    , time >= 1.8.0 && < 1.9 || >= 1.9.3 && < 1.13
+    , template-haskell >= 2.13 && < 2.23
+    , time >= 1.8.0 && < 1.9 || >= 1.9.3 && < 1.15
   ghc-options:
     -Wall
     -Wno-incomplete-uni-patterns
@@ -435,21 +435,21 @@ library
   hs-source-dirs:
     src
   build-depends:
-      aeson >= 1.4.2 && < 1.6 || >= 2.0 && < 2.2
+      aeson >= 1.4.2 && < 1.6 || >= 2.0 && < 2.3
     , array >= 0.4 && < 0.6
     , base16-bytestring >= 0.1.1 && < 1.1
     , binary >= 0.8.5 && < 0.9
-    , bytestring >= 0.10.8 && < 0.12
+    , bytestring >= 0.10.8 && < 0.13
     , cryptonite
     , comonad >= 5.0.4 && < 5.1
-    , containers >= 0.5.11.0 && < 0.7
+    , containers >= 0.5.11.0 && < 0.8
     , deepseq >= 1.4.3 && <1.6
     , deriving-compat >= 0.3 && < 0.7
     , directory >= 1.3.1 && < 1.4
     , extra >= 1.7 && < 1.8
     , free >= 5.1 && < 5.3
     , gitrev >= 1.1.0 && < 1.4
-    , hashable >= 1.2.5 && < 1.5
+    , hashable >= 1.2.5 && < 1.6
     , hashing >= 0.1.0 && < 0.2
     , hnix-store-core >= 0.6.0 && < 0.7
     , hnix-store-remote >= 0.6.0 && < 0.7
@@ -460,7 +460,7 @@ library
     , lens-family-core >= 1.2.2 && < 2.2
     , lens-family-th >= 0.5.0 && < 0.6
     , logict >= 0.6.0 && < 0.7 || >= 0.7.0.2 && < 0.9
-    , megaparsec >= 7.0 && < 9.6
+    , megaparsec >= 7.0 && < 9.7
     , monad-control >= 1.0.2 && < 1.1
     , monadlist >= 0.0.2 && < 0.1
     , mtl >= 2.2.2 && < 2.4


### PR DESCRIPTION
- bump upper bounds based on `cabal outdated`
- `cryptonite` -> `crypton`
- adapted to recent `hnix-store`
- we might want to resolve [`NamedAlgo` thingie](https://github.com/haskell-nix/hnix-store/issues/251) first and do another release of `store` packages prior merging this. Some new dependency requirements might be fixable on `store` side as well

While many derivations eval correctly there are some new failure that need investigating. Will post more details.